### PR TITLE
2024 10 24/sim rs

### DIFF
--- a/sim-rs/Cargo.lock
+++ b/sim-rs/Cargo.lock
@@ -110,6 +110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "average"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a237a6822e1c3c98e700b6db5b293eb341b7524dcb8d227941245702b7431dc"
+dependencies = [
+ "easy-cast",
+ "float-ord",
+ "num-traits",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,10 +228,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "easy-cast"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -797,6 +823,7 @@ name = "sim-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "average",
  "clap",
  "ctrlc",
  "serde",

--- a/sim-rs/sim-cli/Cargo.toml
+++ b/sim-rs/sim-cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+average = "0.15"
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
 serde = { version = "1", features = ["derive"] }

--- a/sim-rs/sim-core/src/clock.rs
+++ b/sim-rs/sim-core/src/clock.rs
@@ -1,5 +1,5 @@
 use std::{
-    ops::Add,
+    ops::{Add, Sub},
     time::{Duration, Instant},
 };
 
@@ -13,6 +13,13 @@ impl Add<Duration> for Timestamp {
 
     fn add(self, rhs: Duration) -> Self::Output {
         Timestamp(self.0 + rhs)
+    }
+}
+impl Sub<Timestamp> for Timestamp {
+    type Output = Duration;
+
+    fn sub(self, rhs: Timestamp) -> Self::Output {
+        self.0 - rhs.0
     }
 }
 

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -61,6 +61,7 @@ pub struct RawConfig {
     pub max_tx_size: u64,
     pub max_ib_size: u64,
     pub max_ib_requests_per_peer: usize,
+    pub ib_shards: u64,
     pub transaction_frequency_ms: DistributionConfig,
     pub transaction_size_bytes: DistributionConfig,
 }
@@ -114,6 +115,7 @@ impl From<RawConfig> for SimConfiguration {
             max_tx_size: value.max_tx_size,
             max_ib_size: value.max_ib_size,
             max_ib_requests_per_peer: value.max_ib_requests_per_peer,
+            ib_shards: value.ib_shards,
             transaction_frequency_ms: value.transaction_frequency_ms.into(),
             transaction_size_bytes: value.transaction_size_bytes.into(),
         }
@@ -133,6 +135,7 @@ pub struct SimConfiguration {
     pub max_tx_size: u64,
     pub max_ib_size: u64,
     pub max_ib_requests_per_peer: usize,
+    pub ib_shards: u64,
     pub transaction_frequency_ms: FloatDistribution,
     pub transaction_size_bytes: FloatDistribution,
 }

--- a/sim-rs/sim-core/src/events.rs
+++ b/sim-rs/sim-core/src/events.rs
@@ -12,7 +12,13 @@ use crate::{
 pub enum Event {
     Transaction {
         id: TransactionId,
+        publisher: NodeId,
         bytes: u64,
+    },
+    TransactionReceived {
+        id: TransactionId,
+        sender: NodeId,
+        recipient: NodeId,
     },
     Slot {
         number: u64,
@@ -56,10 +62,19 @@ impl EventTracker {
         });
     }
 
-    pub fn track_transaction(&self, transaction: &Transaction) {
+    pub fn track_transaction(&self, transaction: &Transaction, publisher: NodeId) {
         self.send(Event::Transaction {
             id: transaction.id,
+            publisher,
             bytes: transaction.bytes,
+        });
+    }
+
+    pub fn track_transaction_received(&self, id: TransactionId, sender: NodeId, recipient: NodeId) {
+        self.send(Event::TransactionReceived {
+            id,
+            sender,
+            recipient,
         });
     }
 

--- a/sim-rs/sim-core/src/model.rs
+++ b/sim-rs/sim-core/src/model.rs
@@ -34,6 +34,7 @@ id_wrapper!(TransactionId, u64);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Transaction {
     pub id: TransactionId,
+    pub shard: u64,
     pub bytes: u64,
 }
 
@@ -51,6 +52,7 @@ pub struct InputBlockHeader {
     /// Need this field to distinguish IBs from the same slot+producer.
     /// The real implementation can use the VRF proof for that.
     pub index: u64,
+    pub vrf: u64,
     pub timestamp: Timestamp,
 }
 impl InputBlockHeader {

--- a/sim-rs/sim-core/src/model.rs
+++ b/sim-rs/sim-core/src/model.rs
@@ -39,12 +39,12 @@ pub struct Transaction {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct InputBlockId {
-    slot: u64,
-    producer: NodeId,
-    index: u64,
+    pub slot: u64,
+    pub producer: NodeId,
+    pub index: u64,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
 pub struct InputBlockHeader {
     pub slot: u64,
     pub producer: NodeId,

--- a/sim-rs/sim-core/src/sim.rs
+++ b/sim-rs/sim-core/src/sim.rs
@@ -181,16 +181,16 @@ impl Simulation {
 
     fn handle_input_block_generation(&mut self, slot: u64) -> Result<()> {
         let mut probability = self.config.ib_generation_probability;
-        let mut block_counts = BTreeMap::new();
+        let mut ib_vrfs: BTreeMap<NodeId, Vec<u64>> = BTreeMap::new();
         while probability > 0.0 {
             let next_p = f64::min(probability, 1.0);
-            for (id, _) in self.run_vrf_lottery(next_p) {
-                *block_counts.entry(id).or_default() += 1;
+            for (id, vrf) in self.run_vrf_lottery(next_p) {
+                ib_vrfs.entry(id).or_default().push(vrf);
             }
             probability -= 1.0;
         }
-        for (id, count) in block_counts {
-            self.get_node_mut(&id).begin_generating_ibs(slot, count)?;
+        for (id, vrfs) in ib_vrfs {
+            self.get_node_mut(&id).begin_generating_ibs(slot, vrfs)?;
         }
         Ok(())
     }
@@ -249,11 +249,12 @@ impl Simulation {
 
     fn generate_tx(&mut self) -> Result<()> {
         let id = TransactionId::new(self.next_tx_id);
+        let shard = self.rng.gen_range(0..self.config.ib_shards);
         let bytes = self
             .config
             .max_tx_size
             .min(self.config.transaction_size_bytes.sample(&mut self.rng) as u64);
-        let tx = Arc::new(Transaction { id, bytes });
+        let tx = Arc::new(Transaction { id, shard, bytes });
 
         // any node could be the first to see a transaction
         let publisher_id = self.choose_random_node();
@@ -294,6 +295,7 @@ struct Node {
     total_stake: u64,
     max_ib_size: u64,
     max_ib_requests_per_peer: usize,
+    ib_shards: u64,
     peers: Vec<NodeId>,
     praos: NodePraosState,
     leios: NodeLeiosState,
@@ -321,7 +323,7 @@ struct PendingInputBlock {
 #[derive(Default)]
 struct NodeLeiosState {
     mempool: BTreeMap<TransactionId, Arc<Transaction>>,
-    unsent_ibs: BTreeMap<u64, VecDeque<InputBlock>>,
+    unsent_ibs: Vec<InputBlock>,
     ibs: BTreeMap<InputBlockId, Arc<InputBlock>>,
     pending_ibs: BTreeMap<InputBlockId, PendingInputBlock>,
     ib_requests: BTreeMap<NodeId, PeerInputBlockRequests>,
@@ -349,6 +351,7 @@ impl Node {
             total_stake,
             max_ib_size: sim_config.max_ib_size,
             max_ib_requests_per_peer: sim_config.max_ib_requests_per_peer,
+            ib_shards: sim_config.ib_shards,
             peers,
             praos: NodePraosState::default(),
             leios: NodeLeiosState::default(),
@@ -389,14 +392,16 @@ impl Node {
         if self.trace {
             info!("node {} saw tx {id}", self.id);
         }
-        self.leios.mempool.insert(tx.id, tx);
         for peer in &self.peers {
             if *peer == from {
                 continue;
             }
             self.send_to(*peer, SimulationMessage::AnnounceTx(id))?;
         }
-        self.try_fill_ibs()
+        if !self.try_adding_tx_to_ib(&tx)? {
+            self.leios.mempool.insert(tx.id, tx);
+        }
+        Ok(())
     }
 
     fn receive_roll_forward(&mut self, from: NodeId, slot: u64) -> Result<()> {
@@ -519,10 +524,8 @@ impl Node {
         for transaction in &ib.transactions {
             // Do not include transactions from this IB in any IBs we produce ourselves.
             self.leios.mempool.remove(&transaction.id);
-            for pending_ibs in self.leios.unsent_ibs.values_mut() {
-                for pending_ib in pending_ibs {
-                    pending_ib.transactions.retain(|tx| tx.id != transaction.id);
-                }
+            for unsent_ib in &mut self.leios.unsent_ibs {
+                unsent_ib.transactions.retain(|tx| tx.id != transaction.id);
             }
         }
         self.leios.ibs.insert(id, ib);
@@ -560,69 +563,72 @@ impl Node {
         Ok(())
     }
 
-    fn begin_generating_ibs(&mut self, slot: u64, count: u64) -> Result<()> {
-        let mut unsent_ibs = VecDeque::new();
-        for index in 0..count {
+    fn begin_generating_ibs(&mut self, slot: u64, vrfs: Vec<u64>) -> Result<()> {
+        for (index, vrf) in vrfs.into_iter().enumerate() {
             let header = InputBlockHeader {
                 slot,
                 producer: self.id,
-                index,
+                index: index as u64,
+                vrf,
                 timestamp: self.clock.now(),
             };
-            unsent_ibs.push_back(InputBlock {
+            self.leios.unsent_ibs.push(InputBlock {
                 header,
                 transactions: vec![],
             });
         }
-        self.leios.unsent_ibs.insert(slot, unsent_ibs);
-        self.try_fill_ibs()
-    }
-
-    fn try_fill_ibs(&mut self) -> Result<()> {
-        loop {
-            let Some(mut first_ib_entry) = self.leios.unsent_ibs.first_entry() else {
-                // we aren't sending any IBs
-                return Ok(());
-            };
-            let slot = *first_ib_entry.key();
-            let unsent_ibs = first_ib_entry.get_mut();
-            let Some(unsent_ib) = unsent_ibs.front_mut() else {
-                // we aren't sending any more IBs this round
-                self.leios.unsent_ibs.remove(&slot);
-                return Ok(());
-            };
-            let Some((_, tx)) = self.leios.mempool.first_key_value() else {
-                // our mempool is empty
-                return Ok(());
-            };
-
-            let remaining_capacity = self.max_ib_size - unsent_ib.bytes();
-            let tx_bytes = tx.bytes;
-
-            if remaining_capacity >= tx_bytes {
-                // This IB has room for another TX, add it in
-                let (id, tx) = self.leios.mempool.pop_first().unwrap();
-                self.leios.mempool.remove(&id);
-                unsent_ib.transactions.push(tx);
-            }
-
-            if remaining_capacity <= tx_bytes {
-                // This IB is full, :shipit:
-                let ib = unsent_ibs.pop_front().unwrap();
-                self.generate_ib(ib)?;
+        let candidate_txs: Vec<TransactionId> = self.leios.mempool.keys().copied().collect();
+        for tx_id in candidate_txs {
+            let tx = self.leios.mempool.get(&tx_id).cloned().unwrap();
+            if self.try_adding_tx_to_ib(&tx)? {
+                self.leios.mempool.remove(&tx_id);
             }
         }
+        Ok(())
+    }
+
+    fn try_adding_tx_to_ib(&mut self, tx: &Arc<Transaction>) -> Result<bool> {
+        let mut added = false;
+        let mut index_to_publish = None;
+        for (index, ib) in self.leios.unsent_ibs.iter_mut().enumerate() {
+            let shard = ib.header.vrf % self.ib_shards;
+            if shard != tx.shard {
+                continue;
+            }
+
+            let remaining_capacity = self.max_ib_size - ib.bytes();
+            let tx_bytes = tx.bytes;
+
+            if remaining_capacity < tx_bytes {
+                continue;
+            }
+
+            // This IB has room for another TX, add it in
+            ib.transactions.push(tx.clone());
+            added = true;
+            if remaining_capacity <= tx_bytes {
+                // This IB is full, :shipit:
+                index_to_publish = Some(index);
+            }
+            break;
+        }
+        if let Some(index) = index_to_publish {
+            let ib = self.leios.unsent_ibs.remove(index);
+            self.generate_ib(ib)?;
+        }
+        Ok(added)
     }
 
     fn finish_generating_ibs(&mut self, slot: u64) -> Result<()> {
-        let Some(unsent_ibs) = self.leios.unsent_ibs.remove(&slot) else {
-            return Ok(());
-        };
+        let mut unsent_ibs = vec![];
+        unsent_ibs.append(&mut self.leios.unsent_ibs);
+
         for ib in unsent_ibs {
-            if ib.transactions.is_empty() {
-                continue;
+            if ib.header.slot != slot {
+                self.leios.unsent_ibs.push(ib);
+            } else if !ib.transactions.is_empty() {
+                self.generate_ib(ib)?;
             }
-            self.generate_ib(ib)?;
         }
         Ok(())
     }

--- a/sim-rs/test_data/realistic.toml
+++ b/sim-rs/test_data/realistic.toml
@@ -1,5 +1,6 @@
 block_generation_probability = 0.05
 ib_generation_probability = 5.0
+ib_shards = 8
 max_block_size = 90112
 max_ib_requests_per_peer = 1
 max_ib_size = 327680

--- a/sim-rs/test_data/simple.toml
+++ b/sim-rs/test_data/simple.toml
@@ -51,5 +51,6 @@ max_block_size = 90112
 
 # IB parameters
 ib_generation_probability = 0.5 # corresponds to 𝑓I in the model
+ib_shards = 2
 max_ib_size = 327680
 max_ib_requests_per_peer = 1


### PR DESCRIPTION
Restructured the sim's event output based on the wasm experiment; events are now more uniform and less redundant.

Implemented basic sharding across IBs. The sim now outputs the mean+stddev of the time it took for a transaction to reach a block, to help understand the effect on latency