### PR TITLE
chore(antithesis): register my user as allowed for moog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This is needed for registering this repository with moog
+antithesis: @wolf31o2


### PR DESCRIPTION
Related to #617 

This allows my registered `moog` user to register this repository and to publish jobs via moog to Antithesis using my credentials.