### PR TITLE
more work on Rust-based ΔQ

### DIFF
--- a/delta_q/Cargo.lock
+++ b/delta_q/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "smallstr",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
@@ -1763,6 +1764,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallstr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
+dependencies = [
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/delta_q/Cargo.lock
+++ b/delta_q/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "winnow 0.6.20",
  "yew",
 ]
 
@@ -1962,7 +1963,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2266,6 +2267,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/delta_q/Cargo.toml
+++ b/delta_q/Cargo.toml
@@ -34,6 +34,7 @@ js-sys = { version = "0.3.70", optional = true }
 parking_lot = { version = "0.12.3", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.128", optional = true }
+smallstr = { version = "0.3.0", features = ["std", "serde"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",

--- a/delta_q/Cargo.toml
+++ b/delta_q/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 ], optional = true }
 wasm-bindgen = { version = "0.2.93", optional = true }
 wasm-bindgen-futures = { version = "0.4.43", optional = true }
+winnow = "0.6.20"
 yew = { version = "0.21.0", features = ["csr"], optional = true }
 
 [dependencies.web-sys]

--- a/delta_q/README.md
+++ b/delta_q/README.md
@@ -41,7 +41,6 @@ Requests to the `delta_q/*` endpoints will be proxied.
 
 ## Known Shortcomings
 
-- not optimised at all, especially regarding memory usage (need to make cloning cheap for CDF, DeltaQ, etc.) and web assembly size
 - functional but ugly
 - duplicates state management in web app and backend, not yet decided what to put where (currently ΔQ expression evaluation is done in the backend, could easily move to a web worker)
 - should have export (probably as JSON) and matching import

--- a/delta_q/README.md
+++ b/delta_q/README.md
@@ -8,7 +8,7 @@ The underlying ΔQ expressions shall be used for export/import of the model, com
 
 ## Implementation plan
 
-The first step is to provide a library for manipulating CDFs, offering all operations required by the theory; the internal representation will be discrete numerical [DONE], with later optimizations for constant parts at the beginning and end of the vector.
+The first step is to provide a library for manipulating CDFs, offering all operations required by the theory; the internal representation will be discrete numerical [DONE], with later optimizations for constant parts at the beginning and end of the vector. [DONE]
 
 The second step yields an internal DSL for creating ΔQ expressions and printing them. [DONE]
 
@@ -32,7 +32,7 @@ The results of the load analysis will indicate where and under which conditions 
 The build comprises two steps:
 
 - `trunk build` (i.e. you’ll need to `cargo install --locked trunk` first)
-- `cargo run --bin editor`
+- `cargo run --bin editor -F main`
 
 The first one builds the web app in the `dist/` folder, which the second one then integrates into the single-binary application that will serve HTTP resources on port 8080 when run.
 

--- a/delta_q/README.md
+++ b/delta_q/README.md
@@ -13,7 +13,7 @@ The first step is to provide a library for manipulating CDFs, offering all opera
 The second step yields an internal DSL for creating ΔQ expressions and printing them. [DONE]
 
 The third step provides evaluation of ΔQ expressions as defined in the paper. [DONE]
-This will later be expanded to include some exponentiation-like operator that simplifies expressing a randomly chosen repetition count for some sub-expression (as frequently occurs in gossip protocols).
+This will later be expanded to include some exponentiation-like operator that simplifies expressing a randomly chosen repetition count for some sub-expression (as frequently occurs in gossip protocols). [DONE]
 
 The fourth step adds a web UI to expose the internal DSL to no-code users. [DONE]
 The interaction with a ΔQ expression shall closely resemble the refinement approach for system modelling as defined in the paper. [DONE]
@@ -45,4 +45,3 @@ Requests to the `delta_q/*` endpoints will be proxied.
 - functional but ugly
 - duplicates state management in web app and backend, not yet decided what to put where (currently ΔQ expression evaluation is done in the backend, could easily move to a web worker)
 - should have export (probably as JSON) and matching import
-- should add “exponentiation” operator to wrap an expression in another one with a hole for a specified number of times

--- a/delta_q/README.md
+++ b/delta_q/README.md
@@ -44,8 +44,5 @@ Requests to the `delta_q/*` endpoints will be proxied.
 - not optimised at all, especially regarding memory usage (need to make cloning cheap for CDF, DeltaQ, etc.) and web assembly size
 - functional but ugly
 - duplicates state management in web app and backend, not yet decided what to put where (currently ΔQ expression evaluation is done in the backend, could easily move to a web worker)
-- no editing of CDFs yet
 - should have export (probably as JSON) and matching import
-- should allow editing the formulas as text, which requires making the syntax more accessible via normal keyboards
-- fixed samples and width for CDF, should be changed to support any step function and compute its width dynamically (with upper bound on details to avoid memory explosion)
 - should add “exponentiation” operator to wrap an expression in another one with a hole for a specified number of times

--- a/delta_q/src/bin/editor-web.rs
+++ b/delta_q/src/bin/editor-web.rs
@@ -134,7 +134,7 @@ fn app_main() -> HtmlResult {
                 <li class={classes!("row")}>
                     <button onclick={cloned!(name, on_change; move |_| on_change.emit((name.clone(), None)))}>{ "delete "}</button>
                     <div class={classes!("expression", sel)} style="margin-left: 8px;" onclick={select.reform(move |_| name.clone())}>
-                        { k }{ ": " }<EditExpression name={k.clone()} value={v.clone()} on_change={on_change.clone()} />
+                        { k }{ ": " }<EditExpression name={k.clone()} value={v.clone()} on_change={on_change.clone()} selected={sel.is_some()} />
                     </div>
                 </li>
             }
@@ -146,7 +146,7 @@ fn app_main() -> HtmlResult {
     }
 
     let dq = selected.as_ref().and_then(|name| ctx.get(name));
-    web_sys::console::log_1(&JsValue::from_str(&format!("{dq:?}")));
+    // web_sys::console::log_1(&JsValue::from_str(&format!("{dq:?}")));
 
     let cdf = match cdf {
         Ok(cdf) => cdf_to_svg(&cdf),
@@ -205,10 +205,11 @@ fn add_expression(props: &AddExpressionProps) -> HtmlResult {
     })
 }
 
