### PR TITLE
Split vote config into separate persistent and non-persistent voter parameters

### DIFF
--- a/data/simulation/config.d.ts
+++ b/data/simulation/config.d.ts
@@ -231,13 +231,22 @@ export interface Config {
   "eb-referenced-txs-max-size-bytes": bigint;
 
   // Vote Configuration
-  "vote-generation-probability": number;
-  "vote-generation-cpu-time-ms-constant": number;
+  "persistent-vote-generation-probability": number;
+  "non-persistent-vote-generation-probability": number;
+  "persistent-vote-generation-cpu-time-ms": number;
+  "non-persistent-vote-generation-cpu-time-ms": number;
   "vote-generation-cpu-time-ms-per-ib": number;
   "vote-generation-cpu-time-ms-per-tx": number;
-  "vote-validation-cpu-time-ms": number;
+  "persistent-vote-validation-cpu-time-ms": number;
+  "non-persistent-vote-validation-cpu-time-ms": number;
   "vote-threshold": bigint;
   "vote-bundle-size-bytes-constant": bigint;
+  "persistent-vote-bundle-size-bytes-per-eb": bigint;
+  "non-persistent-vote-bundle-size-bytes-per-eb": bigint;
+  // Grandfathered for Haskell sim.
+  "vote-generation-probability": number;
+  "vote-generation-cpu-time-ms-constant": number;
+  "vote-validation-cpu-time-ms": number;
   "vote-bundle-size-bytes-per-eb": bigint;
   /** Only supported by Haskell simulation. */
   "vote-diffusion-strategy": DiffusionStrategy;

--- a/data/simulation/config.default.yaml
+++ b/data/simulation/config.default.yaml
@@ -191,31 +191,42 @@ eb-body-avg-size-bytes: 2500000
 ################################################################################
 
 # Cryptography related values taken from [vote-spec](crypto-benchmarks.rs/Specification.md)
-# using weighted averages of 80% persistent and 20% non-persistent.
+# with separate persistent and non-persistent voter parameters.
 
-# vote-spec#Committe and quorum size
+# vote-spec#Committee and quorum size
 #
-# Note: this is used as the expected amount of total weight of
-# generated votes in the sims.
-vote-generation-probability: 500.0
-# vote-spec#"Committe and quorum size"
-# 60% of `vote-generation-probability`
+# Note: total vote-generation-probability is the sum of persistent and
+# non-persistent probabilities.
+persistent-vote-generation-probability: 400.0
+non-persistent-vote-generation-probability: 100.0
+# vote-spec#"Committee and quorum size"
+# 60% of total vote-generation-probability
 vote-threshold: 300
-# vote-spec#"Generate vote" 0.8*135e-3 + 0.2*280e-3
-vote-generation-cpu-time-ms-constant: 164e-3
+# vote-spec#"Generate vote"
+persistent-vote-generation-cpu-time-ms: 135e-3
+non-persistent-vote-generation-cpu-time-ms: 280e-3
 # No benchmark yet.
 vote-generation-cpu-time-ms-per-ib: 0
 # No benchmark yet.
 vote-generation-cpu-time-ms-per-tx: 0
-# vote-spec#"Verify vote" 0.8*670e-3 + 0.2*1.4
-vote-validation-cpu-time-ms: 816e-3
+# vote-spec#"Verify vote"
+persistent-vote-validation-cpu-time-ms: 670e-3
+non-persistent-vote-validation-cpu-time-ms: 1.4
 # The `Vote` structure counted in the -per-eb already identifies slot
 # (in Eid) and voter. We can assume a vote bundle is all for the same
 # voter and slot, so for non-persistent voters we could factor their
 # PoolKeyHash (28bytes) here, but that is for 20% of cases.
 # More relevant if EB generation is very high.
 vote-bundle-size-bytes-constant: 0
-# vote-spec#Votes 0.8*90 + 0.2*164
+# vote-spec#Votes
+persistent-vote-bundle-size-bytes-per-eb: 90
+non-persistent-vote-bundle-size-bytes-per-eb: 164
+
+# Grandfathered weighted averages for Haskell sim compatibility.
+# These are computed as 0.8*persistent + 0.2*non-persistent.
+vote-generation-probability: 500.0
+vote-generation-cpu-time-ms-constant: 164e-3
+vote-validation-cpu-time-ms: 816e-3
 vote-bundle-size-bytes-per-eb: 105
 
 vote-diffusion-strategy: "peer-order"

--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -528,7 +528,14 @@
     },
     "vote-bundle-size-bytes-per-eb": {
       "additionalProperties": false,
+      "description": "Grandfathered for Haskell sim.",
       "properties": {},
+      "type": "number"
+    },
+    "persistent-vote-bundle-size-bytes-per-eb": {
+      "type": "number"
+    },
+    "non-persistent-vote-bundle-size-bytes-per-eb": {
       "type": "number"
     },
     "vote-diffusion-max-bodies-to-request": {
@@ -554,6 +561,13 @@
       "description": "Only supported by Haskell simulation."
     },
     "vote-generation-cpu-time-ms-constant": {
+      "description": "Grandfathered for Haskell sim.",
+      "type": "number"
+    },
+    "persistent-vote-generation-cpu-time-ms": {
+      "type": "number"
+    },
+    "non-persistent-vote-generation-cpu-time-ms": {
       "type": "number"
     },
     "vote-generation-cpu-time-ms-per-ib": {
@@ -563,6 +577,13 @@
       "type": "number"
     },
     "vote-generation-probability": {
+      "description": "Grandfathered for Haskell sim.",
+      "type": "number"
+    },
+    "persistent-vote-generation-probability": {
+      "type": "number"
+    },
+    "non-persistent-vote-generation-probability": {
       "type": "number"
     },
     "vote-threshold": {
@@ -571,6 +592,13 @@
       "type": "number"
     },
     "vote-validation-cpu-time-ms": {
+      "description": "Grandfathered for Haskell sim.",
+      "type": "number"
+    },
+    "persistent-vote-validation-cpu-time-ms": {
+      "type": "number"
+    },
+    "non-persistent-vote-validation-cpu-time-ms": {
       "type": "number"
     }
   },

