### PR TITLE
Replace hashing postulates with type classes

### DIFF
--- a/formal-spec/Leios/Abstract.agda
+++ b/formal-spec/Leios/Abstract.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --safe #-}
+
 module Leios.Abstract where
 
 open import Leios.Prelude

--- a/formal-spec/Leios/Base.agda
+++ b/formal-spec/Leios/Base.agda
@@ -1,3 +1,5 @@
+-- {-# OPTIONS --safe #-}
+
 open import Leios.Prelude
 open import Leios.Abstract
 

--- a/formal-spec/Leios/Base.agda
+++ b/formal-spec/Leios/Base.agda
@@ -1,4 +1,4 @@
--- {-# OPTIONS --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Leios.Prelude
 open import Leios.Abstract

--- a/formal-spec/Leios/Blocks.agda
+++ b/formal-spec/Leios/Blocks.agda
@@ -1,3 +1,5 @@
+-- {-# OPTIONS --safe #-}
+
 open import Leios.Prelude
 open import Leios.Abstract
 open import Leios.FFD

--- a/formal-spec/Leios/FFD.agda
+++ b/formal-spec/Leios/FFD.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --safe #-}
+
 module Leios.FFD where
 
 open import Leios.Prelude

--- a/formal-spec/Leios/Prelude.agda
+++ b/formal-spec/Leios/Prelude.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --safe #-}
+
 module Leios.Prelude where
 
 open import abstract-set-theory.FiniteSetTheory public

--- a/formal-spec/Leios/SimpleSpec.agda
+++ b/formal-spec/Leios/SimpleSpec.agda
@@ -9,6 +9,9 @@ import Leios.Base
 import Leios.Blocks
 
 module Leios.SimpleSpec (a : LeiosAbstract) (let open LeiosAbstract a) (let open Leios.Blocks a)
+  ⦃ IsBlock-Vote : IsBlock (List Vote) ⦄
+  ⦃ Hashable-IBHeaderOSig : ∀ {b} → Hashable (IBHeaderOSig b) Hash ⦄
+  ⦃ Hashable-PreEndorserBlock : Hashable PreEndorserBlock Hash ⦄
   (id : PoolID) (pKey : PrivKey) (FFD' : FFDAbstract.Functionality ffdAbstract)
   (vrf : LeiosVRF a) (let open LeiosVRF vrf) (pubKey : PubKey)
   (let open Leios.Base a) (B' : BaseAbstract) (BF' : BaseAbstract.Functionality B') where

--- a/formal-spec/Leios/SimpleSpec.agda
+++ b/formal-spec/Leios/SimpleSpec.agda
@@ -1,3 +1,4 @@
+-- {-# OPTIONS --safe #-}
 {-# OPTIONS --allow-unsolved-metas #-}
 
 open import Leios.Prelude

--- a/formal-spec/Leios/VRF.agda
+++ b/formal-spec/Leios/VRF.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --safe #-}
+
 open import Leios.Prelude
 open import Leios.Abstract
 


### PR DESCRIPTION
It took me 3 attempts with a whole bunch of complicated things until I realized that we can just do it like that. It's a little annoying that we now have to actually use instance resolution for types that are fully known, but I think it ticks all the boxes: 
- we can instantiate it however we like whenever we like (in particular we don't have to use GHC pragmas, which means we can offer a library and the user of the library can provide hashing capabilities)
- it doesn't clutter the spec beyond some paint threshold