### PR TITLE
Bounded parallelism and CPU Cores usage chart

### DIFF
--- a/simulation/ouroboros-leios-sim.cabal
+++ b/simulation/ouroboros-leios-sim.cabal
@@ -98,6 +98,7 @@ library
     VizSimRelayP2P
     VizSimTCP
     VizUtils
+    WorkerPool
 
   -- other-extensions:
   build-depends:

--- a/simulation/src/LeiosProtocol/Short/Node.hs
+++ b/simulation/src/LeiosProtocol/Short/Node.hs
@@ -395,7 +395,7 @@ leiosNode tracer cfg followers peers = do
       ]
 
 processCPUTasks ::
-  (MonadSTM m, MonadDelay m, MonadMonotonicTimeNSec m) =>
+  (MonadSTM m, MonadDelay m, MonadMonotonicTimeNSec m, MonadFork m) =>
   NumCores ->
   Tracer m CPUTask ->
   TaskMultiQueue LeiosNodeTask m ->

--- a/simulation/src/LeiosProtocol/Short/Node.hs
+++ b/simulation/src/LeiosProtocol/Short/Node.hs
@@ -18,11 +18,12 @@ import Control.Exception (assert)
 import Control.Monad (forever, guard, when)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
+import Control.Monad.Class.MonadThrow
 import Control.Tracer
 import Data.Bifunctor
 import Data.Coerce (coerce)
 import Data.Foldable (forM_)
-import Data.Ix (Ix)
+import Data.Ix (Ix, range)
 import Data.List (sort, sortOn)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -48,6 +49,7 @@ import qualified PraosProtocol.Common.Chain as Chain
 import qualified PraosProtocol.PraosNode as PraosNode
 import STMCompat
 import System.Random
+import WorkerPool
 
 --------------------------------------------------------------
 ---- Events
@@ -297,7 +299,15 @@ newLeiosNodeState cfg = do
 
 leiosNode ::
   forall m.
-  (MonadMVar m, MonadFork m, MonadAsync m, MonadSTM m, MonadTime m, MonadDelay m, MonadMonotonicTimeNSec m) =>
+  ( MonadMVar m
+  , MonadFork m
+  , MonadAsync m
+  , MonadSTM m
+  , MonadTime m
+  , MonadDelay m
+  , MonadMonotonicTimeNSec m
+  , MonadCatch m
+  ) =>
   Tracer m LeiosNodeEvent ->
   LeiosNodeConfig ->
   [Leios (Chan m)] ->
@@ -395,13 +405,23 @@ leiosNode tracer cfg followers peers = do
       ]
 
 processCPUTasks ::
-  (MonadSTM m, MonadDelay m, MonadMonotonicTimeNSec m, MonadFork m) =>
+  (MonadSTM m, MonadDelay m, MonadMonotonicTimeNSec m, MonadFork m, MonadAsync m, MonadCatch m) =>
   NumCores ->
   Tracer m CPUTask ->
   TaskMultiQueue LeiosNodeTask m ->
   m ()
 processCPUTasks Infinite tracer queue = forever $ runInfParallelBlocking tracer queue
-processCPUTasks (Finite _) _ _ = error "TBD"
+processCPUTasks (Finite n) tracer queue = newBoundedWorkerPool n [taskSource l | l <- range (minBound, maxBound)]
+ where
+  taskSource l = do
+    (cpu, m) <- readTMQueue queue l
+    var <- newEmptyTMVar
+    let action = do
+          traceWith tracer cpu
+          threadDelay (cpuTaskDuration cpu)
+          m
+    -- TODO: read from var and log exception.
+    return $ Task action var
 
 computeLedgerStateThread ::
   forall m.

--- a/simulation/src/LeiosProtocol/Short/SimP2P.hs
+++ b/simulation/src/LeiosProtocol/Short/SimP2P.hs
@@ -107,8 +107,8 @@ traceLeiosP2P
     linkTracer nfrom nto =
       contramap (LeiosEventTcp . labelDirToLabelLink nfrom nto) tracer
 
