### PR TITLE
Format simulation code using fourmolu

### DIFF
--- a/simulation/src/Main.hs
+++ b/simulation/src/Main.hs
@@ -55,8 +55,7 @@ cli =
           \ animation frames to a directory."
     )
 
-data CliCmd
-  = CliCmd
+data CliCmd = CliCmd
   { cliVizName :: VizName
   , cliOutputFramesDir :: Maybe FilePath
   , cliOutputSeconds :: Maybe Int

--- a/simulation/src/ModelTCP.hs
+++ b/simulation/src/ModelTCP.hs
@@ -102,8 +102,7 @@ saneTcpState
         == tcpAvailableCongestionWindow
           + Foldable.sum tcpAcknowledgements
 
-data TcpMsgForecast
-  = TcpMsgForecast
+data TcpMsgForecast = TcpMsgForecast
   { msgSendLeadingEdge :: !Time
   -- ^ The time the sender starts sending (leading edge);
   , msgSendTrailingEdge :: !Time

--- a/simulation/src/P2P.hs
+++ b/simulation/src/P2P.hs
@@ -26,8 +26,7 @@ import qualified System.Random as Random
 
 import SimTypes (NodeId (..), Point (..), WorldShape (..))
 
-data P2PTopography
-  = P2PTopography
+data P2PTopography = P2PTopography
   { p2pNodes :: !(Map NodeId Point)
   , p2pLinks :: !(Map (NodeId, NodeId) Latency)
   , p2pWorldShape :: !WorldShape
@@ -38,8 +37,7 @@ type Latency =
   -- | Double rather than DiffTime for efficiency
   Double
 
-data P2PTopographyCharacteristics
-  = P2PTopographyCharacteristics
+data P2PTopographyCharacteristics = P2PTopographyCharacteristics
   { p2pWorldShape :: !WorldShape
   -- ^ Size of the world (in seconds): (Circumference, pole-to-pole)
   , -- \^ Number of nodes, e.g. 100, 1000, 10,000

--- a/simulation/src/RelayProtocol.hs
+++ b/simulation/src/RelayProtocol.hs
@@ -186,8 +186,7 @@ instance MessageSize blk => MessageSize (BlockRelayMessage blk blkid blkmd) wher
 newtype BlockTTL = BlockTTL UTCTime
   deriving (Eq, Ord, Show)
 
-data BlockRelayConfig m blk blkid
-  = BlockRelayConfig
+data BlockRelayConfig m blk blkid = BlockRelayConfig
   { blockId :: blk -> blkid
   , blockTTL :: blk -> BlockTTL
   , submitBlock :: blk -> STM m () -> m ()

--- a/simulation/src/SimRelay.hs
+++ b/simulation/src/SimRelay.hs
@@ -98,8 +98,7 @@ instance MessageSize TestBlock where
 
 type TestBlockRelayMessage = BlockRelayMessage TestBlock TestBlockId BlockTTL
 
-data RelayNodeConfig
-  = RelayNodeConfig
+data RelayNodeConfig = RelayNodeConfig
   { blockProcessingDelay :: TestBlock -> DiffTime
   , blockGeneration :: PacketGenerationPattern
   }

--- a/simulation/src/Viz.hs
+++ b/simulation/src/Viz.hs
@@ -34,14 +34,12 @@ data Vizualisation where
     Layout (VizRender model) ->
     Vizualisation
 
-data VizModel model
-  = VizModel
+data VizModel model = VizModel
   { initModel :: model
   , stepModel :: DiffTime -> Time -> FrameNo -> model -> model
   }
 
-data VizRender model
-  = VizRender
+data VizRender model = VizRender
   { renderReqSize :: (Int, Int)
   , renderChanged :: Time -> FrameNo -> model -> Bool
   , renderModel ::
@@ -108,8 +106,7 @@ stepModelWithTime VizModel{stepModel} fps (time, frameno, model) =
 
 data LayoutTile a = LayoutTile !Tile a
 
-data Tile
-  = Tile
+data Tile = Tile
   { tileX :: !Int
   , tileY :: !Int
   , tileW :: !Int
@@ -251,8 +248,7 @@ takeUpTo n = go 0
     | a + x >= n = [x] -- inclusive
     | otherwise = x : go (a + x) xs
 
-data LayoutProperties
-  = LayoutProps
+data LayoutProperties = LayoutProps
   { reqSize :: !(Int, Int)
   , expand :: !Bool
   }
@@ -389,8 +385,7 @@ renderTiles tiles forceRender time frame model =
       Cairo.clip
       Cairo.translate (fromIntegral tileX) (fromIntegral tileY)
       if tileScale == 1.0
-        then
-          render (fromIntegral tileW, fromIntegral tileH)
+        then render (fromIntegral tileW, fromIntegral tileH)
         else do
           Cairo.scale tileScale tileScale
           render
@@ -399,8 +394,7 @@ renderTiles tiles forceRender time frame model =
             )
       Cairo.restore
 
-data GtkVizConfig
-  = GtkVizConfig
+data GtkVizConfig = GtkVizConfig
   { gtkVizFPS :: Int
   , gtkVizResolution :: Maybe (Int, Int)
   , gtkVizCpuRendering :: Bool
@@ -543,8 +537,7 @@ vizualise
     Gtk.widgetShowAll window
     Gtk.mainGUI
 
-data AnimVizConfig
-  = AnimVizConfig
+data AnimVizConfig = AnimVizConfig
   { animVizFrameFiles :: Int -> FilePath
   , animVizDuration :: Int
   , animVizStartTime :: Int

--- a/simulation/src/VizChart.hs
+++ b/simulation/src/VizChart.hs
@@ -74,8 +74,7 @@ scaledAxis lap rs@(minV, maxV) ps =
     | minV == maxV =
         if minV == 0
           then (-1, 1)
-          else
-            let d = abs (minV * 0.01) in (minV - d, maxV + d)
+          else let d = abs (minV * 0.01) in (minV - d, maxV + d)
     | otherwise = rs
   labelvs = map fromRational $ steps (fromIntegral (Chart._la_nLabels lap)) r
   tickvs =

--- a/simulation/src/VizSimRelay.hs
+++ b/simulation/src/VizSimRelay.hs
@@ -36,8 +36,7 @@ type RelaySimVizModel =
     RelaySimVizState
 
 -- | The vizualisation state within the data model for the relay simulation
-data RelaySimVizState
-  = RelaySimVizState
+data RelaySimVizState = RelaySimVizState
   { vizWorldShape :: !WorldShape
   , vizNodePos :: !(Map NodeId Point)
   , vizNodeLinks :: !(Map (NodeId, NodeId) LinkPoints)
@@ -288,8 +287,7 @@ recentPrune now (RecentRate pq) =
 -- The vizualisation rendering
 --
 
-data RelaySimVizConfig
-  = RelaySimVizConfig
+data RelaySimVizConfig = RelaySimVizConfig
   { nodeMessageColor :: TestBlock -> (Double, Double, Double)
   , ptclMessageColor :: TestBlockRelayMessage -> (Double, Double, Double)
   , nodeMessageText :: TestBlock -> Maybe String

--- a/simulation/src/VizSimRelayP2P.hs
+++ b/simulation/src/VizSimRelayP2P.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 {-# HLINT ignore "Use const" #-}
 
 module VizSimRelayP2P where
@@ -34,8 +35,7 @@ import VizUtils
 -- The vizualisation rendering
 --
 
-data RelayP2PSimVizConfig
-  = RelayP2PSimVizConfig
+data RelayP2PSimVizConfig = RelayP2PSimVizConfig
   { nodeMessageColor :: TestBlock -> (Double, Double, Double)
   , ptclMessageColor :: TestBlockRelayMessage -> Maybe (Double, Double, Double)
   }

--- a/simulation/src/VizSimTCP.hs
+++ b/simulation/src/VizSimTCP.hs
@@ -28,8 +28,7 @@ type TcpSimVizModel =
     TcpSimVizState
 
 -- | The vizualisation state within the data model for the tcp simulation
-data TcpSimVizState
-  = TcpSimVizState
+data TcpSimVizState = TcpSimVizState
   { vizNodePos :: Map NodeId Point
   , vizNodeLinks :: Set (NodeId, NodeId)
   , vizMsgsInTransit ::
@@ -121,8 +120,7 @@ tcpSimVizModel =
 -- The vizualisation rendering
 --
 
-newtype TcpSimVizConfig msg
-  = TcpSimVizConfig
+newtype TcpSimVizConfig msg = TcpSimVizConfig
   { messageColor :: msg -> (Double, Double, Double)
   }
 


### PR DESCRIPTION
Our [coding standards]() requires code to be formatted using fourmolu and the `fourmolu.yaml` file provided at the toplevel of the directory. This PR is the result of running `fourmolu -i .` in the `simulation` directory.