### PR TITLE
Sim rs 1.3

### DIFF
--- a/sim-rs/CHANGELOG.md
+++ b/sim-rs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Linear Leios
+
+- Respect timings according to the latest CIP draft:
+	- RB headers must be received within `Delta_header`
+	- Voting must wait until `3 * Delta_header`
+	- Voting must finish by `3 * Delta_header + L_vote`
+	- EB cannot be referenced until after `3 * Delta_header + L_vote + L_diff`
+
 ### Other
 
 - Fix linter warnings from newer rust version

--- a/sim-rs/CHANGELOG.md
+++ b/sim-rs/CHANGELOG.md
@@ -10,6 +10,7 @@
 	- Voting must finish by `3 * Delta_header + L_vote`
 	- EB cannot be referenced until after `3 * Delta_header + L_vote + L_diff`
 - Don't include transactions directly in an RB if it also includes an endorsement
+- Don't produce empty EBs
 
 ### Other
 

--- a/sim-rs/CHANGELOG.md
+++ b/sim-rs/CHANGELOG.md
@@ -9,6 +9,7 @@
 	- Voting must wait until `3 * Delta_header`
 	- Voting must finish by `3 * Delta_header + L_vote`
 	- EB cannot be referenced until after `3 * Delta_header + L_vote + L_diff`
+- Don't include transactions directly in an RB if it also includes an endorsement
 
 ### Other
 

--- a/sim-rs/CHANGELOG.md
+++ b/sim-rs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.3.0
 
 ### Linear Leios
 

--- a/sim-rs/CHANGELOG.md
+++ b/sim-rs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Other
+
+- Fix linter warnings from newer rust version
+
 ## v1.2.0
 
 ### All Leios variants

--- a/sim-rs/Cargo.lock
+++ b/sim-rs/Cargo.lock
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "sim-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "sim-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/sim-rs/sim-cli/Cargo.toml
+++ b/sim-rs/sim-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sim-cli"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 default-run = "sim-cli"
 rust-version = "1.88"

--- a/sim-rs/sim-cli/src/events.rs
+++ b/sim-rs/sim-cli/src/events.rs
@@ -114,10 +114,10 @@ impl EventMonitor {
             remove_zero_decimal: Some(true),
         });
 
-        if let Some(path) = &self.output_path {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).await?;
-            }
+        if let Some(path) = &self.output_path
+            && let Some(parent) = path.parent()
+        {
+            fs::create_dir_all(parent).await?;
         }
 
         let mut output = match self.output_path.as_mut() {

--- a/sim-rs/sim-core/Cargo.toml
+++ b/sim-rs/sim-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sim-core"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.88"
 

--- a/sim-rs/sim-core/src/clock.rs
+++ b/sim-rs/sim-core/src/clock.rs
@@ -116,15 +116,15 @@ impl ClockBarrier {
         self.tasks.clone()
     }
 
-    pub fn wait_until(&mut self, timestamp: Timestamp) -> Waiter {
+    pub fn wait_until(&mut self, timestamp: Timestamp) -> Waiter<'_> {
         self.wait(Some(timestamp.with_resolution(self.timestamp_resolution)))
     }
 
-    pub fn wait_forever(&mut self) -> Waiter {
+    pub fn wait_forever(&mut self) -> Waiter<'_> {
         self.wait(None)
     }
 
-    fn wait(&mut self, until: Option<Timestamp>) -> Waiter {
+    fn wait(&mut self, until: Option<Timestamp>) -> Waiter<'_> {
         let (tx, rx) = oneshot::channel();
         let done = until.is_some_and(|ts| ts == self.now())
             || self

--- a/sim-rs/sim-core/src/events.rs
+++ b/sim-rs/sim-core/src/events.rs
@@ -44,7 +44,7 @@ impl Eq for Node {}
 
 impl PartialOrd for Node {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.id.cmp(&other.id))
+        Some(self.cmp(other))
     }
 }
 

--- a/sim-rs/sim-core/src/events.rs
+++ b/sim-rs/sim-core/src/events.rs
@@ -8,9 +8,8 @@ use crate::{
     clock::{Clock, Timestamp},
     config::{NodeConfiguration, NodeId},
     model::{
-        Block, BlockId, CpuTaskId, EndorserBlockId, InputBlockId, LinearEndorserBlock,
-        LinearRankingBlock, NoVoteReason, Transaction, TransactionId, TransactionLostReason,
-        VoteBundle, VoteBundleId,
+        Block, BlockId, CpuTaskId, EndorserBlockId, InputBlockId, LinearRankingBlock, NoVoteReason,
+        Transaction, TransactionId, TransactionLostReason, VoteBundle, VoteBundleId,
     },
 };
 
@@ -407,7 +406,7 @@ impl EventTracker {
         });
     }
 
-    pub fn track_linear_rb_generated(&self, rb: &LinearRankingBlock, eb: &LinearEndorserBlock) {
+    pub fn track_linear_rb_generated(&self, rb: &LinearRankingBlock) {
         self.send(Event::RBGenerated {
             id: self.to_block(rb.header.id),
             slot: rb.header.id.slot,
@@ -430,17 +429,6 @@ impl EventTracker {
                     .collect(),
             }),
             transactions: rb.transactions.iter().map(|tx| tx.id).collect(),
-        });
-        self.send(Event::EBGenerated {
-            id: self.to_endorser_block(eb.id()),
-            slot: eb.slot,
-            pipeline: 0,
-            producer: self.to_node(eb.producer),
-            shard: 0,
-            size_bytes: eb.bytes,
-            transactions: eb.txs.iter().map(|tx| BlockRef { id: tx.id }).collect(),
-            input_blocks: vec![],
-            endorser_blocks: vec![],
         });
     }
 
