### PR TITLE
Update haskell.nix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,6 +21,9 @@ packages:
   analysis/deltaq/linear-leios
   post-cip/tx-measurements/betti0
 
+-- This was added to switch from GHC 9.10.1 (with ghc-prim 0.11) to GHC 9.10.3 (with ghc-prim 0.12)
+allow-newer: *:ghc-prim
+
 tests: True
 
 source-repository-package

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "CHaP_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1733132525,
-        "narHash": "sha256-qD1Mo1MUxaNJnJCAQHMo5cfgMoHv6nb7nTS087CPkio=",
+        "lastModified": 1737590273,
+        "narHash": "sha256-zzeaIeeKCVfTxeSLw3oTmguOwH46NJw5LZH8wyWbATQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "4bd42413109a7935695346cabdf4f528f0e4f36f",
+        "rev": "be239ff9f54422603b3acf5c4d87b62a0c715196",
         "type": "github"
       },
       "original": {
@@ -258,7 +258,7 @@
     },
     "blockfrost": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1749464997,
@@ -855,7 +855,7 @@
           "cardano-node",
           "iohkNix"
         ],
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs_": [
           "ouroboros-consensus",
           "cardano-nix",
@@ -1437,21 +1437,6 @@
       }
     },
     "flake-compat_5": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -1464,6 +1449,21 @@
       "original": {
         "owner": "input-output-hk",
         "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -1827,23 +1827,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "ghc910X": {
       "flake": false,
       "locked": {
@@ -2015,11 +1998,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1733358616,
-        "narHash": "sha256-96x1H0cfIX2iMx3FkmFDoXohBCBVUJt5DH3457xAXVM=",
+        "lastModified": 1771461386,
+        "narHash": "sha256-93hCxhNOq9/HAggfTTurLhllI0IiEWZ35jk6i/X/qEo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bb0ec3418c4593dd79ed2f5423f8fddd1db726ae",
+        "rev": "b4f4537825a4db29c10541a50d7eb6c848bf0dca",
         "type": "github"
       },
       "original": {
@@ -2045,7 +2028,40 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771461376,
+        "narHash": "sha256-aEuZkBpTaU0XBFiaIomicJDoWQaw84rYfKXI/r17V/w=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "ca611068e77f15b96ecf71fae827e491c0b2dc3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal_2": {
       "flake": false,
       "locked": {
         "lastModified": 1750307553,
@@ -2144,6 +2160,22 @@
         "type": "github"
       }
     },
+    "hackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737937741,
+        "narHash": "sha256-IbfaZYGn4mDJVsM8/GsPyRBLsRP8saAHvST42IJuiBk=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5f787e9eea8708dc08ae1224a06677c27707205f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
         "HTTP": "HTTP_3",
@@ -2151,14 +2183,16 @@
         "cabal-34": "cabal-34_3",
         "cabal-36": "cabal-36_3",
         "cardano-shell": "cardano-shell_3",
-        "flake-compat": "flake-compat_6",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
-        "hackage": [
-          "iogx",
-          "hackage"
-        ],
+        "flake-compat": "flake-compat_5",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage_2",
+        "hackage-internal": "hackage-internal_2",
+        "hls": "hls_2",
         "hls-1.10": "hls-1.10_3",
         "hls-2.0": "hls-2.0_3",
+        "hls-2.10": "hls-2.10_2",
+        "hls-2.11": "hls-2.11_2",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2_3",
         "hls-2.3": "hls-2.3_3",
         "hls-2.4": "hls-2.4_3",
@@ -2168,31 +2202,27 @@
         "hls-2.8": "hls-2.8_3",
         "hls-2.9": "hls-2.9_2",
         "hpc-coveralls": "hpc-coveralls_3",
-        "hydra": "hydra_2",
         "iserv-proxy": "iserv-proxy_3",
         "nixpkgs": [
-          "iogx",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_2",
-        "nixpkgs-2105": "nixpkgs-2105_2",
-        "nixpkgs-2111": "nixpkgs-2111_2",
-        "nixpkgs-2205": "nixpkgs-2205_2",
-        "nixpkgs-2211": "nixpkgs-2211_2",
         "nixpkgs-2305": "nixpkgs-2305_3",
         "nixpkgs-2311": "nixpkgs-2311_3",
         "nixpkgs-2405": "nixpkgs-2405_2",
+        "nixpkgs-2411": "nixpkgs-2411_2",
+        "nixpkgs-2505": "nixpkgs-2505_2",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable_3",
         "old-ghc-nix": "old-ghc-nix_3",
         "stackage": "stackage_3"
       },
       "locked": {
-        "lastModified": 1733359919,
-        "narHash": "sha256-5LI4bETTK7fi+nr5nfSEQEBhx8+ZtKHFrH9oEqlj18E=",
+        "lastModified": 1771530831,
+        "narHash": "sha256-ZDgY9nRKtMEuiUjU8llJUVpOxM1r+enECGI7MPcD2vA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6bfaa3f488a3aa20153d9278a311120a9036459a",
+        "rev": "916efc290081f4a8a58e3c5ac97e6912ec46347c",
         "type": "github"
       },
       "original": {
@@ -2323,7 +2353,7 @@
         "cabal-36": "cabal-36_4",
         "cardano-shell": "cardano-shell_4",
         "flake-compat": "flake-compat_8",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": [
           "ouroboros-consensus",
           "cardano-nix",
@@ -2341,7 +2371,7 @@
         "hls-2.8": "hls-2.8_4",
         "hls-2.9": "hls-2.9_3",
         "hpc-coveralls": "hpc-coveralls_4",
-        "hydra": "hydra_3",
+        "hydra": "hydra_2",
         "iserv-proxy": "iserv-proxy_4",
         "nixpkgs": [
           "ouroboros-consensus",
@@ -2350,11 +2380,11 @@
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_3",
-        "nixpkgs-2105": "nixpkgs-2105_3",
-        "nixpkgs-2111": "nixpkgs-2111_3",
-        "nixpkgs-2205": "nixpkgs-2205_3",
-        "nixpkgs-2211": "nixpkgs-2211_3",
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
         "nixpkgs-2305": "nixpkgs-2305_4",
         "nixpkgs-2311": "nixpkgs-2311_4",
         "nixpkgs-2405": "nixpkgs-2405_3",
@@ -2384,7 +2414,7 @@
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_5",
         "flake-compat": "flake-compat_10",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
         "ghc910X": "ghc910X_2",
         "ghc911": "ghc911_2",
         "hackage": [
@@ -2403,7 +2433,7 @@
         "hls-2.7": "hls-2.7_5",
         "hls-2.8": "hls-2.8_5",
         "hpc-coveralls": "hpc-coveralls_5",
-        "hydra": "hydra_4",
+        "hydra": "hydra_3",
         "iserv-proxy": "iserv-proxy_5",
         "nixpkgs": [
           "ouroboros-consensus",
@@ -2411,11 +2441,11 @@
           "cardano-node",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_4",
-        "nixpkgs-2105": "nixpkgs-2105_4",
-        "nixpkgs-2111": "nixpkgs-2111_4",
-        "nixpkgs-2205": "nixpkgs-2205_4",
-        "nixpkgs-2211": "nixpkgs-2211_4",
+        "nixpkgs-2003": "nixpkgs-2003_3",
+        "nixpkgs-2105": "nixpkgs-2105_3",
+        "nixpkgs-2111": "nixpkgs-2111_3",
+        "nixpkgs-2205": "nixpkgs-2205_3",
+        "nixpkgs-2211": "nixpkgs-2211_3",
         "nixpkgs-2305": "nixpkgs-2305_5",
         "nixpkgs-2311": "nixpkgs-2311_5",
         "nixpkgs-unstable": "nixpkgs-unstable_5",
@@ -2445,7 +2475,7 @@
         "cabal-36": "cabal-36_6",
         "cardano-shell": "cardano-shell_6",
         "flake-compat": "flake-compat_12",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
         "hackage": [
           "ouroboros-consensus",
           "hackageNix"
@@ -2461,18 +2491,18 @@
         "hls-2.8": "hls-2.8_6",
         "hls-2.9": "hls-2.9_4",
         "hpc-coveralls": "hpc-coveralls_6",
-        "hydra": "hydra_5",
+        "hydra": "hydra_4",
         "iserv-proxy": "iserv-proxy_6",
         "nixpkgs": [
           "ouroboros-consensus",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_5",
-        "nixpkgs-2105": "nixpkgs-2105_5",
-        "nixpkgs-2111": "nixpkgs-2111_5",
-        "nixpkgs-2205": "nixpkgs-2205_5",
-        "nixpkgs-2211": "nixpkgs-2211_5",
+        "nixpkgs-2003": "nixpkgs-2003_4",
+        "nixpkgs-2105": "nixpkgs-2105_4",
+        "nixpkgs-2111": "nixpkgs-2111_4",
+        "nixpkgs-2205": "nixpkgs-2205_4",
+        "nixpkgs-2211": "nixpkgs-2211_4",
         "nixpkgs-2305": "nixpkgs-2305_6",
         "nixpkgs-2311": "nixpkgs-2311_6",
         "nixpkgs-2405": "nixpkgs-2405_4",
@@ -2759,6 +2789,23 @@
         "type": "github"
       }
     },
+    "hls-2.10_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.11": {
       "flake": false,
       "locked": {
@@ -2772,6 +2819,40 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -3510,11 +3591,11 @@
     "hls-2.9_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1720003792,
-        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
         "type": "github"
       },
       "original": {
@@ -3554,6 +3635,22 @@
       "original": {
         "owner": "haskell",
         "ref": "2.9.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -3682,8 +3779,10 @@
       "inputs": {
         "nix": "nix_2",
         "nixpkgs": [
-          "iogx",
-          "haskell-nix",
+          "ouroboros-consensus",
+          "cardano-nix",
+          "cardano-db-sync",
+          "haskellNix",
           "hydra",
           "nix",
           "nixpkgs"
@@ -3708,7 +3807,7 @@
         "nixpkgs": [
           "ouroboros-consensus",
           "cardano-nix",
-          "cardano-db-sync",
+          "cardano-node",
           "haskellNix",
           "hydra",
           "nix",
@@ -3731,32 +3830,6 @@
     "hydra_4": {
       "inputs": {
         "nix": "nix_4",
-        "nixpkgs": [
-          "ouroboros-consensus",
-          "cardano-nix",
-          "cardano-node",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "hydra_5": {
-      "inputs": {
-        "nix": "nix_5",
         "nixpkgs": [
           "ouroboros-consensus",
           "haskellNix",
@@ -3852,10 +3925,12 @@
       "inputs": {
         "CHaP": "CHaP_3",
         "easy-purescript-nix": "easy-purescript-nix",
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_6",
         "flake-utils": "flake-utils_4",
-        "hackage": "hackage",
-        "haskell-nix": "haskell-nix",
+        "hackage": "hackage_2",
+        "haskell-nix": [
+          "haskell-nix"
+        ],
         "iohk-nix": "iohk-nix",
         "nix2container": "nix2container",
         "nixpkgs": [
@@ -3868,16 +3943,17 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1733738060,
-        "narHash": "sha256-uZZB/JE7ED7QWfsj9UOQriu3E5kDCtgWMvLCVujnqAo=",
+        "lastModified": 1740037150,
+        "narHash": "sha256-OmAvyhPwJBEgaoyhtFqT60Lh3VoaKvq1s/0e1fZwAkc=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "507209c0acf0aaf607626d73b1711ea0afde7108",
+        "rev": "0cec4b1b2b7dcaf3653fc32b3ff246e2ff173bb7",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iogx",
+        "rev": "0cec4b1b2b7dcaf3653fc32b3ff246e2ff173bb7",
         "type": "github"
       }
     },
@@ -3892,11 +3968,11 @@
         "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1732287300,
-        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
+        "lastModified": 1734618971,
+        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
+        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
         "type": "github"
       },
       "original": {
@@ -4040,11 +4116,11 @@
     "iserv-proxy_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1770174258,
+        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
         "type": "github"
       },
       "original": {
@@ -4109,7 +4185,7 @@
       "inputs": {
         "agda-nix": "agda-nix",
         "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1766065805,
@@ -4190,22 +4266,6 @@
         "type": "github"
       }
     },
-    "lowdown-src_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -4230,7 +4290,7 @@
     "nix2container": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1730479402,
@@ -4249,7 +4309,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -4291,29 +4351,8 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-regression": "nixpkgs-regression_4"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_5": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_11",
-        "nixpkgs-regression": "nixpkgs-regression_5"
       },
       "locked": {
         "lastModified": 1661606874,
@@ -4455,22 +4494,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2003_5": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2105": {
       "locked": {
         "lastModified": 1659914493,
@@ -4520,22 +4543,6 @@
       }
     },
     "nixpkgs-2105_4": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105_5": {
       "locked": {
         "lastModified": 1659914493,
         "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
@@ -4615,22 +4622,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2111_5": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2205": {
       "locked": {
         "lastModified": 1685573264,
@@ -4695,22 +4686,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2205_5": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2211": {
       "locked": {
         "lastModified": 1688392541,
@@ -4760,22 +4735,6 @@
       }
     },
     "nixpkgs-2211_4": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211_5": {
       "locked": {
         "lastModified": 1688392541,
         "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
@@ -5001,11 +4960,11 @@
     },
     "nixpkgs-2405_2": {
       "locked": {
-        "lastModified": 1729242558,
-        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
@@ -5063,6 +5022,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411_2": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2505": {
       "locked": {
         "lastModified": 1748852332,
@@ -5075,6 +5050,38 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505_2": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5158,22 +5165,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression_5": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1690680713,
@@ -5187,22 +5178,6 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -5240,11 +5215,11 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1729980323,
-        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -5335,22 +5310,6 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1758035966,
-        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
@@ -5365,7 +5324,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1759417375,
         "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
@@ -5383,22 +5342,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1712920918,
         "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
         "owner": "NixOS",
@@ -5412,7 +5355,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1730768919,
         "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
@@ -5428,7 +5371,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1763560035,
         "narHash": "sha256-vkzxkkS6V2r5ngF24HL3fg14eKcpLfHvc7YTgnoRbBA=",
@@ -5443,7 +5386,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1768474748,
         "narHash": "sha256-wdmtaP6IClMWhsUYJ+RDneFhy63A4lTDG7FhVyoqSRI=",
@@ -5458,7 +5401,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1687420147,
         "narHash": "sha256-NILbmZVsoP2Aw0OAIXdbYXrWc/qggIDDyIwZ01yUx+Q=",
@@ -5470,6 +5413,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5492,16 +5451,16 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -5674,7 +5633,7 @@
       "inputs": {
         "flake-compat": "flake-compat_13",
         "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1763988335,
@@ -5694,15 +5653,14 @@
       "inputs": {
         "flake-compat": "flake-compat_7",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_4",
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -5716,9 +5674,10 @@
         "cardano-node": "cardano-node",
         "cardano-node-leios": "cardano-node-leios",
         "flake-parts": "flake-parts",
+        "haskell-nix": "haskell-nix",
         "iogx": "iogx",
         "leios-spec": "leios-spec",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "ouroboros-consensus": "ouroboros-consensus",
         "pre-commit-hooks": "pre-commit-hooks"
       }
@@ -5944,11 +5903,11 @@
     "stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1733357539,
-        "narHash": "sha256-r5B5lCFZC1a/V+banTIYzjOVlP2lIuLrhnC1FnCMAl0=",
+        "lastModified": 1771460325,
+        "narHash": "sha256-RRsGO7QVyuBtUTVqDiB7CYvFruj0Z/yxZK1JarkTqI4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "d6b9beeb93d98ea98b6ad32f36768cad48177e89",
+        "rev": "29c0dcc517e04be238023064412312ad4443ddb2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1998,11 +1998,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1771461386,
-        "narHash": "sha256-93hCxhNOq9/HAggfTTurLhllI0IiEWZ35jk6i/X/qEo=",
+        "lastModified": 1771547819,
+        "narHash": "sha256-0uAueswvAeppzRil1e+Z4m84fqQjVcTUMBfkWgGdsOY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b4f4537825a4db29c10541a50d7eb6c848bf0dca",
+        "rev": "470e1772d3e8a4eac7fdc1c66caaa9751e81f761",
         "type": "github"
       },
       "original": {
@@ -2031,11 +2031,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1771461376,
-        "narHash": "sha256-aEuZkBpTaU0XBFiaIomicJDoWQaw84rYfKXI/r17V/w=",
+        "lastModified": 1771547505,
+        "narHash": "sha256-bMzsfwx12qxSaTgblE4HEB2geKGprl2gvDI/zbisnPc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ca611068e77f15b96ecf71fae827e491c0b2dc3b",
+        "rev": "fdf356c62640ba6e22bd2e2b06033428514927e7",
         "type": "github"
       },
       "original": {
@@ -2218,11 +2218,11 @@
         "stackage": "stackage_3"
       },
       "locked": {
-        "lastModified": 1771530831,
-        "narHash": "sha256-ZDgY9nRKtMEuiUjU8llJUVpOxM1r+enECGI7MPcD2vA=",
+        "lastModified": 1771548869,
+        "narHash": "sha256-oGr4S/reR92UnegalkPNCxsbsahLgJalGmCr7BZ4gG8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "916efc290081f4a8a58e3c5ac97e6912ec46347c",
+        "rev": "cdb0f374eda1d07f17fe7213a261ceb6f8ae9403",
         "type": "github"
       },
       "original": {
@@ -5903,11 +5903,11 @@
     "stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1771460325,
-        "narHash": "sha256-RRsGO7QVyuBtUTVqDiB7CYvFruj0Z/yxZK1JarkTqI4=",
+        "lastModified": 1771546616,
+        "narHash": "sha256-C86rhsWU9AB0HFjeNie53eRv41w0X00/HOz4DmXmrHM=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "29c0dcc517e04be238023064412312ad4443ddb2",
+        "rev": "025f8f247268dade13530c2dfdbf748a7b16864d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
 
-    iogx.url = "github:input-output-hk/iogx";
+    # Pinning this version until the nix code in this repo is updated to support newer versions
+    iogx.url = "github:input-output-hk/iogx/0cec4b1b2b7dcaf3653fc32b3ff246e2ff173bb7";
+    # Allowing haskell.nix to be updated
+    haskell-nix.url = "github:input-output-hk/haskell.nix";
+    iogx.inputs.haskell-nix.follows = "haskell-nix";
 
     leios-spec.url = "github:input-output-hk/ouroboros-leios-formal-spec?rev=a654a1761476fcf8e6a43aeedbc1455bd7ad77db";
 

--- a/leios-trace-verifier/cabal.project
+++ b/leios-trace-verifier/cabal.project
@@ -1,3 +1,6 @@
 packages:
   dist/haskell
   ../leios-trace-hs
+
+-- This was added to switch from GHC 9.10.1 (with ghc-prim 0.11) to GHC 9.10.3 (with ghc-prim 0.12)
+allow-newer: *:ghc-prim

--- a/leios-trace-verifier/cabal.project
+++ b/leios-trace-verifier/cabal.project
@@ -1,6 +1,3 @@
 packages:
   dist/haskell
   ../leios-trace-hs
-
--- This was added to switch from GHC 9.10.1 (with ghc-prim 0.11) to GHC 9.10.3 (with ghc-prim 0.12)
-allow-newer: *:ghc-prim

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -27,10 +27,10 @@ let
 
   ouroboros-leios-sim-src = pkgs.runCommand "ouroboros-leios-sim-src" { } ''
     # Copy the original source.
-    cp -r ${./simulation} $out
+    cp -r ${../simulation} $out
     # Clean up troublesome symbolic links.
     rm -r $out/test/data
-    cp -r ${./data} $out/test/
+    cp -r ${../data} $out/test/
   '';
 
   cabalProject' = pkgs.haskell-nix.cabalProject' {

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -10,46 +10,49 @@ let
 
   inherit (repoRoot.nix) agda;
 
-  sources = pkgs.stdenv.mkDerivation {
-    name = "leios-hs-sources";
-    src = ./..;
-    patchPhase = ''
-      # Add the trace verifier package.
-      sed -i '/^packages:/a\ \ leios-trace-verifier/dist/haskell' cabal.project
-      # Clean up troublesome symbolic links.
-      rm -r simulation/test/data
-      cp -r data simulation/test/
-    '';
-    buildPhase = ''
-      # Copy the source for the trace verifier.
-      mkdir -p $out/leios-trace-verifier/dist/haskell
-      cp -r ${agda.hsTraceParser.out}/hs-src/* $out/leios-trace-verifier/dist/haskell/
-      # Copy the original source.
-      cp -r . $out
-      # Copy the test data.
-      mkdir -p $out/leios-trace-verifier/dist/haskell/data
-      cp -r leios-trace-verifier/conformance-traces/{config.yaml,topology.yaml,valid,invalid} $out/leios-trace-verifier/dist/haskell/data/
-    '';
-    installPhase = ''
-      # Add the MAlonzo modules to the cabal file.
-      chmod +w $out/leios-trace-verifier/dist/haskell/trace-parser.cabal
-      find $out/leios-trace-verifier/dist/haskell/src/MAlonzo -name "*.hs" -print\
-      | sed "s#^.*/src/#        #;s#\.hs##;s#/#.#g" \
-      >> $out/leios-trace-verifier/dist/haskell/trace-parser.cabal
-    '';
-    fixupPhase = ''
-      # Skip fixup phase, so as not to mangle any of the source.
-    '';
-  };
+  trace-parser-src = pkgs.runCommand "trace-parser-src" { } ''
+    # Copy the source for the trace verifier.
+    mkdir -p $out
+    cp -r ${agda.hsTraceParser.out}/hs-src/* $out/
+    # Copy the test data.
+    mkdir -p $out/data
+    cp -r ${../leios-trace-verifier/conformance-traces}/{config.yaml,topology.yaml,valid,invalid} $out/data/
+    # Add the MAlonzo modules to the cabal file.
+    chmod +w $out/trace-parser.cabal
+    find $out/src/MAlonzo -name "*.hs" -print\
+    | sed "s#^.*/src/#        #;s#\.hs##;s#/#.#g" \
+    >> $out/trace-parser.cabal
+    echo $out
+  '';
+
+  ouroboros-leios-sim-src = pkgs.runCommand "ouroboros-leios-sim-src" { } ''
+    # Copy the original source.
+    cp -r ${./simulation} $out
+    # Clean up troublesome symbolic links.
+    rm -r $out/test/data
+    cp -r ${./data} $out/test/
+  '';
 
   cabalProject' = pkgs.haskell-nix.cabalProject' {
-    src = sources.out;
+    src = ./..;
     shell.withHoogle = false;
     inputMap = {
       "https://chap.intersectmbo.org/" = inputs.iogx.inputs.CHaP;
     };
     name = "ouroboros-leios";
     compiler-nix-name = lib.mkDefault "ghc9101";
+    # Add trace-parser in the cabalProjectLocal as we need the generated
+    # `.cabal` file for the cabal planner to work.
+    cabalProjectLocal = ''
+      packages: ${trace-parser-src}
+    '';
+    modules = [
+      {
+        # We can wait and replace the `ouroboros-leios-sim` source here
+        # because we do not need to change the `.cabal` file.
+        packages.ouroboros-leios-sim.src = ouroboros-leios-sim-src;
+      }
+    ];
   };
 
   cabalProject = cabalProject'.appendOverlays [ ];

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -50,7 +50,7 @@ let
       {
         # We can wait and replace the `ouroboros-leios-sim` source here
         # because we do not need to change the `.cabal` file.
-        packages.ouroboros-leios-sim.src = ouroboros-leios-sim-src;
+        packages.ouroboros-leios-sim.src = lib.mkForce ouroboros-leios-sim-src;
       }
     ];
   };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -40,7 +40,7 @@ let
       "https://chap.intersectmbo.org/" = inputs.iogx.inputs.CHaP;
     };
     name = "ouroboros-leios";
-    compiler-nix-name = lib.mkDefault "ghc9101";
+    compiler-nix-name = lib.mkDefault "ghc9103";
     # Add trace-parser in the cabalProjectLocal as we need the generated
     # `.cabal` file for the cabal planner to work.
     cabalProjectLocal = ''


### PR DESCRIPTION
This updates to the latest haskell.nix and improves the way the source for trace-parser and ouroboros-leios-sim are updated for cabalProject.

This makes use of https://github.com/input-output-hk/haskell.nix/pull/2479 and https://github.com/input-output-hk/haskell.nix/pull/2480