### PR TITLE
Add support for conflicting transactions

### DIFF
--- a/data/simulation/config.d.ts
+++ b/data/simulation/config.d.ts
@@ -76,6 +76,10 @@ export interface Config {
   /** Only supported by Rust simulation. */
   "tx-max-size-bytes": bigint;
   /**
+   * What fraction of TXs (from 0 to 1) should introduce conflicts with transactions which were produced before?
+   * Only supported by Rust simulation.  */
+  "tx-conflict-fraction": number | null;
+  /**
    * When the first transaction should appear.
    * Only supported by Rust simulation.  */
   "tx-start-time"?: number | null;

--- a/data/simulation/config.default.yaml
+++ b/data/simulation/config.default.yaml
@@ -48,6 +48,7 @@ tx-size-bytes-distribution:
   sigma: 1.127
 tx-validation-cpu-time-ms: 1.5
 tx-max-size-bytes: 16384
+tx-conflict-fraction: 0
 
 ################################################################################
 # Ranking Block Configuration

--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -355,6 +355,10 @@
       "description": "When `true`, any delays and message sizes are calculated as if\neach block contained as much data as the expected average, rounded up.\nIn particular, for the sake of the above, we consider that:\n  - Each RB includes a certificate.\n  - Certificates contain votes from `vote-threshold` nodes.\n  - Vote bundles vote for `ceil eb-generation-probability` EBs.\n  - EBs reference `ceil (ib-generation-probability * leios-stage-length-slots)` IBs.\nOnly supported by Haskell simulation.",
       "type": "boolean"
     },
