### PR TITLE
Replace netsim with a decentralized network layer

### DIFF
--- a/sim-rs/Cargo.lock
+++ b/sim-rs/Cargo.lock
@@ -620,6 +620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-bytes-rust"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9cf90f159a57d064a311cfcc6d65f189c12bf399080a7dd2b64de47181639b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +835,7 @@ dependencies = [
  "average",
  "clap",
  "ctrlc",
+ "pretty-bytes-rust",
  "serde",
  "serde_json",
  "sim-core",

--- a/sim-rs/sim-cli/Cargo.toml
+++ b/sim-rs/sim-cli/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 average = "0.15"
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
+pretty-bytes-rust = "0.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sim-core = { path = "../sim-core" }

--- a/sim-rs/sim-cli/src/events.rs
+++ b/sim-rs/sim-cli/src/events.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    path::PathBuf, time::Duration,
+    path::PathBuf,
+    time::Duration,
 };
 
 use anyhow::Result;
@@ -83,7 +84,7 @@ impl EventMonitor {
             None => OutputTarget::None,
         };
         while let Some((event, time)) = self.events_source.recv().await {
-            last_timestamp = time.clone();
+            last_timestamp = time;
             if should_log_event(&event) {
                 let output_event = OutputEvent {
                     time,
@@ -229,7 +230,7 @@ impl EventMonitor {
                 txs.len(),
             );
             let avg_age = pending_txs.iter().map(|id| {
-                let tx = txs.get(&id).unwrap();
+                let tx = txs.get(id).unwrap();
                 (last_timestamp - tx.generated).as_secs_f64()
             });
             let avg_age_stats = compute_stats(avg_age);

--- a/sim-rs/sim-core/src/clock.rs
+++ b/sim-rs/sim-core/src/clock.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use tokio::time;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Timestamp(Duration);
+pub struct Timestamp(pub Duration);
 impl Add<Duration> for Timestamp {
     type Output = Timestamp;
 

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -100,12 +100,7 @@ impl From<RawConfig> for SimConfiguration {
             nodes[id2].peers.push(NodeId::new(id1));
             links.push(LinkConfiguration {
                 nodes: (NodeId::new(id1), NodeId::new(id2)),
-                latency: compute_latency(
-                    nodes[id1].location,
-                    nodes[id2].location,
-                    link.latency_ms,
-                    timescale,
-                ),
+                latency: compute_latency(nodes[id1].location, nodes[id2].location, link.latency_ms),
             });
         }
         Self {
@@ -180,18 +175,12 @@ fn to_netsim_location((lat, long): (f64, f64)) -> Location {
     ((lat * 10000.) as i64, (long * 10000.) as u64)
 }
 
-fn compute_latency(
-    loc1: Location,
-    loc2: Location,
-    extra_ms: Option<u64>,
-    timescale: f64,
-) -> Duration {
+fn compute_latency(loc1: Location, loc2: Location, extra_ms: Option<u64>) -> Duration {
     let geo_latency = geo::latency_between_locations(loc1, loc2, 1.)
         .map(|l| l.to_duration())
         .unwrap_or(Duration::ZERO);
     let extra_latency = Duration::from_millis(extra_ms.unwrap_or(5));
-    let latency = geo_latency + extra_latency;
-    Duration::from_secs_f64(latency.as_secs_f64() / timescale)
+    geo_latency + extra_latency
 }
 
 #[derive(Debug, Clone)]

--- a/sim-rs/sim-core/src/network.rs
+++ b/sim-rs/sim-core/src/network.rs
@@ -1,75 +1,154 @@
-use std::time::Duration;
-
-use anyhow::Result;
-use netsim_async::{
-    Edge, EdgePolicy, HasBytesSize, SimContext, SimId, SimSocketReadHalf, SimSocketWriteHalf,
+use std::{
+    collections::{BinaryHeap, HashMap},
+    time::Duration,
 };
 
-use crate::config::NodeId;
+use anyhow::{bail, Result};
+use netsim_async::EdgePolicy;
+use tokio::sync::mpsc;
 
-pub struct Network<T: HasBytesSize> {
-    context: SimContext<T>,
+use crate::{
+    clock::{Clock, Timestamp},
+    config::NodeId,
+};
+
+pub struct Network<T> {
+    sources: HashMap<NodeId, NetworkSource<T>>,
+    sinks: HashMap<NodeId, NetworkSink<T>>,
+    clock: Clock,
 }
 
-impl<T: HasBytesSize> Network<T> {
-    pub fn new(timescale: f64) -> Self {
-        let mut config = netsim_async::SimConfiguration::default();
-        config.idle_duration =
-            Duration::from_secs_f64(config.idle_duration.as_secs_f64() / timescale);
+impl<T> Network<T> {
+    pub fn new(clock: Clock) -> Self {
         Self {
-            context: SimContext::with_config(config),
+            sources: HashMap::new(),
+            sinks: HashMap::new(),
+            clock,
         }
     }
 
-    pub fn shutdown(self) -> Result<()> {
-        self.context.shutdown()
-    }
-
-    pub fn open(&mut self, node_id: NodeId) -> Result<(NetworkSource<T>, NetworkSink<T>)> {
-        let socket = self.context.open()?;
-        assert_eq!(
-            node_id.to_string(),
-            socket.id().to_string(),
-            "Nodes must be initialized in order"
-        );
-
-        let (inner_source, inner_sink) = socket.into_split();
-        let source = NetworkSource(inner_source);
-        let sink = NetworkSink(inner_sink);
-        Ok((source, sink))
-    }
-
     pub fn set_edge_policy(&mut self, from: NodeId, to: NodeId, policy: EdgePolicy) -> Result<()> {
-        let from = to_sim_id(from);
-        let to = to_sim_id(to);
-        let edge = Edge::new((from, to));
-        self.context.set_edge_policy(edge, policy)
+        self.add_edge(from, to, policy.latency.to_duration());
+        self.add_edge(to, from, policy.latency.to_duration());
+        Ok(())
+    }
+
+    fn add_edge(&mut self, from: NodeId, to: NodeId, latency: Duration) {
+        let to_source = self
+            .sources
+            .entry(to)
+            .or_insert_with(|| NetworkSource::new(self.clock.clone()));
+        let from_sink = self
+            .sinks
+            .entry(from)
+            .or_insert_with(|| NetworkSink::new(from, self.clock.clone()));
+        from_sink
+            .channels
+            .insert(to, (to_source.sink.clone(), latency));
+    }
+
+    pub fn open(&mut self, node_id: NodeId) -> Result<(NetworkSink<T>, NetworkSource<T>)> {
+        let Some(sink) = self.sinks.remove(&node_id) else {
+            bail!("Node has no edges")
+        };
+        let Some(source) = self.sources.remove(&node_id) else {
+            bail!("Node has no edges")
+        };
+        Ok((sink, source))
+    }
+
+    pub fn shutdown(self) -> Result<()> {
+        Ok(())
     }
 }
 
-pub struct NetworkSource<T: HasBytesSize>(SimSocketReadHalf<T>);
-impl<T: HasBytesSize> NetworkSource<T> {
+pub struct NetworkSource<T> {
+    messages: BinaryHeap<PendingMessage<T>>,
+    source: mpsc::UnboundedReceiver<PendingMessage<T>>,
+    sink: mpsc::UnboundedSender<PendingMessage<T>>,
+    clock: Clock,
+}
+
+impl<T> NetworkSource<T> {
+    fn new(clock: Clock) -> Self {
+        let (sink, source) = mpsc::unbounded_channel();
+        Self {
+            messages: BinaryHeap::new(),
+            source,
+            sink,
+            clock,
+        }
+    }
     pub async fn recv(&mut self) -> Option<(NodeId, T)> {
-        let (sim_id, msg) = self.0.recv().await?;
-        let node_id = to_node_id(sim_id);
-        Some((node_id, msg))
+        while let Ok(pending) = self.source.try_recv() {
+            self.messages.push(pending);
+        }
+        if self.messages.is_empty() {
+            let next = self.source.recv().await?;
+            self.messages.push(next);
+        }
+        let next = self.messages.peek()?;
+        self.clock.wait_until(next.arrival).await;
+        let message = self.messages.pop()?;
+        Some((message.from, message.body))
     }
 }
 
-pub struct NetworkSink<T: HasBytesSize>(SimSocketWriteHalf<T>);
-impl<T: HasBytesSize> NetworkSink<T> {
+pub struct NetworkSink<T> {
+    id: NodeId,
+    channels: HashMap<NodeId, (mpsc::UnboundedSender<PendingMessage<T>>, Duration)>,
+    clock: Clock,
+}
+
+impl<T> NetworkSink<T> {
+    fn new(id: NodeId, clock: Clock) -> Self {
+        Self {
+            id,
+            channels: HashMap::new(),
+            clock,
+        }
+    }
     pub fn send_to(&self, to: NodeId, msg: T) -> Result<()> {
-        let sim_id = to_sim_id(to);
-        self.0.send_to(sim_id, msg)
+        let Some((sink, latency)) = self.channels.get(&to) else {
+            bail!("Invalid connection")
+        };
+        let arrival = self.clock.now() + *latency;
+        if sink
+            .send(PendingMessage {
+                from: self.id,
+                arrival,
+                body: msg,
+            })
+            .is_err()
+        {
+            bail!("Connection is closed")
+        }
+        Ok(())
     }
 }
 
-fn to_node_id(sim_id: SimId) -> NodeId {
-    // SAFETY: these IDs are both wrappers around sequential u64s.
-    unsafe { std::mem::transmute(sim_id) }
+struct PendingMessage<T> {
+    from: NodeId,
+    arrival: Timestamp,
+    body: T,
 }
 
-fn to_sim_id(node_id: NodeId) -> SimId {
-    // SAFETY: these IDs are both wrappers around sequential u64s.
-    unsafe { std::mem::transmute(node_id) }
+impl<T> PartialEq for PendingMessage<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.arrival.eq(&other.arrival)
+    }
+}
+
+impl<T> Eq for PendingMessage<T> {}
+
+impl<T> PartialOrd for PendingMessage<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for PendingMessage<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.arrival.cmp(&self.arrival)
+    }
 }

--- a/sim-rs/sim-core/src/sim/node.rs
+++ b/sim-rs/sim-core/src/sim/node.rs
@@ -117,7 +117,7 @@ impl Node {
         loop {
             select! {
                 _ = self.slot_receiver.changed() => {
-                    let slot = *self.slot_receiver.borrow();
+                    let slot = *self.slot_receiver.borrow_and_update();
                     self.handle_new_slot(slot)?;
                 }
                 Some(tx) = self.tx_source.recv() => {

--- a/sim-rs/test_data/realistic.toml
+++ b/sim-rs/test_data/realistic.toml
@@ -1,10 +1,20 @@
 block_generation_probability = 0.05
 ib_generation_probability = 5.0
-ib_shards = 8
+ib_shards = 16
 max_block_size = 90112
 max_ib_requests_per_peer = 1
 max_ib_size = 327680
 max_tx_size = 16384
+
+[transaction_frequency_ms]
+distribution = "exp"
+lambda = 0.85
+scale = 10.0
+
+[transaction_size_bytes]
+distribution = "log_normal"
+mu = 6.833
+sigma = 1.127
 
 [[nodes]]
 location = [
@@ -90175,13 +90185,3 @@ nodes = [
     1864,
     2645,
 ]
-
-[transaction_frequency_ms]
-distribution = "exp"
-lambda = 0.85
-scale = 1000.0
-
-[transaction_size_bytes]
-distribution = "log_normal"
-mu = 6.833
-sigma = 1.127


### PR DESCRIPTION
This lets the rust program simulate TX/IB propagation in realtime at 100x current transaction volume, and in 25% of realtime at 1000x current transaction volume.

Senders each hold one channel per receiver they communicate with, and receivers pull from those channels on demand. This lets us avoid maintaining a centralized core or running a background thread to forward messages to the right nodes.

Every receiver tracks a VecDeque of incoming messages per sender. In the `recv` method, the receiver just needs to compare the first elements of each VecDeque to decide what to return.