-exampleTrace2 :: StdGen -> Int -> P2PTopography -> LeiosTrace
-exampleTrace2 rng0 sliceLength p2pTopography@P2PTopography{..} =
+exampleTrace2 :: StdGen -> Int -> P2PTopography -> NumCores -> LeiosTrace
+exampleTrace2 rng0 sliceLength p2pTopography@P2PTopography{..} processingCores =
   traceLeiosP2P
     rng0
     p2pTopography
@@ -125,7 +125,7 @@ exampleTrace2 rng0 sliceLength p2pTopography@P2PTopography{..} =
       , rankingBlockPayload = 0
       , inputBlockPayload = kilobytes 96
       , processingQueueBound = 100
-      , processingCores = Infinite
+      , processingCores
       , nodeId
       , rng
       }

--- a/simulation/src/LeiosProtocol/Short/VizSim.hs
+++ b/simulation/src/LeiosProtocol/Short/VizSim.hs
@@ -27,7 +27,7 @@ import GHC.Records
 import qualified Graphics.Rendering.Cairo as Cairo
 import LeiosProtocol.Common hiding (Point)
 import LeiosProtocol.Relay (Message (MsgRespondBodies), RelayMessage, relayMessageLabel)
-import LeiosProtocol.Short.Node (BlockEvent (..), LeiosEventBlock (..), LeiosMessage (..), LeiosNodeEvent (..), RelayEBMessage, RelayIBMessage, RelayVoteMessage)
+import LeiosProtocol.Short.Node (BlockEvent (..), LeiosEventBlock (..), LeiosMessage (..), LeiosNodeEvent (..), NumCores (Infinite), RelayEBMessage, RelayIBMessage, RelayVoteMessage)
 import LeiosProtocol.Short.Sim (LeiosEvent (..), LeiosTrace, exampleTrace1)
 import ModelTCP
 import Network.TypedProtocol
@@ -52,7 +52,7 @@ example1 =
         Layout $
           leiosSimVizRender examplesLeiosSimVizConfig
  where
-  model = leiosSimVizModel (LeiosModelConfig 5) trace
+  model = leiosSimVizModel (LeiosModelConfig 5 Infinite) trace
    where
     trace = exampleTrace1
 
@@ -229,9 +229,10 @@ accumDiffusionLatency' now _nid EnterState msgid _msg vs =
     vs
 accumDiffusionLatency' _now _nid _event _id _msg vs = vs
 
-newtype LeiosModelConfig = LeiosModelConfig
-  { recentSpan :: DiffTime
+data LeiosModelConfig = LeiosModelConfig
+  { recentSpan :: !DiffTime
   -- ^ length of time the Recent* maps should cover
+  , numCores :: !NumCores
   }
 
 -- | Make the vizualisation model for the relay simulation from a simulation

--- a/simulation/src/LeiosProtocol/Short/VizSimP2P.hs
+++ b/simulation/src/LeiosProtocol/Short/VizSimP2P.hs
@@ -706,8 +706,8 @@ blendColors (x : xs) = foldl' (Dia.blend 0.5) x xs
 toSRGB :: Dia.Colour Double -> (Double, Double, Double)
 toSRGB (Dia.toSRGB -> Dia.RGB r g b) = (r, g, b)
 
-example2 :: Int -> Int -> Maybe P2PTopography -> Visualization
-example2 seed sliceLength maybeP2PTopography =
+example2 :: Int -> Int -> Maybe P2PTopography -> NumCores -> Visualization
+example2 seed sliceLength maybeP2PTopography processingCores =
   slowmoVisualization 0.5 $
     Viz model $
       LayoutAbove
@@ -758,4 +758,4 @@ example2 seed sliceLength maybeP2PTopography =
           , p2pNodeLinksClose = 5
           , p2pNodeLinksRandom = 5
           }
-  model = leiosSimVizModel modelConfig (exampleTrace2 rng2 sliceLength p2pTopography)
+  model = leiosSimVizModel modelConfig (exampleTrace2 rng2 sliceLength p2pTopography processingCores)