-#[derive(Properties, PartialEq, Clone)]
+#[derive(Properties, PartialEq, Clone, Debug)]
 struct EditExpressionProps {
     name: String,
     value: DeltaQ,
+    selected: bool,
     on_change: Callback<(String, Option<DeltaQ>)>,
 }
 
@@ -240,6 +241,16 @@ fn edit_expression(props: &EditExpressionProps) -> HtmlResult {
             }
         }
     }));
+
+    use_memo(
+        (props.value.clone(), props.selected),
+        cloned!(editing, value, buffer; move |x| {
+               editing.set(false);
+               value.set(x.0.clone());
+               buffer.set(x.0.to_string());
+            }
+        ),
+    );
 
     Ok(html! {
         if *editing {

--- a/delta_q/src/bin/editor-web.rs
+++ b/delta_q/src/bin/editor-web.rs
@@ -124,7 +124,7 @@ fn app_main() -> HtmlResult {
         .map(|(k, v)| {
             let name = k.clone();
             let select = select.clone();
-            let sel = if selected.as_ref() == Some(k) {
+            let sel = if selected.as_deref() == Some(k.as_str()) {
                 sel_found = true;
                 Some("selected")
             } else {
@@ -132,9 +132,9 @@ fn app_main() -> HtmlResult {
             };
             html! {
                 <li class={classes!("row")}>
-                    <button onclick={cloned!(name, on_change; move |_| on_change.emit((name.clone(), None)))}>{ "delete "}</button>
-                    <div class={classes!("expression", sel)} style="margin-left: 8px;" onclick={select.reform(move |_| name.clone())}>
-                        { k }{ ": " }<EditExpression name={k.clone()} value={v.clone()} on_change={on_change.clone()} selected={sel.is_some()} />
+                    <button onclick={cloned!(name, on_change; move |_| on_change.emit((name.to_string(), None)))}>{ "delete "}</button>
+                    <div class={classes!("expression", sel)} style="margin-left: 8px;" onclick={select.reform(move |_| name.to_string())}>
+                        { k }{ ": " }<EditExpression name={k.to_string()} value={v.clone()} on_change={on_change.clone()} selected={sel.is_some()} />
                     </div>
                 </li>
             }

--- a/delta_q/src/bin/editor.rs
+++ b/delta_q/src/bin/editor.rs
@@ -107,7 +107,7 @@ async fn main() -> io::Result<()> {
     ctx.put("black".to_owned(), DeltaQ::BlackBox);
     ctx.put(
         "cdf".to_owned(),
-        DeltaQ::cdf(CDF::step(&[(0.1, 0.33), (0.2, 0.66), (0.4, 1.0)], 0.01, 300).unwrap()),
+        DeltaQ::cdf(CDF::step(&[(0.1, 0.33), (0.2, 0.66), (0.4, 1.0)]).unwrap()),
     );
     ctx.put(
         "out".to_owned(),

--- a/delta_q/src/cdf.rs
+++ b/delta_q/src/cdf.rs
@@ -368,20 +368,6 @@ fn compact(data: &mut Vec<(f32, f32)>, mode: CompactionMode, max_size: usize) {
     }
     let mk_d = |dist: f32, idx: usize| D((dist / granularity) as i16, idx, dist);
 
-    {
-        let mut heap = [mk_d(0.1, 1), mk_d(0.1, 0), mk_d(0.2, 1), mk_d(0.2, 2)]
-            .into_iter()
-            .collect::<BinaryHeap<_>>();
-        let mut v = Vec::new();
-        while let Some(elem) = heap.pop() {
-            v.push(elem);
-        }
-        assert_eq!(
-            v,
-            vec![mk_d(0.1, 1), mk_d(0.1, 0), mk_d(0.2, 2), mk_d(0.2, 1)],
-        );
-    }
-
     // use a binary heap to pull the closest pairs, identifying them by their x coordinate and sorting them by the distance to their right neighbor.
     let mut heap = data
         .iter()

--- a/delta_q/src/delta_q.rs
+++ b/delta_q/src/delta_q.rs
@@ -340,6 +340,7 @@ mod tests {
         let dq2 = DeltaQ::name("B");
         let seq = DeltaQ::seq(dq1, dq2);
         assert_eq!(seq.to_string(), "A ->- B");
+        assert_eq!(seq, "A ->- B".parse().unwrap());
     }
 
     #[test]
@@ -348,6 +349,7 @@ mod tests {
         let dq2 = DeltaQ::name("B");
         let choice = DeltaQ::choice(dq1, 0.3, dq2, 0.7);
         assert_eq!(choice.to_string(), "A 0.3<>0.7 B");
+        assert_eq!(choice, "A 0.3<>0.7 B".parse().unwrap());
     }
 
     #[test]
@@ -356,6 +358,7 @@ mod tests {
         let dq2 = DeltaQ::name("B");
         let for_all = DeltaQ::for_all(dq1, dq2);
         assert_eq!(for_all.to_string(), "all(A | B)");
+        assert_eq!(for_all, "all(A | B)".parse().unwrap());
     }
 
     #[test]
@@ -364,6 +367,7 @@ mod tests {
         let dq2 = DeltaQ::name("B");
         let for_some = DeltaQ::for_some(dq1, dq2);
         assert_eq!(for_some.to_string(), "some(A | B)");
+        assert_eq!(for_some, "some(A | B)".parse().unwrap());
     }
 
     #[test]
@@ -373,6 +377,8 @@ mod tests {
         let dq3 = DeltaQ::name("C");
         let nested_seq = DeltaQ::seq(DeltaQ::seq(dq1, dq2), dq3);
         assert_eq!(nested_seq.to_string(), "(A ->- B) ->- C");
+        assert_eq!(nested_seq, "(A ->- B) ->- C".parse().unwrap());
+        assert_eq!(nested_seq, "A ->- B ->- C".parse().unwrap());
     }
 
     #[test]
@@ -382,6 +388,8 @@ mod tests {
         let dq3 = DeltaQ::name("C");
         let nested_choice = DeltaQ::choice(DeltaQ::choice(dq1, 0.3, dq2, 0.7), 0.5, dq3, 0.5);
         assert_eq!(nested_choice.to_string(), "(A 0.3<>0.7 B) 0.5<>0.5 C");
+        assert_eq!(nested_choice, "(A 0.3<>0.7 B) 0.5<>0.5 C".parse().unwrap());
+        assert_eq!(nested_choice, "A 0.3<>0.7 B 0.5<>0.5 C".parse().unwrap());
     }
 
     #[test]
@@ -392,6 +400,7 @@ mod tests {
         let dq4 = DeltaQ::name("D");
         let nested_for_all = DeltaQ::for_all(DeltaQ::for_all(dq1, dq2), DeltaQ::seq(dq3, dq4));
         assert_eq!(nested_for_all.to_string(), "all(all(A | B) | C ->- D)");
+        assert_eq!(nested_for_all, "all(all(A | B) | C ->- D)".parse().unwrap());
     }
 
     #[test]
@@ -405,6 +414,10 @@ mod tests {
             DeltaQ::choice(dq3, 1.0, dq4, 2.0),
         );
         assert_eq!(nested_for_some.to_string(), "some(some(A | B) | C 1<>2 D)");
+        assert_eq!(
+            nested_for_some,
+            "some(some(A | B) | C 1<>2 D)".parse().unwrap()
+        );
     }
 
     #[test]

--- a/delta_q/src/delta_q.rs
+++ b/delta_q/src/delta_q.rs
@@ -402,8 +402,6 @@ mod tests {
             "single".to_owned() =>
                 DeltaQ::cdf(CDF::step(
                     &[(0.024, 1.0 / 3.0), (0.143, 2.0 / 3.0), (0.531, 1.0)],
-                    0.01,
-                    300,
                 )
                 .unwrap()),
             "model2".to_owned() =>

--- a/delta_q/src/delta_q.rs
+++ b/delta_q/src/delta_q.rs
@@ -476,4 +476,16 @@ mod tests {
         let result = DeltaQ::name("recursive").eval(&mut ctx.into()).unwrap_err();
         assert_eq!(result, DeltaQError::NameError("recursive".to_owned()));
     }
+
+    #[test]
+    fn parse_cdf() {
+        let res = "CDF[(2, 0.2), (2, 0.9)]".parse::<DeltaQ>().unwrap_err();
+        assert!(res.contains("must contain monotonic"), "{}", res);
+
+        let res = "CDF[(2a, 0.2), (2, 0.9)]".parse::<DeltaQ>().unwrap_err();
+        assert!(res.contains("expected CDF[("), "{}", res);
+
+        let res = "+a".parse::<DeltaQ>().unwrap_err();
+        assert!(res.contains("expected 'BB', name, CDF, 'all(', 'some(', or a parentheses"), "{}", res);
+    }
 }

--- a/delta_q/src/lib.rs
+++ b/delta_q/src/lib.rs
@@ -8,6 +8,7 @@ macro_rules! cloned {
 
 mod cdf;
 mod delta_q;
+mod parser;
 #[cfg(feature = "web")]
 mod render;
 

--- a/delta_q/src/lib.rs
+++ b/delta_q/src/lib.rs
@@ -11,7 +11,7 @@ mod delta_q;
 #[cfg(feature = "web")]
 mod render;
 
-pub use cdf::{CDFError, CDF};
+pub use cdf::{CDFError, CompactionMode, CDF};
 pub use delta_q::{DeltaQ, EvaluationContext};
 #[cfg(feature = "web")]
 pub use render::{cdf_to_svg, DeltaQComponent, DeltaQContext};

--- a/delta_q/src/parser.rs
+++ b/delta_q/src/parser.rs
@@ -1,0 +1,122 @@
+use crate::DeltaQ;
+use winnow::{
+    combinator::{alt, delimited, repeat, separated_pair},
+    stream::Stream,
+    token::take_while,
+    PResult, Parser,
+};
+
+pub fn parse(input: &str) -> Result<DeltaQ, String> {
+    delta_q
+        .parse(input)
+        .map_err(|e| format!("ΔQ parse error: {} (at position {})", e.inner(), e.offset()))
+}
+
+fn delta_q(input: &mut &str) -> PResult<DeltaQ> {
+    // https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html
+    fn rec(input: &mut &str, min_bp: u8) -> PResult<DeltaQ> {
+        let mut lhs = atom.parse_next(input)?;
+
+        loop {
+            let snap = input.checkpoint();
+            let Ok(op) = alt((
+                "->-".value(Op::Seq),
+                (num, "<>", num).map(|(l, _, r)| Op::Choice(l, r)),
+            ))
+            .parse_next(input) else {
+                break;
+            };
+
+            let (lbp, rbp) = op.bp();
+            if lbp < min_bp {
+                input.reset(&snap);
+                break;
+            }
+
+            let rhs = rec(input, rbp)?;
+            lhs = match op {
+                Op::Seq => DeltaQ::Seq(Box::new(lhs), Box::new(rhs)),
+                Op::Choice(l, r) => DeltaQ::Choice(Box::new(lhs), l, Box::new(rhs), r),
+            };
+        }
+        Ok(lhs)
+    }
+    rec(input, 0)
+}
+
+fn atom(input: &mut &str) -> PResult<DeltaQ> {
+    delimited(
+        ws,
+        alt((
+            blackbox,
+            name,
+            cdf,
+            for_all,
+            for_some,
+            delimited('(', delta_q, ')'),
+        )),
+        ws,
+    )
+    .parse_next(input)
+}
+
+fn ws(input: &mut &str) -> PResult<()> {
+    take_while(0.., |c: char| c.is_whitespace())
+        .void()
+        .parse_next(input)
+}
+
+fn blackbox(input: &mut &str) -> PResult<DeltaQ> {
+    "BB".value(DeltaQ::BlackBox).parse_next(input)
+}
+
+fn name(input: &mut &str) -> PResult<DeltaQ> {
+    take_while(1.., |c: char| c.is_alphanumeric())
+        .parse_next(input)
+        .map(|name| DeltaQ::Name(name.to_string()))
+}
+
+fn cdf(input: &mut &str) -> PResult<DeltaQ> {
+    (
+        "CDF[",
+        repeat::<_, _, (), _, _>(0.., (ws, '(', ws, num, ws, ',', ws, num, ws, ')')),
+        ws,
+        "]",
+    )
+        .take()
+        .try_map(|s| s.parse().map(DeltaQ::CDF))
+        .parse_next(input)
+}
+
+fn for_all(input: &mut &str) -> PResult<DeltaQ> {
+    delimited("all(", separated_pair(delta_q, "|", delta_q), ")")
+        .map(|(left, right)| DeltaQ::ForAll(Box::new(left), Box::new(right)))
+        .parse_next(input)
+}
+
+fn for_some(input: &mut &str) -> PResult<DeltaQ> {
+    delimited("some(", separated_pair(delta_q, "|", delta_q), ")")
+        .map(|(left, right)| DeltaQ::ForSome(Box::new(left), Box::new(right)))
+        .parse_next(input)
+}
+
+fn num(input: &mut &str) -> PResult<f32> {
+    take_while(1.., |c: char| c.is_digit(10) || c == '.')
+        .parse_next(input)
+        .map(|num_str| num_str.parse::<f32>().unwrap())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Op {
+    Seq,
+    Choice(f32, f32),
+}
+
+impl Op {
+    fn bp(&self) -> (u8, u8) {
+        match self {
+            Op::Seq => (1, 2),
+            Op::Choice { .. } => (3, 4),
+        }
+    }
+}

--- a/delta_q/src/render.rs
+++ b/delta_q/src/render.rs
@@ -35,8 +35,8 @@ pub fn delta_q_component(props: &Props) -> Html {
         DeltaQ::BlackBox => {
             html! { <BlackBox {on_change} /> }
         }
-        DeltaQ::Name(name) => {
-            html! { <NameComponent name={name.clone()} {on_change} /> }
+        DeltaQ::Name(name, rec) => {
+            html! { <NameComponent name={name.clone()} rec={*rec} {on_change} /> }
         }
         DeltaQ::CDF(cdf) => {
             html! { <div class={classes!("cdf")}>{ format!("{}", cdf) }</div> }
@@ -96,6 +96,7 @@ pub fn black_box(props: &BlackBoxProps) -> Html {
 #[derive(Properties, Clone, PartialEq)]
 pub struct NameProps {
     pub name: String,
+    pub rec: Option<usize>,
     pub on_change: Callback<(String, Option<DeltaQ>)>,
 }
 
@@ -104,6 +105,7 @@ pub fn name_component(props: &NameProps) -> Html {
     let on_change = props.on_change.clone();
     let popup = use_state(|| false);
     let name = props.name.clone();
+    let rec = props.rec;
     let ctx = use_context::<DeltaQContext>().unwrap();
 
     let new_name = use_state(|| props.name.clone());
@@ -114,13 +116,14 @@ pub fn name_component(props: &NameProps) -> Html {
         move |e: SubmitEvent| {
             e.prevent_default();
             popup.set(false);
-            on_change.emit((ctx.name.clone(), Some(DeltaQ::Name((*new_name).clone()))));
+            on_change.emit((ctx.name.clone(), Some(DeltaQ::Name((*new_name).clone(), rec))));
         }
     ));
 
     html! {
         <div class={classes!("name", "anchor")} onclick={cloned!(popup; move |_| if !*popup { popup.set(true) })}>
             { &props.name }
+            if let Some(rec) = rec { <sup>{ rec }</sup> }
             if *popup {
                 <div class={classes!("popup")}>
                     <button onclick={cloned!(popup;
@@ -440,7 +443,7 @@ pub fn cdf_to_svg(cdf: &CDF) -> Html {
     let svg = VNode::from_html_unchecked(canvas.svg().unwrap().into());
     html! {
         <>
-            <p>{ "result: " }{cdf.to_string()} </p>
+            <p class={classes!("result")}>{ "result: " }{cdf.to_string()} </p>
             { svg }
         </>
     }

--- a/delta_q/src/render.rs
+++ b/delta_q/src/render.rs
@@ -36,7 +36,7 @@ pub fn delta_q_component(props: &Props) -> Html {
             html! { <BlackBox {on_change} /> }
         }
         DeltaQ::Name(name, rec) => {
-            html! { <NameComponent name={name.clone()} rec={*rec} {on_change} /> }
+            html! { <NameComponent name={(&**name).to_owned()} rec={*rec} {on_change} /> }
         }
         DeltaQ::CDF(cdf) => {
             html! { <div class={classes!("cdf")}>{ format!("{}", cdf) }</div> }
@@ -116,7 +116,7 @@ pub fn name_component(props: &NameProps) -> Html {
         move |e: SubmitEvent| {
             e.prevent_default();
             popup.set(false);
-            on_change.emit((ctx.name.clone(), Some(DeltaQ::Name((*new_name).clone(), rec))));
+            on_change.emit((ctx.name.clone(), Some(DeltaQ::name_rec(&new_name, rec))));
         }
     ));
 
@@ -354,7 +354,7 @@ fn branch(props: &BranchProps) -> Html {
     let top = props.top.clone();
     let bottom = props.bottom.clone();
     let kind = props.kind;
-    let constructor: Arc<dyn Fn(Box<DeltaQ>, Box<DeltaQ>) -> DeltaQ> = match kind {
+    let constructor: Arc<dyn Fn(Arc<DeltaQ>, Arc<DeltaQ>) -> DeltaQ> = match kind {
         BranchKind::Choice(l, r) => Arc::new(move |dql, dqr| DeltaQ::Choice(dql, l, dqr, r)),
         BranchKind::ForAll => Arc::new(DeltaQ::ForAll),
         BranchKind::ForSome => Arc::new(DeltaQ::ForSome),
@@ -367,7 +367,7 @@ fn branch(props: &BranchProps) -> Html {
             if name != ctx.name {
                 on_change.emit((name, delta_q));
             } else if let Some(delta_q) = delta_q {
-                on_change.emit((name, Some(constructor(Box::new(delta_q), Box::new(bottom.clone())))));
+                on_change.emit((name, Some(constructor(Arc::new(delta_q), Arc::new(bottom.clone())))));
             }
         }
     ));
@@ -378,7 +378,7 @@ fn branch(props: &BranchProps) -> Html {
             if name != ctx.name {
                 on_change.emit((name, delta_q));
             } else if let Some(delta_q) = delta_q {
-                on_change.emit((name, Some(constructor(Box::new(top.clone()), Box::new(delta_q)))));
+                on_change.emit((name, Some(constructor(Arc::new(top.clone()), Arc::new(delta_q)))));
             }
         }
     ));

--- a/delta_q/src/render.rs
+++ b/delta_q/src/render.rs
@@ -29,7 +29,7 @@ pub struct Props {
 
 #[function_component(DeltaQComponent)]
 pub fn delta_q_component(props: &Props) -> Html {
-    web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!("{props:?}")));
+    // web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!("{props:?}")));
     let on_change = props.on_change.clone();
     match &props.delta_q {
         DeltaQ::BlackBox => {

--- a/delta_q/styles.css
+++ b/delta_q/styles.css
@@ -28,6 +28,7 @@
 .dq_edit form { display: flex; }
 .dq_edit input[type="text"] { width: 100%; }
 .dq_show { margin-left: 16px; }
+.result { max-height: 5em; overflow-y: scroll; }
 
 .column { display: flex; flex-direction: column; }
 .row { display: flex; flex-direction: row; }

--- a/delta_q/styles.css
+++ b/delta_q/styles.css
@@ -14,7 +14,20 @@
 .frame { margin: 4px; border: 1px solid grey; }
 .seqSymbol { width: 10px; height: 10px; border: 2px solid black; margin: 4px; cursor: pointer; }
 .branchKind { padding: 8px; cursor: pointer; }
-.expression { background-color: rgb(206, 236, 254); padding: 4px; display: inline-block; margin: 4px; cursor: pointer; }
+.expression {
+  background-color: rgb(206, 236, 254);
+  padding: 4px;
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  margin: 4px;
+  cursor: pointer;
+}
+.selected { font-weight: bold; }
+.dq_edit { vertical-align: text-top; flex-grow: 1; margin-left: 16px; }
+.dq_edit form { display: flex; }
+.dq_edit input[type="text"] { width: 100%; }
+.dq_show { margin-left: 16px; }
 
 .column { display: flex; flex-direction: column; }
 .row { display: flex; flex-direction: row; }


### PR DESCRIPTION
- optimise representation of CDFs
- add printing and parsing for CDFs and ΔQ expressions
- make expressions textually editable in the UI
- add recursion (a.k.a. exponentiation) operator