### PR TITLE
Trace Schema Changes

### DIFF
--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -41,6 +41,8 @@ interface EndorserBlockEvent extends BaseBlockEvent {
 
 interface RankingBlockEvent extends BaseBlockEvent {
     slot: number;
+    endorse_blocks: string[]; // References to certified endorser blocks
+    payload_bytes: number; // Size of directly included transactions
 }
 
 interface VoteEvent extends BaseBlockEvent {

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -13,7 +13,7 @@ type HaskellEvent =
     | HaskellNetworkEvent; // Combine Sent/Received into network events
 
 interface HaskellCpuEvent {
-    tag: "Cpu";
+    type: "Cpu";
     node: string;
     cpu_time_s: number;
     // CPU task types: Block validation (ValIB, ValEB, ValRB), Header validation (ValIH, ValRH), Vote validation (ValVote). Format: "<task_type>: <id>"
@@ -29,25 +29,21 @@ interface BaseBlockEvent {
 }
 
 interface InputBlockEvent extends BaseBlockEvent {
-    kind: "IB";
     slot: number;
     payload_bytes: number;
     rb_ref: string; // Reference to ranking block
 }
 
 interface EndorserBlockEvent extends BaseBlockEvent {
-    kind: "EB";
     slot: number;
     input_blocks: string[]; // References to input blocks
 }
 
 interface RankingBlockEvent extends BaseBlockEvent {
-    kind: "RB";
     slot: number;
 }
 
 interface VoteEvent extends BaseBlockEvent {
-    kind: "VT";
     votes: number;
     endorse_blocks: string[]; // References to endorser blocks
 }

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -15,7 +15,6 @@ type HaskellEvent =
 interface HaskellCpuEvent {
     tag: "Cpu";
     node: string;
-    node_name: string;
     duration_s: number;
     cpu_time_s: number;
     // CPU task types: Block validation (ValIB, ValEB, ValRB), Header validation (ValIH, ValRH), Vote validation (ValVote). Format: "<task_type>: <id>"
@@ -26,7 +25,6 @@ interface HaskellCpuEvent {
 interface BaseBlockEvent {
     type: `${BlockKind}${BlockAction}`;
     node: string;
-    node_name: string;
     id: string;
     size_bytes: number;
 }

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -26,21 +26,19 @@ interface BaseBlockEvent {
     node: string;
     id: string;
     size_bytes: number;
+    slot: number;
 }
 
 interface InputBlockEvent extends BaseBlockEvent {
-    slot: number;
     payload_bytes: number;
     rb_ref: string; // Reference to ranking block
 }
 
 interface EndorserBlockEvent extends BaseBlockEvent {
-    slot: number;
     input_blocks: string[]; // References to input blocks
 }
 
 interface RankingBlockEvent extends BaseBlockEvent {
-    slot: number;
     endorse_blocks: string[]; // References to certified endorser blocks
     payload_bytes: number; // Size of directly included transactions
 }

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -15,7 +15,6 @@ type HaskellEvent =
 interface HaskellCpuEvent {
     tag: "Cpu";
     node: string;
-    duration_s: number;
     cpu_time_s: number;
     // CPU task types: Block validation (ValIB, ValEB, ValRB), Header validation (ValIH, ValRH), Vote validation (ValVote). Format: "<task_type>: <id>"
     task_label: string; // e.g., "ValIB: 6-29" or "ValRH: 6253064077348247640"

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -20,39 +20,47 @@ interface HaskellCpuEvent {
     task_label: string; // e.g., "ValIB: 6-29" or "ValRH: 6253064077348247640"
 }
 
-// Base block event interface
+// Base block event interface with just identification info
 interface BaseBlockEvent {
     type: `${BlockKind}${BlockAction}`;
     node: string;
     id: string;
-    size_bytes: number;
     slot: number;
 }
 
-interface InputBlockEvent extends BaseBlockEvent {
+// Additional fields for Generated events
+interface GeneratedBlockEvent extends BaseBlockEvent {
+    size_bytes: number;
+}
+
+interface GeneratedInputBlock extends GeneratedBlockEvent {
     payload_bytes: number;
-    rb_ref: string; // Reference to ranking block
+    rb_ref: string;
 }
 
-interface EndorserBlockEvent extends BaseBlockEvent {
-    input_blocks: string[]; // References to input blocks
+interface GeneratedEndorserBlock extends GeneratedBlockEvent {
+    input_blocks: string[];
 }
 
-interface RankingBlockEvent extends BaseBlockEvent {
-    endorse_blocks: string[]; // References to certified endorser blocks
-    payload_bytes: number; // Size of directly included transactions
+interface GeneratedRankingBlock extends GeneratedBlockEvent {
+    endorse_blocks: string[];
+    payload_bytes: number;
 }
 
-interface VoteEvent extends BaseBlockEvent {
+interface GeneratedVote extends GeneratedBlockEvent {
     votes: number;
-    endorse_blocks: string[]; // References to endorser blocks
+    endorse_blocks: string[];
 }
+
+// EnteredState events only need the base identification info
+type EnteredStateBlock = BaseBlockEvent;
 
 type HaskellBlockEvent =
-    | InputBlockEvent
-    | EndorserBlockEvent
-    | RankingBlockEvent
-    | VoteEvent;
+    | GeneratedInputBlock
+    | GeneratedEndorserBlock
+    | GeneratedRankingBlock
+    | GeneratedVote
+    | EnteredStateBlock;
 
 interface HaskellNetworkEvent {
     type: "NetworkMessage";

--- a/data/simulation/trace.haskell.d.ts
+++ b/data/simulation/trace.haskell.d.ts
@@ -15,9 +15,10 @@ type HaskellEvent =
 
 interface HaskellCpuEvent {
     tag: "Cpu";
-    node: number;
+    node: string;
     node_name: string;
     duration_s: number;
+    cpu_time_s: number;
     // CPU task types: Block validation (ValIB, ValEB, ValRB), Header validation (ValIH, ValRH), Vote validation (ValVote). Format: "<task_type>: <id>"
     task_label: string; // e.g., "ValIB: 6-29" or "ValRH: 6253064077348247640"
 }

--- a/data/simulation/trace.rust.d.ts
+++ b/data/simulation/trace.rust.d.ts
@@ -16,10 +16,10 @@ interface RustTaskInfo {
 
 // CPU Events
 type BlockOrTaskType =
-    | "RankingBlock"
-    | "EndorserBlock"
-    | "VoteBundle"
-    | "InputBlock"
+    | "RBBlock"
+    | "EBBlock"
+    | "VTBundle"
+    | "IBBlock"
     | "Transaction";
 type Action = "Validated" | "Generated";
 type RustCpuTaskType = `${BlockOrTaskType}${Action}`;
@@ -50,9 +50,9 @@ interface RustBaseBlockEvent {
     recipient?: string;
 }
 
-type BlockType = "Input" | "Endorser" | "Ranking";
+type BlockType = "IB" | "EB" | "RB";
 type BlockAction = "Sent" | "Received" | "LotteryWon" | "Generated";
-type RustBlockMessageType = `${BlockType}Block${BlockAction}`;
+type RustBlockMessageType = `${BlockType}${BlockAction}`;
 
 interface RustBlockEvent extends Omit<RustBaseEvent, "message"> {
     message: RustBaseBlockEvent & {

--- a/data/simulation/trace.rust.d.ts
+++ b/data/simulation/trace.rust.d.ts
@@ -2,7 +2,7 @@
 
 // Base types
 interface RustBaseEvent {
-    time: number; // nanoseconds
+    time_s: number;
     message: {
         type: string;
         [key: string]: any;
@@ -35,6 +35,8 @@ interface RustCpuEvent extends Omit<RustBaseEvent, "message"> {
         task_type?: RustCpuTaskType;
         subtasks?: number;
         subtask_id?: number;
+        duration_s?: number;
+        cpu_time_s?: number;
         extra?: string;
     };
 }

--- a/data/simulation/trace.rust.d.ts
+++ b/data/simulation/trace.rust.d.ts
@@ -16,7 +16,7 @@ interface RustTaskInfo {
 
 // CPU Events
 type BlockOrTaskType =
-    | "PraosBlock"
+    | "RankingBlock"
     | "EndorserBlock"
     | "VoteBundle"
     | "InputBlock"
@@ -50,7 +50,7 @@ interface RustBaseBlockEvent {
     recipient?: string;
 }
 
-type BlockType = "Input" | "Endorser" | "Praos";
+type BlockType = "Input" | "Endorser" | "Ranking";
 type BlockAction = "Sent" | "Received" | "LotteryWon" | "Generated";
 type RustBlockMessageType = `${BlockType}Block${BlockAction}`;
 


### PR DESCRIPTION
- [x] add cpu_time_s field to track total CPU time across cores
- [x] align block event names
- [x] separate block lifecycle actions from network actions