### PR TITLE
Fix React re-render cascade causing maximum depth exceeded

### DIFF
--- a/post-cip/mempool-sim-web/src/cli.ts
+++ b/post-cip/mempool-sim-web/src/cli.ts
@@ -196,6 +196,5 @@ try {
 
 } catch (error) {
   logger.fatal({ error }, "simulation failed");
-  console.log(`Fatal: ${error}`);
   process.exit(1);
 }


### PR DESCRIPTION
Fix React re-render cascade in mempool visualizer:

- Remove redundant console.log in cli.ts
- Remove duplicate Canvas useEffect
- Use ref instead of state for hoveredNode in draw()
- Throttle force layout updates with requestAnimationFrame
- Only update state when values actually change

Prevents force layout from triggering 100+ re-renders/sec during settling.