### PR TITLE
docs(cip): announced_eb_size is size of the txs rather than of their references

### DIFF
--- a/docs/cip/README.md
+++ b/docs/cip/README.md
@@ -605,7 +605,8 @@ their headers and embedding EB certificates in their bodies.
 
 1. **Header additions**:
    - `announced_eb` (optional): Hash of the EB created by this block producer
-   - `announced_eb_size` (optional): Size in bytes of the announced EB's referenced transactions (4 bytes)
+   - `announced_eb_size` (optional): Size in bytes of the announced EB's
+     referenced transactions (4 bytes)
    - `certified_eb` (optional): Single bit indicating whether this RB certifies
      the EB announced by the previous RB (the EB hash is already available via
      the previous header's `announced_eb` field)


### PR DESCRIPTION
For this to be true ...

> The `certified_eb` bit enables syncing nodes to predict the total size of valid responses to their requests for batches of EBs certified on the historical chain.

... the `announced_eb_size` field needs to be the size of the txs, not the size of the tx references. Syncing nodes need to download all of the txs --- there's no reason they'd already have a subset of them. And they can reconstruct the tx references from the list of txs they receive.

The MsgLeiosBlockOffer does claim a byte size for the list of references, and the peer can disconnect if the peer sends an EB body with a different size.

---

This resulting scheme is a natural match for the fact that the reason an EB body contains references to txs instead of the txs themselves is merely an optimization.