--- a/data/simulation/small/config-[slice=20]-[voting=send-recv]-[ib-diff=ffd].yaml
+++ b/data/simulation/small/config-[slice=20]-[voting=send-recv]-[ib-diff=ffd].yaml
@@ -29,11 +29,20 @@ rb-body-max-size-bytes: 90112
 rb-generation-cpu-time-ms: 300.0
 rb-head-size-bytes: 1024
 rb-head-validation-cpu-time-ms: 1
-vote-generation-cpu-time-ms-constant: 1
+persistent-vote-generation-probability: 400.0
+non-persistent-vote-generation-probability: 100.0
+persistent-vote-generation-cpu-time-ms: 1
+non-persistent-vote-generation-cpu-time-ms: 1
 vote-generation-cpu-time-ms-per-ib: 1
-vote-generation-probability: 500.0
 vote-one-eb-per-vrf-win: false
 vote-bundle-size-bytes-constant: 256
-vote-bundle-size-bytes-per-eb: 32
+persistent-vote-bundle-size-bytes-per-eb: 32
+non-persistent-vote-bundle-size-bytes-per-eb: 32
 vote-threshold: 150
+persistent-vote-validation-cpu-time-ms: 3
+non-persistent-vote-validation-cpu-time-ms: 3
+# Grandfathered for Haskell sim.
+vote-generation-probability: 500.0
+vote-generation-cpu-time-ms-constant: 1
+vote-bundle-size-bytes-per-eb: 32
 vote-validation-cpu-time-ms: 3

--- a/data/simulation/small/config-[slice=20]-[voting=single-stage]-[ib-diff=ffd].yaml
+++ b/data/simulation/small/config-[slice=20]-[voting=single-stage]-[ib-diff=ffd].yaml
@@ -29,11 +29,20 @@ rb-body-max-size-bytes: 90112
 rb-generation-cpu-time-ms: 300.0
 rb-head-size-bytes: 1024
 rb-head-validation-cpu-time-ms: 1
-vote-generation-cpu-time-ms-constant: 1
+persistent-vote-generation-probability: 400.0
+non-persistent-vote-generation-probability: 100.0
+persistent-vote-generation-cpu-time-ms: 1
+non-persistent-vote-generation-cpu-time-ms: 1
 vote-generation-cpu-time-ms-per-ib: 1
-vote-generation-probability: 500.0
 vote-one-eb-per-vrf-win: false
 vote-bundle-size-bytes-constant: 256