--- a/simulation/src/LeiosProtocol/Short/VizSimP2P.hs
+++ b/simulation/src/LeiosProtocol/Short/VizSimP2P.hs
@@ -15,6 +15,7 @@ import Data.Array.Unboxed (Ix, UArray, accumArray, (!))
 import Data.Bifunctor (second)
 import qualified Data.Colour.SRGB as Colour
 import Data.Hashable (hash)
+import qualified Data.IntervalMap.Strict as ILMap
 import Data.List (foldl', intercalate, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, maybeToList)
@@ -51,7 +52,7 @@ import Network.TypedProtocol
 import P2P
 import PraosProtocol.BlockFetch (Message (..))
 import PraosProtocol.PraosNode (PraosMessage (..))
-import SimTypes (Point (..), WorldShape (..))
+import SimTypes (NodeId (..), Point (..), WorldShape (..))
 import System.Random (uniformR)
 import qualified System.Random as Random
 import System.Random.Stateful (mkStdGen)
@@ -507,6 +508,8 @@ chartBandwidth LeiosModelConfig{recentSpan} =
  where
   recentPlot lbl color maps =
     [ bandwidthHistPlot
+      maxX
+      (0, maxX)
       lbl
       color
       ( map
@@ -540,24 +543,68 @@ chartBandwidth LeiosModelConfig{recentSpan} =
       ]
   maxX :: Num a => a
   maxX = 150
-  bandwidthHistPlot title color values =
-    Chart.histToPlot $
-      Chart.defaultNormedPlotHist
-        { Chart._plot_hist_title = title
-        , Chart._plot_hist_values = values
-        , Chart._plot_hist_range = Just (0, maxX)
-        , Chart._plot_hist_bins = maxX
-        , Chart._plot_hist_fill_style =
-            Chart.def
-              { Chart._fill_color =
-                  Chart.withOpacity color 0.4
-              }
-        , Chart._plot_hist_line_style =
-            Chart.def
-              { Chart._line_color =
-                  Chart.opaque color
-              }
-        }
+
+bandwidthHistPlot :: RealFrac x => Int -> (x, x) -> String -> Chart.Colour Double -> [x] -> Chart.Plot x Double
+bandwidthHistPlot maxX range title color values =
+  Chart.histToPlot $
+    Chart.defaultNormedPlotHist
+      { Chart._plot_hist_title = title
+      , Chart._plot_hist_values = values
+      , Chart._plot_hist_range = Just range
+      , Chart._plot_hist_bins = maxX
+      , Chart._plot_hist_fill_style =
+          Chart.def
+            { Chart._fill_color =
+                Chart.withOpacity color 0.4
+            }
+      , Chart._plot_hist_line_style =
+          Chart.def
+            { Chart._line_color =
+                Chart.opaque color
+            }
+      }
+
+chartCPUUsage :: LeiosModelConfig -> VizRender LeiosSimVizModel
+chartCPUUsage LeiosModelConfig{numCores} =
+  chartVizRender 25 $
+    \(Time now)
+     _
+     ( SimVizModel
+        _
+        vs
+      ) ->
+        let
+          numNodes = Map.size vs.vizNodePos
+          maxCPUs = case numCores of
+            Infinite -> 20
+            Finite n -> n
+          values =
+            [ (nid, [(n, if n <= 5 then "" else show n)])
+            | (NodeId nid, m) <- Map.toList vs.nodeCpuUsage
+            , let n = sum . ILMap.elems . flip ILMap.containing now $ m
+            ]
+         in
+          (Chart.def :: Chart.Layout Double Double)
+            { Chart._layout_title = "Instantaneous CPU Usage per Node"
+            , Chart._layout_title_style = Chart.def{Chart._font_size = 15}
+            , Chart._layout_x_axis =
+                Chart.def
+                  { Chart._laxis_generate =
+                      Chart.scaledIntAxis
+                        Chart.defaultIntAxis{Chart._la_nLabels = 10}
+                        (0, numNodes - 1)
+                  , Chart._laxis_title = "Node #"
+                  }
+            , Chart._layout_y_axis =
+                Chart.def
+                  { Chart._laxis_generate =
+                      Chart.scaledIntAxis Chart.defaultIntAxis{Chart._la_nLabels = 5} (0, maxCPUs)
+                  , Chart._laxis_title = "CPUs in use"
+                  }
+            , Chart._layout_plots =
+                [ Chart.plotBars (Chart.def{Chart._plot_bars_values_with_labels = values})
+                ]
+            }
 
 chartLinkUtilisation :: VizRender LeiosSimVizModel
 chartLinkUtilisation =
@@ -637,15 +684,15 @@ isRelayMessageControl (ProtocolMessage (SomeMessage msg)) = case msg of
   _otherwise -> True
 
 -- | takes stage length, assumes pipelines start at Slot 0.
-defaultVizConfig :: Int -> LeiosP2PSimVizConfig
-defaultVizConfig stageLength =
+defaultVizConfig :: Int -> NumCores -> LeiosP2PSimVizConfig
+defaultVizConfig stageLength numCores =
   LeiosP2PSimVizConfig
     { nodeMessageColor = testNodeMessageColor
     , ptclMessageColor = testPtclMessageColor
     , voteColor = toSRGB . voteColor
     , ebColor = toSRGB . ebColor
     , ibColor = toSRGB . pipelineColor Propose . (hash . (.id) &&& (.slot))
-    , model = LeiosModelConfig{recentSpan = fromIntegral stageLength}
+    , model = LeiosModelConfig{recentSpan = fromIntegral stageLength, numCores}
     }
  where
   testPtclMessageColor ::
@@ -735,13 +782,16 @@ example2 seed sliceLength maybeP2PTopography processingCores =
                         Layout $
                           chartBandwidth modelConfig
                     , LayoutReqSize 350 300 $
+                        Layout $
+                          chartCPUUsage modelConfig
+                    , LayoutReqSize 350 300 $
                         Layout chartLinkUtilisation
                     ]
                 ]
             ]
         ]
  where
