### PR TITLE
Removed misplaced obselete paragraph about txs in RBs

### DIFF
--- a/docs/cip/README.md
+++ b/docs/cip/README.md
@@ -996,14 +996,6 @@ ensure seamless participation.
 
 ### Network
 
-As outlined above, Leios splits transactions between RBs and EBs, with EB
-inclusion dependent on committee voting and certification. **Transactions in
-RBs**: EB certificate generation requires an absolute stake majority. Given that
-this may not always be the case, if transactions were only included in EBs, the
-protocol would risk **losing liveness** due to no EB certificate being
-generated. As a remedy, RBs are allowed to directly contain transactions,
-ensuring basic liveness even when EB certification fails.
-
 Unlike Ouroboros Praos, where the RB chain contains all necessary data, Leios
 requires additional message types to:
 


### PR DESCRIPTION
This didn't belong in the network section and is an artifact of a previous version. The requirement that RBs not be empty if an EB is produced is discussed in the section "Step 1: Block Production".

See `https://github.com/input-output-hk/ouroboros-leios/pull/396/#discussion_r2300355843`.