### PR TITLE
Fix build with ghc-9.6.x

### DIFF
--- a/simulation/src/ChanDriver.hs
+++ b/simulation/src/ChanDriver.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeAbstractions #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/simulation/src/LeiosProtocol/Short/VizSim.hs
+++ b/simulation/src/LeiosProtocol/Short/VizSim.hs
@@ -27,7 +27,7 @@ import qualified Data.Set as Set
 import GHC.Records
 import qualified Graphics.Rendering.Cairo as Cairo
 import LeiosProtocol.Common hiding (Point)
-import LeiosProtocol.Relay (Message (MsgRespondBodies, MsgRespondHeaders), RelayMessage, relayMessageLabel)
+import LeiosProtocol.Relay (Message (MsgRespondBodies, MsgRespondHeaders), RelayMessage, relayMessageLabel, RelayState)
 import LeiosProtocol.Short.Node (BlockEvent (..), LeiosEventBlock (..), LeiosMessage (..), LeiosNodeEvent (..), NumCores (Infinite), RelayEBMessage, RelayIBMessage, RelayVoteMessage)
 import LeiosProtocol.Short.Sim (LeiosEvent (..), LeiosTrace, exampleTrace1)
 import ModelTCP
@@ -466,6 +466,9 @@ accumDataTransmitted msg forecast DataTransmitted{..} =
   _accumPayloadAndBlocksTransmitted (payload0, blocks0) =
     (maybe id (ILMap.insert interval) payload payload0, maybe id (ILMap.insert interval) block blocks0)
    where
+    payloadIB :: HasField "size" body Bytes
+              => ProtocolMessage (RelayState id header body)
+              -> Maybe Bytes
     payloadIB (ProtocolMessage (SomeMessage rmsg)) =
       case rmsg of
         MsgRespondBodies xs -> Just $ sum $ map ((.size) . snd) xs

--- a/simulation/src/Topology.hs
+++ b/simulation/src/Topology.hs
@@ -47,7 +47,6 @@ import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.Lazy (LazyText)
 import qualified Data.Text.Lazy as TL
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -319,7 +318,7 @@ clusterByClusterName node@(_, nodeInfo) = case nodeInfo.clusterName of
   Nothing -> GV.N node
   Just nodeClusterName -> GV.C nodeClusterName (GV.N node)
 
-clusterNameToLazyText :: ClusterName -> LazyText
+clusterNameToLazyText :: ClusterName -> TL.Text
 clusterNameToLazyText = TL.fromStrict . unClusterName
 
 clusterNameToGraphID :: ClusterName -> GVTG.GraphID


### PR DESCRIPTION
* Some trickery with named fields. Fixed by an explict type signature.
* Unused type extensions.
* New library type aliases

In truth it doesn't build-as is because the custom version of io-sim doesn't build with ghc-9.6, but the custom version is not needed except for performance. Would be nice if we could get back to upstream io-sim.