-vote-bundle-size-bytes-per-eb: 32
+persistent-vote-bundle-size-bytes-per-eb: 32
+non-persistent-vote-bundle-size-bytes-per-eb: 32
 vote-threshold: 150
+persistent-vote-validation-cpu-time-ms: 3
+non-persistent-vote-validation-cpu-time-ms: 3
+# Grandfathered for Haskell sim.
+vote-generation-probability: 500.0
+vote-generation-cpu-time-ms-constant: 1
+vote-bundle-size-bytes-per-eb: 32
 vote-validation-cpu-time-ms: 3

--- a/data/simulation/small/config-[slice=5]-[voting=send-recv]-[ib-diff=ffd].yaml
+++ b/data/simulation/small/config-[slice=5]-[voting=send-recv]-[ib-diff=ffd].yaml
@@ -29,11 +29,20 @@ rb-body-max-size-bytes: 90112
 rb-generation-cpu-time-ms: 300.0
 rb-head-size-bytes: 1024
 rb-head-validation-cpu-time-ms: 1
-vote-generation-cpu-time-ms-constant: 1
+persistent-vote-generation-probability: 400.0
+non-persistent-vote-generation-probability: 100.0
+persistent-vote-generation-cpu-time-ms: 1
+non-persistent-vote-generation-cpu-time-ms: 1
 vote-generation-cpu-time-ms-per-ib: 1
-vote-generation-probability: 500.0
 vote-one-eb-per-vrf-win: false
 vote-bundle-size-bytes-constant: 256
-vote-bundle-size-bytes-per-eb: 32
+persistent-vote-bundle-size-bytes-per-eb: 32
+non-persistent-vote-bundle-size-bytes-per-eb: 32
 vote-threshold: 150
+persistent-vote-validation-cpu-time-ms: 3
+non-persistent-vote-validation-cpu-time-ms: 3
+# Grandfathered for Haskell sim.
+vote-generation-probability: 500.0
+vote-generation-cpu-time-ms-constant: 1
+vote-bundle-size-bytes-per-eb: 32
 vote-validation-cpu-time-ms: 3

--- a/data/simulation/small/config-[slice=5]-[voting=single-stage]-[ib-diff=ffd].yaml
+++ b/data/simulation/small/config-[slice=5]-[voting=single-stage]-[ib-diff=ffd].yaml
@@ -29,11 +29,20 @@ rb-body-max-size-bytes: 90112
 rb-generation-cpu-time-ms: 300.0
 rb-head-size-bytes: 1024
 rb-head-validation-cpu-time-ms: 1
-vote-generation-cpu-time-ms-constant: 1
+persistent-vote-generation-probability: 400.0
+non-persistent-vote-generation-probability: 100.0
+persistent-vote-generation-cpu-time-ms: 1
+non-persistent-vote-generation-cpu-time-ms: 1
 vote-generation-cpu-time-ms-per-ib: 1
-vote-generation-probability: 500.0
 vote-one-eb-per-vrf-win: false
 vote-bundle-size-bytes-constant: 256
-vote-bundle-size-bytes-per-eb: 32
+persistent-vote-bundle-size-bytes-per-eb: 32
+non-persistent-vote-bundle-size-bytes-per-eb: 32
 vote-threshold: 150
+persistent-vote-validation-cpu-time-ms: 3
+non-persistent-vote-validation-cpu-time-ms: 3
+# Grandfathered for Haskell sim.
+vote-generation-probability: 500.0
+vote-generation-cpu-time-ms-constant: 1
+vote-bundle-size-bytes-per-eb: 32
 vote-validation-cpu-time-ms: 3

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -133,14 +133,18 @@ pub struct RawParameters {
     pub eb_include_txs_from_previous_stage: bool,
 
     // Vote configuration
-    pub vote_generation_probability: f64,
-    pub vote_generation_cpu_time_ms_constant: f64,
+    pub persistent_vote_generation_probability: f64,
+    pub non_persistent_vote_generation_probability: f64,
+    pub persistent_vote_generation_cpu_time_ms: f64,
+    pub non_persistent_vote_generation_cpu_time_ms: f64,
     pub vote_generation_cpu_time_ms_per_tx: f64,
     pub vote_generation_cpu_time_ms_per_ib: f64,
-    pub vote_validation_cpu_time_ms: f64,
+    pub persistent_vote_validation_cpu_time_ms: f64,
+    pub non_persistent_vote_validation_cpu_time_ms: f64,
     pub vote_threshold: u64,
     pub vote_bundle_size_bytes_constant: u64,
-    pub vote_bundle_size_bytes_per_eb: u64,
+    pub persistent_vote_bundle_size_bytes_per_eb: u64,
+    pub non_persistent_vote_bundle_size_bytes_per_eb: u64,
 
     // Certificate configuration
     pub cert_generation_cpu_time_ms_constant: f64,
@@ -393,6 +397,16 @@ impl From<RawTopology> for Topology {
     }
 }
 
