### PR TITLE
ci(antithesis): poll for test results after submission

### DIFF
--- a/.github/workflows/antithesis-leios.yaml
+++ b/.github/workflows/antithesis-leios.yaml
@@ -210,7 +210,6 @@ jobs:
     permissions:
       contents: read
     env:
-      MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
       MOOG_WALLET_FILE: wallet.json
       MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
       MOOG_PLATFORM: github
@@ -267,6 +266,8 @@ jobs:
           TXID=$(echo "$RESULT" | jq -e .txHash | jq -r .)
           echo "id=$ID" >> "$GITHUB_OUTPUT"
           echo "txHash=$TXID" >> "$GITHUB_OUTPUT"
+        env:
+          MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
 
       - name: Wait for results
         run: timeout $(((DURATION + 1) * 3600)) ./antithesis/scripts/wait-for-test.sh "${{ steps.request.outputs.id }}"

--- a/.github/workflows/antithesis-leios.yaml
+++ b/.github/workflows/antithesis-leios.yaml
@@ -206,8 +206,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-images, check-moog-secrets]
     if: needs['check-moog-secrets'].outputs.available == 'true'
+    timeout-minutes: 180
     permissions:
       contents: read
+    env:
+      MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
+      MOOG_WALLET_FILE: wallet.json
+      MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
+      MOOG_PLATFORM: github
+      MOOG_REQUESTER: ${{ vars.MOOG_REQUESTER }}
+      MOOG_TOKEN_ID: ${{ vars.MOOG_TOKEN_ID || '21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b' }} # not a secret
+      DURATION: 1
 
     steps:
       - name: Checkout repository
@@ -240,18 +249,24 @@ jobs:
           MOOG_WALLET: ${{ secrets.MOOG_REQUESTER_WALLET }}
 
       - name: Submit test to Antithesis
+        id: request
         run: |
-          echo "Submitting Antithesis test for commit ${GITHUB_SHA}..."
-          moog requester create-test \
+          set -euo pipefail
+          TRY=$(moog facts test-runs --whose "$MOOG_REQUESTER" \
+            | jq --arg sha "$GITHUB_SHA" 'map(select(.key.commitId == $sha)) | length')
+          TRY=$((TRY + 1))
+          echo "Submitting Antithesis test for commit ${GITHUB_SHA} (try $TRY, duration ${DURATION}h)..."
+          RESULT=$(moog requester create-test \
             -d "antithesis/testnets/leios-devnet" \
             -c "${GITHUB_SHA}" \
             -r "${GITHUB_REPOSITORY}" \
-            -t 1 \
-            -y 1
-        env:
-          MOOG_GITHUB_PAT: ${{ secrets.MOOG_GITHUB_PAT }}
-          MOOG_WALLET_FILE: wallet.json
-          MOOG_MPFS_HOST: ${{ vars.MOOG_MPFS_HOST || 'https://mpfs.plutimus.com' }}
-          MOOG_PLATFORM: github
-          MOOG_REQUESTER: ${{ vars.MOOG_REQUESTER }}
-          MOOG_TOKEN_ID: ${{ vars.MOOG_TOKEN_ID || '21c523c3b4565f1fc1ad7e54e82ca976f60997d8e7e9946826813fabf341069b' }} # not a secret
+            --try "$TRY" \
+            -t "$DURATION")
+          echo "$RESULT"
+          ID=$(echo "$RESULT" | jq -e .value.testRunId | jq -r .)
+          TXID=$(echo "$RESULT" | jq -e .txHash | jq -r .)
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "txHash=$TXID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for results
+        run: timeout $(((DURATION + 1) * 3600)) ./antithesis/scripts/wait-for-test.sh "${{ steps.request.outputs.id }}"

--- a/antithesis/scripts/wait-for-test.sh
+++ b/antithesis/scripts/wait-for-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Poll Moog for Antithesis test results.
+# Usage: wait-for-test.sh <testRunId>
+# Exits 0 on success, 1 on rejection/failure/unknown.
+set -euo pipefail
+
+ID="$1"
+
+# Wallet auth isn't needed for read-only queries
+unset MOOG_WALLET_FILE
+
+function query_run() { moog facts test-runs --test-run-id "$ID"; }
+
+# Phase 1: wait for acceptance (fast poll)
+echo "Waiting to be accepted..."
+while true; do
+  RESULT=$(query_run)
+  echo "current status: $RESULT"
+  STATUS=$(echo "$RESULT" | jq -r '.[0].value.phase')
+  case $STATUS in
+    accepted)
+      echo "accepted"
+      break
+      ;;
+    rejected)
+      echo "rejected"
+      exit 1
+      ;;
+    finished)
+      echo "already finished"
+      break
+      ;;
+    pending)
+      ;;
+    *)
+      echo "unknown status: $STATUS"
+      ;;
+  esac
+  sleep 10
+  echo "..."
+done
+
+# Phase 2: wait for completion (slow poll)
+echo "Waiting to finish..."
+while true; do
+  RESULT=$(query_run)
+  echo "current status: $RESULT"
+  STATUS=$(echo "$RESULT" | jq -r '.[0].value.phase')
+  case $STATUS in
+    finished)
+      echo "finished"
+      break
+      ;;
+    accepted)
+      ;;
+    *)
+      echo "unknown status: $STATUS"
+      ;;
+  esac
+  sleep 60
+  echo "..."
+done
+
+# Final outcome check
+RESULT=$(query_run)
+echo "final result: $RESULT"
+case $(echo "$RESULT" | jq -r '.[0].value.outcome') in
+  success)
+    exit 0
+    ;;
+  failure)
+    echo "failed"
+    exit 1
+    ;;
+  *)
+    echo "unknown outcome"
+    exit 1
+    ;;
+esac

--- a/antithesis/scripts/wait-for-test.sh
+++ b/antithesis/scripts/wait-for-test.sh
@@ -5,6 +5,11 @@
 # Exits 0 on success, 1 on rejection/failure/unknown.
 set -euo pipefail
 
+if [ "$#" -ne 1 ]; then
+  echo "error: expected exactly 1 argument: <testRunId>" >&2
+  echo "usage: wait-for-test.sh <testRunId>" >&2
+  exit 1
+fi
 ID="$1"
 
 # Wallet auth isn't needed for read-only queries


### PR DESCRIPTION
Add a two-phase polling script (wait-for-test.sh) that monitors Antithesis test status via Moog:
- Phase 1: poll every 10s until the test is accepted or rejected
- Phase 2: poll every 60s until the test finishes
- Final check: exit 0 on success, 1 on failure/unknown

Also hoists Moog env vars to job level, auto-increments the try counter per commit, and caps the job at 180 minutes.

Adapted from cardano-foundation/cardano-node-antithesis.