### PR TITLE
Ci optimization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
   ################################################################################
   # Formal Specification in Agda - under /formal-spec/
   ################################################################################
-
   formal-spec-typecheck:
     name: "formal-spec: Typecheck"
     runs-on: ubuntu-22.04
@@ -185,21 +184,34 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 2 # Needed to get previous commit for comparison
 
       - name: Install D2
         run: |
           curl -fsSL https://d2lang.com/install.sh | sh -s --
           d2 --version
 
-      - name: Generate PNG files
+      - name: Generate PNG files for changed D2 files
         run: |
-          find . -name "*.d2" -type f -exec sh -c '
-            for file do
+          # Get list of changed .d2 files
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep '\.d2$' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No .d2 files were changed"
+            exit 0
+          fi
+
+          echo "Changed .d2 files:"
+          echo "$CHANGED_FILES"
+
+          # Process each changed file
+          echo "$CHANGED_FILES" | while read -r file; do
+            if [ -f "$file" ]; then
               output_file="${file%.d2}.png"
               echo "Converting $file to $output_file"
               d2 "$file" "$output_file"
-            done
-          ' sh {} +
+            fi
+          done
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ on:
       - "data/**"
       - "site/**"
       - "docs/**"
+      - "cabal.project"
   push:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - "data/**"
       - "site/**"
       - "docs/**"
+      - "cabal.project"
 
 jobs:
   ################################################################################
@@ -80,7 +82,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.files.*.path, 'simulation/') ||
-      contains(github.event.pull_request.files.*.path, 'data/')
+      contains(github.event.pull_request.files.*.path, 'data/') ||
+      contains(github.event.pull_request.files.*.path, 'cabal.project')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -150,7 +153,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.files.*.path, 'simulation/') ||
-      contains(github.event.pull_request.files.*.path, 'data/')
+      contains(github.event.pull_request.files.*.path, 'data/') ||
+      contains(github.event.pull_request.files.*.path, 'cabal.project')
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -170,7 +174,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.files.*.path, 'simulation/') ||
-      contains(github.event.pull_request.files.*.path, 'data/')
+      contains(github.event.pull_request.files.*.path, 'data/') ||
+      contains(github.event.pull_request.files.*.path, 'cabal.project')
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,9 @@ jobs:
   formal-spec-typecheck:
     name: "formal-spec: Typecheck"
     if: |
-      github.event_name == 'push' ||
+      github.event_name == 'push' &&
+      contains(github.event.commits.*.modified, 'formal-spec/') ||
+      github.event_name == 'pull_request' &&
       contains(github.event.pull_request.files.*.path, 'formal-spec/')
     runs-on: ubuntu-22.04
     steps:
@@ -80,10 +82,14 @@ jobs:
   simulation-test:
     name: "simulation: Test on ${{ matrix.os }} with GHC ${{ matrix.ghc-version }}"
     if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      github.event_name == 'push' &&
+      (contains(github.event.commits.*.modified, 'simulation/') ||
+      contains(github.event.commits.*.modified, 'data/') ||
+      contains(github.event.commits.*.modified, 'cabal.project')) ||
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.files.*.path, 'simulation/') ||
       contains(github.event.pull_request.files.*.path, 'data/') ||
-      contains(github.event.pull_request.files.*.path, 'cabal.project')
+      contains(github.event.pull_request.files.*.path, 'cabal.project'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -151,10 +157,14 @@ jobs:
   simulation-hlint:
     name: "simulation: Check with HLint"
     if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      github.event_name == 'push' &&
+      (contains(github.event.commits.*.modified, 'simulation/') ||
+      contains(github.event.commits.*.modified, 'data/') ||
+      contains(github.event.commits.*.modified, 'cabal.project')) ||
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.files.*.path, 'simulation/') ||
       contains(github.event.pull_request.files.*.path, 'data/') ||
-      contains(github.event.pull_request.files.*.path, 'cabal.project')
+      contains(github.event.pull_request.files.*.path, 'cabal.project'))
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -172,10 +182,14 @@ jobs:
   simulation-fourmolu:
     name: "simulation: Check with fourmolu"
     if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      github.event_name == 'push' &&
+      (contains(github.event.commits.*.modified, 'simulation/') ||
+      contains(github.event.commits.*.modified, 'data/') ||
+      contains(github.event.commits.*.modified, 'cabal.project')) ||
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.files.*.path, 'simulation/') ||
       contains(github.event.pull_request.files.*.path, 'data/') ||
-      contains(github.event.pull_request.files.*.path, 'cabal.project')
+      contains(github.event.pull_request.files.*.path, 'cabal.project'))
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -193,9 +207,12 @@ jobs:
   sim-rs-check:
     name: "sim-rs: Test"
     if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.files.*.path, 'sim-rs/') ||
-      contains(github.event.pull_request.files.*.path, 'data/')
+      github.event_name == 'push' &&
+      (contains(github.event.commits.*.modified, 'sim-rs/') ||
+      contains(github.event.commits.*.modified, 'data/')) ||
+      github.event_name == 'pull_request' &&
+      (contains(github.event.pull_request.files.*.path, 'sim-rs/') ||
+      contains(github.event.pull_request.files.*.path, 'data/'))
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -215,7 +232,9 @@ jobs:
   docs-generate-d2-diagrams:
     name: "docs: Generate D2 Diagrams"
     if: |