@@ -646,6 +634,20 @@ impl EventTracker {
                     id: self.to_endorser_block(*id),
                 })
                 .collect(),
+        });
+    }
+
+    pub fn track_linear_eb_generated(&self, block: &crate::model::LinearEndorserBlock) {
+        self.send(Event::EBGenerated {
+            id: self.to_endorser_block(block.id()),
+            slot: block.slot,
+            pipeline: 0,
+            producer: self.to_node(block.producer),
+            shard: 0,
+            size_bytes: block.bytes,
+            transactions: block.txs.iter().map(|tx| BlockRef { id: tx.id }).collect(),
+            input_blocks: vec![],
+            endorser_blocks: vec![],
         });
     }
 

--- a/sim-rs/sim-core/src/model.rs
+++ b/sim-rs/sim-core/src/model.rs
@@ -90,7 +90,7 @@ pub struct LinearRankingBlockHeader {
     pub vrf: u64,
     pub parent: Option<BlockId>,
     pub bytes: u64,
-    pub eb_announcement: EndorserBlockId,
+    pub eb_announcement: Option<EndorserBlockId>,
 }
 
 #[derive(Clone, Debug)]

--- a/sim-rs/sim-core/src/sim/leios.rs
+++ b/sim-rs/sim-core/src/sim/leios.rs
@@ -1114,12 +1114,12 @@ impl LeiosNode {
     }
 
     fn receive_request_ib_header(&mut self, from: NodeId, id: InputBlockId) {
-        if let Some(ib) = self.leios.ibs.get(&id) {
-            if let Some(header) = ib.header() {
-                let have_body = matches!(ib, InputBlockState::Received { .. });
-                self.queued
-                    .send_to(from, SimulationMessage::IBHeader(header.clone(), have_body));
-            }
+        if let Some(ib) = self.leios.ibs.get(&id)
+            && let Some(header) = ib.header()
+        {
+            let have_body = matches!(ib, InputBlockState::Received { .. });
+            self.queued
+                .send_to(from, SimulationMessage::IBHeader(header.clone(), have_body));
         }
     }
 

--- a/sim-rs/sim-core/src/sim/linear_leios.rs
+++ b/sim-rs/sim-core/src/sim/linear_leios.rs
@@ -554,7 +554,7 @@ impl LinearLeiosNode {
         let produce_empty_block = !self.leios.incomplete_onchain_ebs.is_empty();
 
         let mut rb_transactions = vec![];
-        if !produce_empty_block && self.sim_config.praos_fallback {
+        if !produce_empty_block && self.sim_config.praos_fallback && endorsement.is_none() {
             if let TransactionConfig::Mock(config) = &self.sim_config.transactions {
                 // Add one transaction, the right size for the extra RB payload
                 let tx = config.mock_tx(config.rb_size);

--- a/sim-rs/sim-core/src/sim/stracciatella.rs
+++ b/sim-rs/sim-core/src/sim/stracciatella.rs
@@ -583,8 +583,8 @@ impl StracciatellaLeiosNode {
 
     fn select_txs_for_eb(&mut self, shard: u64, pipeline: u64) -> Vec<Arc<Transaction>> {
         let mut txs = vec![];
-        if self.sim_config.eb_include_txs_from_previous_stage {
-            if let Some(eb_from_last_pipeline) =
+        if self.sim_config.eb_include_txs_from_previous_stage
+            && let Some(eb_from_last_pipeline) =
                 self.leios.ebs_by_pipeline.get(&pipeline).and_then(|ebs| {
                     ebs.iter()
                         .find_map(|eb_id| match self.leios.ebs.get(eb_id) {
@@ -592,12 +592,11 @@ impl StracciatellaLeiosNode {
                             _ => None,
                         })
                 })
-            {
-                // include TXs from the first EB in the last pipeline
-                for tx in &eb_from_last_pipeline.txs {
-                    if matches!(self.txs.get(&tx.id), Some(TransactionView::Received(_))) {
-                        txs.push(tx.clone());
-                    }
+        {
+            // include TXs from the first EB in the last pipeline
+            for tx in &eb_from_last_pipeline.txs {
+                if matches!(self.txs.get(&tx.id), Some(TransactionView::Received(_))) {
+                    txs.push(tx.clone());
                 }
             }
         }
@@ -1088,12 +1087,11 @@ impl StracciatellaLeiosNode {
 
     fn remove_rb_txs_from_mempools(&mut self, rb: &RankingBlock) {
         let mut txs = rb.transactions.clone();
-        if let Some(endorsement) = &rb.endorsement {
-            if let Some(EndorserBlockView::Received { eb, .. }) =
+        if let Some(endorsement) = &rb.endorsement
+            && let Some(EndorserBlockView::Received { eb, .. }) =
                 self.leios.ebs.get(&endorsement.eb)
-            {
-                txs.extend(eb.txs.iter().cloned());
-            }
+        {
+            txs.extend(eb.txs.iter().cloned());
         }
         self.remove_txs_from_mempools(&txs);
     }


### PR DESCRIPTION
### Linear Leios

- Respect timings according to the latest CIP draft:
	- RB headers must be received within `Delta_header`
	- Voting must wait until `3 * Delta_header`
	- Voting must finish by `3 * Delta_header + L_vote`
	- EB cannot be referenced until after `3 * Delta_header + L_vote + L_diff`
- Don't include transactions directly in an RB if it also includes an endorsement
- Don't produce empty EBs

### Other

- Fix linter warnings from newer rust version