### PR TITLE
fix: optimize ib size for 3 TCP round trips

### DIFF
--- a/data/simulation/config.default.yaml
+++ b/data/simulation/config.default.yaml
@@ -81,8 +81,8 @@ ib-shards: 1
 #       would instead more than double the total to 668.
 #       And even 828 including Op Cert.
 ib-head-size-bytes: 304
-# 100kB, using praos max size as ballpark estimate.
-ib-body-avg-size-bytes: 102400
+# 98KB to optimize for 3 TCP round trips
+ib-body-avg-size-bytes: 98304
 ib-body-max-size-bytes: 327680
 # Here we also use praos blocks as ballpark estimate.
 # Sec 2.3 Forging, of the benchmark cluster report, lists

--- a/simulation/src/LeiosProtocol/Config.hs
+++ b/simulation/src/LeiosProtocol/Config.hs
@@ -146,7 +146,7 @@ instance Default Config where
       , ibBodyValidationCpuTimeMsConstant = 50.0
       , ibBodyValidationCpuTimeMsPerByte = 0.0005
       , ibBodyMaxSizeBytes = 327680
-      , ibBodyAvgSizeBytes = 102400
+      , ibBodyAvgSizeBytes = 98304
       , ibDiffusionStrategy = FreshestFirst
       , ibDiffusionMaxWindowSize = 100
       , ibDiffusionMaxHeadersToRequest = 100


### PR DESCRIPTION
During TCP's slow start phase, the congestion window (CWND) typically:

Starts with an initial congestion window (initcwnd) of 10 MSS (Maximum Segment Size)
Doubles after each round trip time (RTT)

With a standard MSS of 1460 bytes:

- Round Trip 1: 10 MSS = 10 × 1460 = 14,600 bytes
- Round Trip 2: 20 MSS = 20 × 1460 = 29,200 bytes
- Round Trip 3: 40 MSS = 40 × 1460 = 58,400 bytes

Total for 3 round trips: 14,600 + 29,200 + 58,400 = 102,200 bytes

However, we need to account for TCP/IP overhead:

- TCP header: 20 bytes
- IP header: 20 bytes

This means each segment carries 1460 bytes of payload but requires 1500 bytes on the wire.
When accounting for this overhead and some implementation variations (like initial window sizes that might be slightly different in various TCP stacks), the practical optimal size for 3 round trips is approximately 98304 bytes (96KB).

This value represents a sweet spot that:
1. Fully utilizes 3 complete round trips
2. Doesn't require a partial 4th round trip
3. Accounts for real-world TCP implementation variations