-  config = defaultVizConfig 5
+  config = defaultVizConfig 5 processingCores
   modelConfig = config.model
   rng0 = mkStdGen seed
   (rng1, rng2) = Random.split rng0

--- a/simulation/src/WorkerPool.hs
+++ b/simulation/src/WorkerPool.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTSyntax #-}
+
 module WorkerPool where
 
--- | A simple simulation of a worker pool with either bounded or unbounded
+-- \| A simple simulation of a worker pool with either bounded or unbounded
 -- CPU resources.
 --
 -- The intention is to use this where we need to model CPU resources being
@@ -19,36 +20,43 @@ module WorkerPool where
 -- work and execute it. Thus there are at most N tasks executing concurrently
 -- and the total task CPU throughput is N * time. In this approach, the order
 -- of the sources is relevant: when there are multiple tasks available, new
--- tasks are 
+-- tasks are
 
 import Control.Concurrent.Class.MonadSTM
+import Control.Monad
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
-import Control.Monad
 
 data Task m where
   Task :: m a -> !(TMVar m (Either SomeException a)) -> Task m
 
 type TaskSource m = STM m (Task m)
 
-newBoundedWorkerPool :: (MonadAsync m, MonadCatch m, MonadSTM m)
-                     => Int -> [TaskSource m] -> m ()
+newBoundedWorkerPool ::
+  (MonadAsync m, MonadCatch m, MonadSTM m) =>
+  Int ->
+  [TaskSource m] ->
+  m ()
 newBoundedWorkerPool n sources =
-    replicateConcurrentlyOn_ n worker
-  where
-    worker = forever $ do
-      Task task resultVar <- atomically $ foldr orElse retry sources
-      result <- try task
-      atomically $ writeTMVar resultVar result
+  replicateConcurrentlyOn_ n worker
+ where
+  worker = forever $ do
+    Task task resultVar <- atomically $ foldr orElse retry sources
+    result <- try task
+    atomically $ writeTMVar resultVar result
 
 replicateConcurrentlyOn_ :: (MonadThrow m, MonadAsync m) => Int -> m () -> m ()
 replicateConcurrentlyOn_ n action =