-      github.event_name == 'push' ||
+      github.event_name == 'push' &&
+      endsWith(github.event.commits.*.modified, '.d2') ||
+      github.event_name == 'pull_request' &&
       endsWith(github.event.pull_request.files.*.path, '.d2')
     runs-on: ubuntu-22.04
     permissions:
@@ -277,7 +296,9 @@ jobs:
   docs-build:
     name: "docs: Build"
     if: |
-      github.event_name == 'push' ||
+      github.event_name == 'push' &&
+      contains(github.event.commits.*.modified, 'site/') ||
+      github.event_name == 'pull_request' &&
       contains(github.event.pull_request.files.*.path, 'site/')
     runs-on: ubuntu-22.04
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -236,11 +236,29 @@ jobs:
   docs-build:
     name: "docs: Build"
     runs-on: ubuntu-22.04
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for site changes
+        id: check_changes
+        run: |
+          SITE_CHANGES=$(git diff --name-only HEAD^ HEAD -- site/ || true)
+          if [ -z "$SITE_CHANGES" ]; then
+            echo "No changes in site directory"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in site directory:"
+            echo "$SITE_CHANGES"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: 🛠️ Setup Node.js
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -248,15 +266,18 @@ jobs:
           cache-dependency-path: site/yarn.lock
 
       - name: 📦 Install dependencies
+        if: steps.check_changes.outputs.has_changes == 'true'
         working-directory: site
         run: yarn install
 
       - name: 🏗️ Build Docusaurus site
+        if: steps.check_changes.outputs.has_changes == 'true'
         working-directory: site
         run: |
           yarn build
 
       - name: 🚀 Publish Docusaurus build
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: docusaurus-build
@@ -266,7 +287,10 @@ jobs:
 
   docs-publish:
     name: "docs: Publish"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.docs-build.outputs.has_changes == 'true'
     runs-on: ubuntu-22.04
     needs: docs-build
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,23 @@ env:
 
 on:
   pull_request:
+    paths:
+      - "formal-spec/**"
+      - "simulation/**"
+      - "sim-rs/**"
+      - "data/**"
+      - "site/**"
+      - "docs/**"
   push:
     branches:
       - main
+    paths:
+      - "formal-spec/**"
+      - "simulation/**"
+      - "sim-rs/**"
+      - "data/**"
+      - "site/**"
+      - "docs/**"
 
 jobs:
   ################################################################################
@@ -18,6 +32,9 @@ jobs:
   ################################################################################
   formal-spec-typecheck:
     name: "formal-spec: Typecheck"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'formal-spec/')
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -60,6 +77,10 @@ jobs:
 
   simulation-test:
     name: "simulation: Test on ${{ matrix.os }} with GHC ${{ matrix.ghc-version }}"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      contains(github.event.pull_request.files.*.path, 'data/')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -126,6 +147,10 @@ jobs:
 
   simulation-hlint:
     name: "simulation: Check with HLint"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      contains(github.event.pull_request.files.*.path, 'data/')
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -142,6 +167,10 @@ jobs:
 
   simulation-fourmolu:
     name: "simulation: Check with fourmolu"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'simulation/') ||
+      contains(github.event.pull_request.files.*.path, 'data/')
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
@@ -158,6 +187,10 @@ jobs:
 
   sim-rs-check:
     name: "sim-rs: Test"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'sim-rs/') ||
+      contains(github.event.pull_request.files.*.path, 'data/')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -176,6 +209,9 @@ jobs:
 
   docs-generate-d2-diagrams:
     name: "docs: Generate D2 Diagrams"
+    if: |
+      github.event_name == 'push' ||
+      endsWith(github.event.pull_request.files.*.path, '.d2')
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -235,6 +271,9 @@ jobs:
 
   docs-build:
     name: "docs: Build"
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.files.*.path, 'site/')
     runs-on: ubuntu-22.04
     outputs:
       has_changes: ${{ steps.check_changes.outputs.has_changes }}
@@ -288,7 +327,6 @@ jobs:
   docs-publish:
     name: "docs: Publish"
     if: |
-      github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       needs.docs-build.outputs.has_changes == 'true'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
- Add path-based filtering to all CI jobs to run only when relevant files change:
  - formal-spec-typecheck: only for formal-spec/ changes
  - simulation jobs (test/hlint/fourmolu): for simulation/, data/, cabal.project changes
  - sim-rs-check: for sim-rs/ and data/ changes
  - docs-generate-d2-diagrams: only for .d2 file changes
  - docs-build/publish: only for site/ directory changes

- Add workflow-level path filters to prevent unnecessary workflow runs
- Fix docs-publish job to only run on main branch with site/ changes
- Improve change detection logic for both pull request and push events

This change makes the CI more efficient by only running relevant jobs based on 
modified files, reducing unnecessary builds and checks.