+    "tx-conflict-fraction": {
+      "description": "What fraction of TXs (from 0 to 1) should introduce conflicts with transactions which were produced before?\nOnly supported by Rust simulation.",
+      "type": "number"
+    },
     "tx-generation-distribution": {
       "$ref": "#/definitions/Distribution",
       "description": "Only supported by Rust simulation."

--- a/data/simulation/example.rust.jsonl
+++ b/data/simulation/example.rust.jsonl
@@ -7,7 +7,7 @@
 {"time_s":0.0,"message":{"type":"CpuTaskScheduled","task":{"node":"node-0","index":1},"task_type":"GenIB","subtasks":1}}
 {"time_s":0.0,"message":{"type":"Cpu","task":{"node":"node-0","index":1},"node":"node-0","cpu_time_s":0.13,"task_label":"GenIB: node-0-1-0","task_type":"GenIB","id":"node-0-1-0"}}
 {"time_s":0.0,"message":{"type":"VTLotteryWon","id":"0-node-1","slot":0,"pipeline":0,"producer":"node-1"}}
-{"time_s":0.0,"message":{"type":"TXGenerated","id":"0","publisher":"node-11","size_bytes":156}}
+{"time_s":0.0,"message":{"type":"TXGenerated","id":"0","publisher":"node-11","size_bytes":156,"input_id":0}}
 {"time_s":0.0,"message":{"type":"VTLotteryWon","id":"0-node-3","slot":0,"pipeline":0,"producer":"node-3"}}
 {"time_s":0.0,"message":{"type":"VTLotteryWon","id":"0-node-4","slot":0,"pipeline":0,"producer":"node-4"}}
 {"time_s":0.0,"message":{"type":"EBLotteryWon","id":"0-node-4","slot":0,"pipeline":1,"producer":"node-4"}}

--- a/data/simulation/topology.d.ts
+++ b/data/simulation/topology.d.ts
@@ -9,12 +9,12 @@
  */
 export interface Topology {
   nodes:
-    | {
-        [name: NodeName]: Node<Cluster>;
-      }
-    | {
-        [name: NodeName]: Node<Coord2D>;
-      };
+  | {
+    [name: NodeName]: Node<Cluster>;
+  }
+  | {
+    [name: NodeName]: Node<Coord2D>;
+  };
 }
 
 /** A node. */
@@ -23,6 +23,10 @@ export interface Node<Location> {
   "cpu-core-count"?: bigint | null;
   location: Location;
   producers: { [producer: NodeName]: LinkInfo };
+  /**
+   * What fraction of TXs (from 0 to 1) should introduce conflicts with transactions which were produced before?
+   * Only supported by Rust simulation.  */
+  "tx-conflict-fraction"?: number | null;
   /** If not null, the node will behave according to the given Behaviour.
   *
   * Only supported by Haskell simulation.

--- a/data/simulation/topology.schema.json
+++ b/data/simulation/topology.schema.json
@@ -48,6 +48,10 @@
           "additionalProperties": false,
           "properties": {},
           "type": "number"
+        },
+        "tx-conflict-fraction": {
+          "description": "What fraction of TXs (from 0 to 1) should introduce conflicts with transactions which were produced before?\nOnly supported by Rust simulation.",
+          "type": "number"
         }
       },
       "type": "object"
@@ -86,6 +90,10 @@
         "stake": {
           "additionalProperties": false,
           "properties": {},
+          "type": "number"
+        },
+        "tx-conflict-fraction": {
+          "description": "What fraction of TXs (from 0 to 1) should introduce conflicts with transactions which were produced before?\nOnly supported by Rust simulation.",
           "type": "number"
         }
       },

--- a/data/simulation/trace.rust.d.ts
+++ b/data/simulation/trace.rust.d.ts
@@ -56,6 +56,7 @@ interface GeneratedTransaction {
     id: string;
     publisher: string;
     size_bytes: number;
+    input_id: number;
 }
 
 interface LostTransaction {

--- a/data/simulation/trace.rust.schema.json
+++ b/data/simulation/trace.rust.schema.json
@@ -239,6 +239,9 @@
         "id": {
           "type": "string"
         },
+        "input_id": {
+          "type": "number"
+        },
         "publisher": {
           "type": "string"
         },
@@ -250,7 +253,7 @@
           "type": "string"
         }
       },
-      "required": ["id", "publisher", "size_bytes", "type"],
+      "required": ["id", "input_id", "publisher", "size_bytes", "type"],
       "type": "object"
     },
     "GeneratedVote": {

--- a/sim-rs/sim-cli/src/bin/gen-test-data/strategy/utils.rs
+++ b/sim-rs/sim-cli/src/bin/gen-test-data/strategy/utils.rs
@@ -170,6 +170,7 @@ impl GraphBuilder {
                     stake: n.stake,
                     location: RawNodeLocation::Coords(n.location),
                     cpu_core_count: n.cores,
+                    tx_conflict_fraction: None,
                     producers: BTreeMap::new(),
                 };
                 (name, node)

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -437,11 +437,16 @@ pub(crate) struct MockTransactionConfig {
 }
 
 impl MockTransactionConfig {
-    pub fn next_id(&self) -> TransactionId {
+    pub fn mock_tx(&self, bytes: u64) -> Transaction {
         let id = self
             .next_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        TransactionId::new(id)
+        Transaction {
+            id: TransactionId::new(id),
+            shard: 0,
+            bytes,
+            input_id: id,
+        }
     }
 }
 

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -76,6 +76,7 @@ pub struct RawParameters {
     pub tx_size_bytes_distribution: DistributionConfig,
     pub tx_validation_cpu_time_ms: f64,
     pub tx_max_size_bytes: u64,
+    pub tx_conflict_fraction: Option<f64>,
     pub tx_start_time: Option<f64>,
     pub tx_stop_time: Option<f64>,
 
@@ -177,6 +178,8 @@ pub struct RawNode {
     pub location: RawNodeLocation,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_core_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_conflict_fraction: Option<f64>,
     pub producers: BTreeMap<String, RawLinkInfo>,
 }
 
@@ -254,6 +257,7 @@ impl From<RawTopology> for Topology {
                     stake: node.stake.unwrap_or_default(),
                     cpu_multiplier: 1.0,
                     cores: node.cpu_core_count,
+                    tx_conflict_fraction: node.tx_conflict_fraction,
                     consumers: vec![],
                 },
             );
@@ -403,6 +407,7 @@ impl TransactionConfig {
                 max_size: params.tx_max_size_bytes,
                 frequency_ms: params.tx_generation_distribution.into(),
                 size_bytes: params.tx_size_bytes_distribution.into(),
+                conflict_fraction: params.tx_conflict_fraction.unwrap_or_default(),
                 start_time: params
                     .tx_start_time
                     .map(|t| Timestamp::zero() + Duration::from_secs_f64(t)),
@@ -425,6 +430,7 @@ pub(crate) struct RealTransactionConfig {
     pub max_size: u64,
     pub frequency_ms: FloatDistribution,
     pub size_bytes: FloatDistribution,
+    pub conflict_fraction: f64,
     pub start_time: Option<Timestamp>,
     pub stop_time: Option<Timestamp>,
 }
@@ -547,6 +553,7 @@ pub struct NodeConfiguration {
     pub stake: u64,
     pub cpu_multiplier: f64,
     pub cores: Option<u64>,
+    pub tx_conflict_fraction: Option<f64>,
     pub consumers: Vec<NodeId>,
 }
 

--- a/sim-rs/sim-core/src/events.rs
+++ b/sim-rs/sim-core/src/events.rs
@@ -169,6 +169,7 @@ pub enum Event {
         tx_payload_bytes: u64,
         size_bytes: u64,
         transactions: Vec<TransactionId>,
+        rb_ref: Option<BlockId<Node>>,
     },
     NoIBGenerated {
         node: Node,
@@ -478,6 +479,7 @@ impl EventTracker {
             tx_payload_bytes,
             size_bytes: header_bytes + tx_payload_bytes,
             transactions: block.transactions.iter().map(|tx| tx.id).collect(),
+            rb_ref: block.rb_ref.map(|b| self.to_block(b)),
         });
     }
 

--- a/sim-rs/sim-core/src/events.rs
+++ b/sim-rs/sim-core/src/events.rs
@@ -103,6 +103,7 @@ pub enum Event {
         publisher: Node,
         size_bytes: u64,
         shard: u64,
+        input_id: u64,
     },
     TXSent {
         id: TransactionId,
@@ -427,6 +428,7 @@ impl EventTracker {
             publisher: self.to_node(publisher),
             size_bytes: transaction.bytes,
             shard: transaction.shard,
+            input_id: transaction.input_id,
         });
     }
 

--- a/sim-rs/sim-core/src/model.rs
+++ b/sim-rs/sim-core/src/model.rs
@@ -136,6 +136,7 @@ pub struct InputBlock {
     pub header: InputBlockHeader,
     pub tx_payload_bytes: u64,
     pub transactions: Vec<Arc<Transaction>>,
+    pub rb_ref: Option<BlockId>,
 }
 impl InputBlock {
     pub fn bytes(&self) -> u64 {

--- a/sim-rs/sim-core/src/model.rs
+++ b/sim-rs/sim-core/src/model.rs
@@ -91,6 +91,7 @@ pub struct Transaction {
     pub id: TransactionId,
     pub shard: u64,
     pub bytes: u64,
+    pub input_id: u64,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/sim-rs/sim-core/src/sim.rs
+++ b/sim-rs/sim-core/src/sim.rs
@@ -15,7 +15,7 @@ use crate::{
     config::SimConfiguration,
     events::EventTracker,
     model::{
-        Block, EndorserBlock, EndorserBlockId, InputBlock, InputBlockHeader, InputBlockId,
+        Block, BlockId, EndorserBlock, EndorserBlockId, InputBlock, InputBlockHeader, InputBlockId,
         Transaction, TransactionId, VoteBundle, VoteBundleId,
     },
     network::Network,
@@ -132,8 +132,8 @@ enum SimulationMessage {
     RequestTx(TransactionId),
     Tx(Arc<Transaction>),
     // praos block propagation
-    RollForward(u64),
-    RequestBlock(u64),
+    RollForward(BlockId),
+    RequestBlock(BlockId),
     Block(Arc<Block>),
     // IB header propagation
     AnnounceIBHeader(InputBlockId),

--- a/sim-rs/sim-core/src/sim/node.rs
+++ b/sim-rs/sim-core/src/sim/node.rs
@@ -750,11 +750,7 @@ impl Node {
         if self.sim_config.praos_fallback {
             if let TransactionConfig::Mock(config) = &self.sim_config.transactions {
                 // Add one transaction, the right size for the extra RB payload
-                let tx = Transaction {
-                    id: config.next_id(),
-                    shard: 0,
-                    bytes: config.rb_size,
-                };
+                let tx = config.mock_tx(config.rb_size);
                 self.tracker.track_transaction_generated(&tx, self.id);
                 transactions.push(Arc::new(tx));
             } else {
@@ -1361,11 +1357,7 @@ impl Node {
 
     fn select_txs_for_ib(&mut self, shard: u64) -> Vec<Arc<Transaction>> {
         if let TransactionConfig::Mock(config) = &self.sim_config.transactions {
-            let tx = Transaction {
-                id: config.next_id(),
-                shard,
-                bytes: config.ib_size,
-            };
+            let tx = config.mock_tx(config.ib_size);
             self.tracker.track_transaction_generated(&tx, self.id);
             vec![Arc::new(tx)]
         } else {

--- a/sim-rs/sim-core/src/sim/node.rs
+++ b/sim-rs/sim-core/src/sim/node.rs
@@ -723,11 +723,13 @@ impl Node {
         };
         for header in headers {
             self.tracker.track_ib_lottery_won(header.id);
+            let rb_ref = self.praos.blocks.last_key_value().map(|(_, b)| b.id);
             let transactions = self.select_txs_for_ib(header.shard);
             let ib = InputBlock {
                 header,
                 tx_payload_bytes: self.sim_config.sizes.ib_payload(&transactions),
                 transactions,
+                rb_ref,
             };
             self.schedule_cpu_task(CpuTaskType::IBBlockGenerated(ib));
         }

--- a/sim-rs/sim-core/src/sim/tx.rs
+++ b/sim-rs/sim-core/src/sim/tx.rs
@@ -11,10 +11,15 @@ use crate::{
     model::{Transaction, TransactionId},
 };
 
+struct NodeState {
+    sink: mpsc::UnboundedSender<Arc<Transaction>>,
+    tx_conflict_fraction: Option<f64>,
+}
+
 pub struct TransactionProducer {
     rng: ChaChaRng,
     clock: ClockBarrier,
-    node_tx_sinks: HashMap<NodeId, mpsc::UnboundedSender<Arc<Transaction>>>,
+    nodes: HashMap<NodeId, NodeState>,
     ib_shards: u64,
     config: Option<RealTransactionConfig>,
 }
@@ -23,13 +28,25 @@ impl TransactionProducer {
     pub fn new(
         rng: ChaChaRng,
         clock: ClockBarrier,
-        node_tx_sinks: HashMap<NodeId, mpsc::UnboundedSender<Arc<Transaction>>>,
+        mut node_tx_sinks: HashMap<NodeId, mpsc::UnboundedSender<Arc<Transaction>>>,
         config: &SimConfiguration,
     ) -> Self {
+        let nodes = config
+            .nodes
+            .iter()
+            .map(|node| {
+                let sink = node_tx_sinks.remove(&node.id).unwrap();
+                let state = NodeState {
+                    sink,
+                    tx_conflict_fraction: node.tx_conflict_fraction,
+                };
+                (node.id, state)
+            })
+            .collect();
         Self {
             rng,
             clock,
-            node_tx_sinks,
+            nodes,
             ib_shards: config.ib_shards,
             config: match &config.transactions {
                 TransactionConfig::Real(config) => Some(config.clone()),
@@ -43,7 +60,7 @@ impl TransactionProducer {
             self.clock.wait_forever().await;
             return Ok(());
         };
-        let node_count = self.node_tx_sinks.len();
+        let node_count = self.nodes.len();
         let mut next_tx_id = 0;
         let mut next_tx_at = Timestamp::zero();
         let mut next_input_id = 0;
@@ -55,10 +72,25 @@ impl TransactionProducer {
         };
 
         loop {
+            let node_index = rng.random_range(0..node_count);
+            let node_id = NodeId::new(node_index);
+            let node = self.nodes.get(&node_id).unwrap();
+
+            let conflict_fraction = node
+                .tx_conflict_fraction
+                .unwrap_or(config.conflict_fraction);
+
             let id = TransactionId::new(next_tx_id);
             let shard = rng.random_range(0..self.ib_shards);
             let bytes = (config.size_bytes.sample(&mut rng) as u64).min(config.max_size);
-            let input_id = next_input_id;
+            let input_id = if next_input_id > 0 && rng.random_bool(conflict_fraction) {
+                next_input_id - 1
+            } else {
+                let id = next_input_id;
+                next_input_id += 1;
+                id
+            };
+
             let tx = Transaction {
                 id,
                 shard,
@@ -66,16 +98,9 @@ impl TransactionProducer {
                 input_id,
             };
 
-            let node_index = rng.random_range(0..node_count);
-            let node_id = NodeId::new(node_index);
-
-            self.node_tx_sinks
-                .get(&node_id)
-                .unwrap()
-                .send(Arc::new(tx))?;
+            node.sink.send(Arc::new(tx))?;
 
             next_tx_id += 1;
-            next_input_id += 1;
             let millis_until_tx = config.frequency_ms.sample(&mut rng) as u64;
             next_tx_at += Duration::from_millis(millis_until_tx);
 

--- a/sim-rs/sim-core/src/sim/tx.rs
+++ b/sim-rs/sim-core/src/sim/tx.rs
@@ -46,6 +46,7 @@ impl TransactionProducer {
         let node_count = self.node_tx_sinks.len();
         let mut next_tx_id = 0;
         let mut next_tx_at = Timestamp::zero();
+        let mut next_input_id = 0;
         let mut rng = &mut self.rng;
 
         if let Some(start) = config.start_time {
@@ -57,7 +58,13 @@ impl TransactionProducer {
             let id = TransactionId::new(next_tx_id);
             let shard = rng.random_range(0..self.ib_shards);
             let bytes = (config.size_bytes.sample(&mut rng) as u64).min(config.max_size);
-            let tx = Transaction { id, shard, bytes };
+            let input_id = next_input_id;
+            let tx = Transaction {
+                id,
+                shard,
+                bytes,
+                input_id,
+            };
 
             let node_index = rng.random_range(0..node_count);
             let node_id = NodeId::new(node_index);
@@ -68,6 +75,7 @@ impl TransactionProducer {
                 .send(Arc::new(tx))?;
 
             next_tx_id += 1;
+            next_input_id += 1;
             let millis_until_tx = config.frequency_ms.sample(&mut rng) as u64;
             next_tx_at += Duration::from_millis(millis_until_tx);
 


### PR DESCRIPTION
The probability of TXs conflicting is controlled by the `tx-conflict-fraction` setting in global config, or the `tx-conflict-fraction` setting on an individual node.

See https://docs.google.com/document/d/1dOEOYMLX8wXswKmAM9Hpt7XKc30rQd--OUG6PEGYy-U/edit?tab=t.0 for details on how it works.