### PR TITLE
Fix Moog submission: add required --try / --duration

### DIFF
--- a/.github/workflows/antithesis-leios.yaml
+++ b/.github/workflows/antithesis-leios.yaml
@@ -217,7 +217,8 @@ jobs:
             -d "antithesis/testnets/leios-devnet" \
             -c "${GITHUB_SHA}" \
             -r "${GITHUB_REPOSITORY}" \
-            -t 30
+            -t 1 \
+            -y 1
         env:
           MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
           MOOG_WALLET_FILE: wallet.json


### PR DESCRIPTION
Moog now requires --try|-y for create-test. Set to 1 for the initial attempt on each commit. Set --duration|-t to 1 for 1 hour run.