-    void $
-      bracket
-        (forM [0..n-1] $ \i -> asyncOn i action)
-        (mapM_ cancel) --TODO prefer cancelMany
-        waitAny
+  void $
+    bracket
+      (forM [0 .. n - 1] $ \i -> asyncOn i action)
+      cancelMany
+      waitAny
 
-newUnboundedWorkerPool :: MonadSTM m => [STM m (m ())] -> m ()
-newUnboundedWorkerPool _sources = undefined
+-- newUnboundedWorkerPool :: MonadSTM m => [STM m (m ())] -> m ()
+-- newUnboundedWorkerPool _sources = undefined
 
+cancelMany :: MonadAsync m => [Async m a] -> m ()
+cancelMany as = do
+  mapM_ cancel as
+  mapM_ waitCatch as

--- a/simulation/src/WorkerPool.hs
+++ b/simulation/src/WorkerPool.hs
@@ -22,10 +22,10 @@ module WorkerPool where
 -- of the sources is relevant: when there are multiple tasks available, new
 -- tasks are
 
-import Control.Concurrent.Class.MonadSTM
 import Control.Monad
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
+import STMCompat
 
 data Task m where
   Task :: m a -> !(TMVar m (Either SomeException a)) -> Task m

--- a/simulation/src/WorkerPool.hs
+++ b/simulation/src/WorkerPool.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE ExistentialQuantification #-}
+module WorkerPool where
+
+-- | A simple simulation of a worker pool with either bounded or unbounded
+-- CPU resources.
+--
+-- The intention is to use this where we need to model CPU resources being
+-- used, such as validating network messages.
+--
+-- The idea is we (statically) have several sources of work (each modelled as
+-- an STM action that either blocks or gives us a work item to do) and the
+-- worker pool continuously pulls work from these sources and executes them.
+--
+-- In the unbounded CPU resource approach, each task is executed as soon as it
+-- is made available from one of the sources.
+--
+-- In the bounded CPU resource approach, we run N threads to repeatedly grab
+-- work and execute it. Thus there are at most N tasks executing concurrently
+-- and the total task CPU throughput is N * time. In this approach, the order
+-- of the sources is relevant: when there are multiple tasks available, new
+-- tasks are 
+
+import Control.Concurrent.Class.MonadSTM
+import Control.Monad.Class.MonadAsync
+import Control.Monad.Class.MonadThrow
+import Control.Monad
+
+data Task m where
+  Task :: m a -> !(TMVar m (Either SomeException a)) -> Task m
+
+type TaskSource m = STM m (Task m)
+
+newBoundedWorkerPool :: (MonadAsync m, MonadCatch m, MonadSTM m)
+                     => Int -> [TaskSource m] -> m ()
+newBoundedWorkerPool n sources =
+    replicateConcurrentlyOn_ n worker
+  where
+    worker = forever $ do
+      Task task resultVar <- atomically $ foldr orElse retry sources
+      result <- try task
+      atomically $ writeTMVar resultVar result
+
+replicateConcurrentlyOn_ :: (MonadThrow m, MonadAsync m) => Int -> m () -> m ()
+replicateConcurrentlyOn_ n action =
+    void $
+      bracket
+        (forM [0..n-1] $ \i -> asyncOn i action)
+        (mapM_ cancel) --TODO prefer cancelMany
+        waitAny
+
+newUnboundedWorkerPool :: MonadSTM m => [STM m (m ())] -> m ()
+newUnboundedWorkerPool _sources = undefined
+


### PR DESCRIPTION
* Added rather crude chart to show number of cores used per node.
* TODO: moving average might be more illustrative.
* Added `-N` flag to control parallelism, accepts 'unbounded' or number of cores.
* `cabal run ols -- viz short-leios-p2p-1 -N unbounded` shows a node using 13 cores around 30s.
* Otherwise things seem to get busy around votes, though maybe less so as time goes on?
