### PR TITLE
delta-q: handle redundant x values in compact

### DIFF
--- a/delta_q/src/compaction.rs
+++ b/delta_q/src/compaction.rs
@@ -20,17 +20,14 @@ pub(crate) fn compact(data: &mut Vec<(f32, f32)>, mode: CompactionMode, max_size
         let mut prev_x = -1.0;
         for i in 0..data.len() {
             let (x, y) = data[i];
-            if y != prev_y {
+            if x == prev_x {
+                data[pos - 1] = (x, y);
+            } else if y != prev_y {
                 data[pos] = (x, y);
-                prev_y = y;
                 pos += 1;
             }
-            if x == prev_x {
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_2(&"duplicate x".into(), &format!("{:?}", data).into());
-                panic!("duplicate x {data:?}");
-            }
             prev_x = x;
+            prev_y = y;
         }
         data.truncate(pos);
     }

--- a/delta_q/src/step_function.rs
+++ b/delta_q/src/step_function.rs
@@ -682,6 +682,22 @@ mod tests {
     }
 
     #[test]
+    fn test_compact_redundant_x() {
+        let data = vec![(0.5, 0.1), (0.5, 0.2), (1.0, 1.0)];
+        let mut data1 = data.clone();
+        f32::compact(&mut data1, CompactionMode::default(), DEFAULT_MAX_SIZE);
+        assert_eq!(data1, vec![(0.5, 0.2), (1.0, 1.0)]);
+    }
+
+    #[test]
+    fn test_compact_redundant_y() {
+        let data = vec![(0.5, 0.1), (0.6, 0.1), (1.0, 1.0)];
+        let mut data1 = data.clone();
+        f32::compact(&mut data1, CompactionMode::default(), DEFAULT_MAX_SIZE);
+        assert_eq!(data1, vec![(0.5, 0.1), (1.0, 1.0)]);
+    }
+
+    #[test]
     fn test_at() {
         let sf = StepFunction::from_str("[(0.5, 0.1), (1, 1)]").unwrap();
         assert_eq!(sf.at(-1.0), 0.0);


### PR DESCRIPTION
If we create a CDF with multiple points at the same X value, only the highest Y for each X is relevant.