+fn vote_weighted_average(params: &RawParameters, persistent: f64, non_persistent: f64) -> f64 {
+    let total = params.persistent_vote_generation_probability
+        + params.non_persistent_vote_generation_probability;
+    if total == 0.0 {
+        return 0.0;
+    }
+    let frac = params.persistent_vote_generation_probability / total;
+    frac * persistent + (1.0 - frac) * non_persistent
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CpuTimeConfig {
     pub tx_validation_constant: Duration,
@@ -449,10 +463,18 @@ impl CpuTimeConfig {
             eb_body_validation_per_byte: duration_ms(
                 params.eb_body_validation_cpu_time_ms_per_byte,
             ),
-            vote_generation_constant: duration_ms(params.vote_generation_cpu_time_ms_constant),
+            vote_generation_constant: duration_ms(vote_weighted_average(
+                params,
+                params.persistent_vote_generation_cpu_time_ms,
+                params.non_persistent_vote_generation_cpu_time_ms,
+            )),
             vote_generation_per_tx: duration_ms(params.vote_generation_cpu_time_ms_per_tx),
             vote_generation_per_ib: duration_ms(params.vote_generation_cpu_time_ms_per_ib),
-            vote_validation: duration_ms(params.vote_validation_cpu_time_ms),
+            vote_validation: duration_ms(vote_weighted_average(
+                params,
+                params.persistent_vote_validation_cpu_time_ms,
+                params.non_persistent_vote_validation_cpu_time_ms,
+            )),
             cert_generation_constant: duration_ms(params.cert_generation_cpu_time_ms_constant),
             cert_generation_per_node: duration_ms(params.cert_generation_cpu_time_ms_per_node),
             cert_validation_constant: duration_ms(params.cert_validation_cpu_time_ms_constant),
@@ -485,7 +507,12 @@ impl BlockSizeConfig {
             eb_constant: params.eb_size_bytes_constant,
             eb_per_ib: params.eb_size_bytes_per_ib,
             vote_constant: params.vote_bundle_size_bytes_constant,
-            vote_per_eb: params.vote_bundle_size_bytes_per_eb,
+            vote_per_eb: vote_weighted_average(
+                params,
+                params.persistent_vote_bundle_size_bytes_per_eb as f64,
+                params.non_persistent_vote_bundle_size_bytes_per_eb as f64,
+            )
+            .round() as u64,
         }
     }
 
@@ -791,7 +818,8 @@ impl SimConfiguration {
             block_generation_probability: params.rb_generation_probability,
             ib_generation_probability: params.ib_generation_probability,
             eb_generation_probability: params.eb_generation_probability,
-            vote_probability: params.vote_generation_probability,
+            vote_probability: params.persistent_vote_generation_probability
+                + params.non_persistent_vote_generation_probability,
             vote_threshold: params.vote_threshold,
             vote_slot_length: params.leios_stage_active_voting_slots,
             eb_include_txs_from_previous_stage: params.eb_include_txs_from_previous_stage,


### PR DESCRIPTION
Replace pre-computed weighted averages (80:20 persistent:non-persistent) with independently configurable persistent and non-persistent voter parameters for vote generation CPU time, vote validation CPU time, and vote bundle size per EB:

```yaml
persistent-vote-generation-probability: 400.0
non-persistent-vote-generation-probability: 100.0

persistent-vote-generation-cpu-time-ms: 135e-3
non-persistent-vote-generation-cpu-time-ms: 280e-3

persistent-vote-validation-cpu-time-ms: 670e-3
non-persistent-vote-validation-cpu-time-ms: 1.4

persistent-vote-bundle-size-bytes-per-eb: 90
non-persistent-vote-bundle-size-bytes-per-eb: 164
```

The code now computes the weighted averages from these component values.

Old config fields are grandfathered for Haskell sim compatibility.

Part of #805 