### PR TITLE
Add a `SlotUpkeep` type to enforce dependencies between rules

### DIFF
--- a/formal-spec/Leios/SimpleSpec.agda
+++ b/formal-spec/Leios/SimpleSpec.agda
@@ -284,3 +284,29 @@ module _ (open Leios.Voting a) (va : VotingAbstract LeiosState) (open VotingAbst
             ∙ ffds FFD.-⟦ Send (vHeader votes) nothing / SendRes ⟧⇀ ffds'
             ─────────────────────────────────────────────────────────────────────────
             just s -⟦ SLOT / EMPTY ⟧⇀ addUpkeep record s { FFDState = ffds' } V2-Role
+
+    -- Note: Base doesn't need a negative rule, since it can always be invoked
+
+    No-IB-Role : let open LeiosState s in
+            ∙ needsUpkeep IB-Role
+            ∙ ¬ canProduceIB slot sk-IB (stake s) π
+            ─────────────────────────────────────────────
+            just s -⟦ SLOT / EMPTY ⟧⇀ addUpkeep s IB-Role
+
+    No-EB-Role : let open LeiosState s in
+            ∙ needsUpkeep EB-Role
+            ∙ ¬ canProduceEB slot sk-EB (stake s) π
+            ─────────────────────────────────────────────
+            just s -⟦ SLOT / EMPTY ⟧⇀ addUpkeep s EB-Role
+
+    No-V1-Role : let open LeiosState s in
+            ∙ needsUpkeep V1-Role
+            ∙ ¬ canProduceV1 slot sk-V (stake s)
+            ─────────────────────────────────────────────
+            just s -⟦ SLOT / EMPTY ⟧⇀ addUpkeep s V1-Role
+
+    No-V2-Role : let open LeiosState s in
+            ∙ needsUpkeep V2-Role
+            ∙ ¬ canProduceV2 slot sk-V (stake s)
+            ─────────────────────────────────────────────
+            just s -⟦ SLOT / EMPTY ⟧⇀ addUpkeep s V2-Role

--- a/formal-spec/Leios/SimpleSpec.agda
+++ b/formal-spec/Leios/SimpleSpec.agda
@@ -100,7 +100,7 @@ record LeiosState : Type where
   constructLedger = concatMap lookupTxs
 
   needsUpkeep : SlotUpkeep → Set
-  needsUpkeep = _∈ Upkeep
+  needsUpkeep = _∉ Upkeep
 
 addUpkeep : LeiosState → SlotUpkeep → LeiosState
 addUpkeep s u = let open LeiosState s in record s { Upkeep = Upkeep ∪ ❴ u ❵ }


### PR DESCRIPTION
We want to ensure that the `Slot` rule only fires if all our block production duties are completed. To do this, I've added a set that keeps track of these to the state and adjusted the rules so that they can only fire one per slot. Then, `Slot` checks that all duties are indeed completed. This means that if we can't produce anything, we still need to update the state to not get stuck, which is why there are now negative versions of some rules.

While doing this, I noticed that we're not keeping the state of the base chain in our state and instead always universally quantifying over all those states. I fixed that too.