### PR TITLE
DeltaQ: fix used quantities

### DIFF
--- a/analysis/deltaq/linear-leios/src/DeltaQ/Leios.hs
+++ b/analysis/deltaq/linear-leios/src/DeltaQ/Leios.hs
@@ -44,6 +44,7 @@ import qualified Numeric.Measure.Finite.Mixed as M
 -- | fetchingEB
 --
 -- TODO: Model FFD
+-- REVIEW(SN): These are 512kB, 1024kB and 2048kB respectively. EB bodies are <= 512kB per CIP-164
 fetchingEB :: DQ
 fetchingEB = choices [(1, blendedDelay B512), (1, blendedDelay B1024), (1, blendedDelay B2048)]
 
@@ -75,7 +76,7 @@ fetchingTx :: Double -> DQ
 fetchingTx p =
   choices
     [ (hitRate, wait 0.001)
-    , (1 - hitRate, blendedDelay B1024)
+    , (1 - hitRate, blendedDelay B1024) -- REVIEW(SN): This is a 1024kB transaction transfer
     ]
  where
   -- Steady-state hit rate
@@ -100,7 +101,7 @@ txCache :: M.Measure Rational
 txCache = M.add (M.scale π_1 blendedDelay') (M.scale π_2 (M.dirac 0.001))
  where
   blendedDelay' :: M.Measure Rational
-  blendedDelay' = fromJust $ M.fromDistribution (PW.distribution (blendedDelay B1024))
+  blendedDelay' = fromJust $ M.fromDistribution (PW.distribution (blendedDelay B1024)) -- REVIEW(SN): This is a 1024kB transaction transfer
   π_1 = (2 - p) / (2 + p)
   π_2 = 2 * p / (2 + p)
   p = 0.75
@@ -116,6 +117,7 @@ txCache' = measuredDQ pairs
       [0.0, 1.0, 2.0, 5.0, 7.0]
       (\i -> let fi = successWithin dq i in fi * (1 % n) * (1 - fi ^ n) / (1 - fi))
 
+-- REVIEW(SN): An RB may contain txs OR a cert; not both!
 processRBandEB :: DQ
 processRBandEB = processRB ./\. processEB
  where

--- a/analysis/deltaq/linear-leios/src/DeltaQ/Leios.hs
+++ b/analysis/deltaq/linear-leios/src/DeltaQ/Leios.hs
@@ -13,7 +13,6 @@ module DeltaQ.Leios (
   -- * Probabilities
   pValidating,
   pHeaderOnTime,
-  pEBOnTime,
 ) where
 
 import Data.Maybe (fromJust)
@@ -36,17 +35,23 @@ import qualified DeltaQ.PiecewisePolynomial as PW
 import DeltaQ.Praos (
   BlockSize (..),
   blendedDelay,
-  sendRBBody,
   sendRBHeader,
+  sendTxRBBody,
  )
 import qualified Numeric.Measure.Finite.Mixed as M
 
 -- | fetchingEB
 --
 -- TODO: Model FFD
--- REVIEW(SN): These are 512kB, 1024kB and 2048kB respectively. EB bodies are <= 512kB per CIP-164
+-- NOTE(SN): EBs may be up to 512kB in size.
 fetchingEB :: DQ
-fetchingEB = choices [(1, blendedDelay B512), (1, blendedDelay B1024), (1, blendedDelay B2048)]
+fetchingEB =
+  choices
+    [ (1, blendedDelay B1)
+    , (1, blendedDelay B64)
+    , (1, blendedDelay B256)
+    , (1, blendedDelay B512)
+    ]
 
 -- | fetchingTx
 --
@@ -76,7 +81,7 @@ fetchingTx :: Double -> DQ
 fetchingTx p =
   choices
     [ (hitRate, wait 0.001)
-    , (1 - hitRate, blendedDelay B1024) -- REVIEW(SN): This is a 1024kB transaction transfer
+    , (1 - hitRate, blendedDelay B1) -- NOTE(SN): Current mean of tx size is ~1kB
     ]
  where
   -- Steady-state hit rate
@@ -101,7 +106,8 @@ txCache :: M.Measure Rational
 txCache = M.add (M.scale π_1 blendedDelay') (M.scale π_2 (M.dirac 0.001))
  where
   blendedDelay' :: M.Measure Rational
-  blendedDelay' = fromJust $ M.fromDistribution (PW.distribution (blendedDelay B1024)) -- REVIEW(SN): This is a 1024kB transaction transfer
+  -- FIXME(SN): This is still a 1024kB transaction transfer. But lower values result in a 0 denominator?
+  blendedDelay' = fromJust $ M.fromDistribution (PW.distribution (blendedDelay B1024))
   π_1 = (2 - p) / (2 + p)
   π_2 = 2 * p / (2 + p)
   p = 0.75
@@ -121,7 +127,7 @@ txCache' = measuredDQ pairs
 processRBandEB :: DQ
 processRBandEB = processRB ./\. processEB
  where
-  processRB = sendRBBody .>>. applyTxs
+  processRB = sendTxRBBody .>>. applyTxs
   processEB = fetchingEB .>>. fetchingTxs
 
 -- | Distribution of EB validation time
@@ -150,17 +156,6 @@ pHeaderOnTime ::
 pHeaderOnTime lHdr =
   successWithin
     sendRBHeader
-    (fromIntegral lHdr)
-
--- | Probability that 'emitRBHeader' is within \(L_\text{hdr}\)
-pEBOnTime ::
-  -- | \(L_\text{hdr}\)
-  Integer ->
-  -- | Probability that the RB header is within \(L_\text{hdr}\)
-  Probability DQ
-pEBOnTime lHdr =
-  successWithin
-    fetchingEB
     (fromIntegral lHdr)
 
 -- | Probability that 'validateEB' is successful before the end of \(L_\text{vote}\)

--- a/analysis/deltaq/linear-leios/src/DeltaQ/Praos.hs
+++ b/analysis/deltaq/linear-leios/src/DeltaQ/Praos.hs
@@ -7,7 +7,8 @@ module DeltaQ.Praos (
 
   -- * DeltaQ
   sendRBHeader,
-  sendRBBody,
+  sendCertRBBody,
+  sendTxRBBody,
 
   -- * Utils
   blockSizes,
@@ -17,13 +18,14 @@ module DeltaQ.Praos (
 import DeltaQ (DQ, Outcome (wait), ProbabilisticOutcome (choices))
 import DeltaQ.Common (doSequentially)
 
-data BlockSize = B64 | B256 | B512 | B1024 | B2048
+data BlockSize = B1 | B64 | B256 | B512 | B1024 | B2048
   deriving (Show, Eq)
 
 blockSizes :: [BlockSize]
-blockSizes = [B64, B256, B512, B1024, B2048]
+blockSizes = [B1, B64, B256, B512, B1024, B2048]
 
 short :: BlockSize -> DQ
+short B1 = wait 0.012 -- HACK(SN): one RTT
 short B64 = wait 0.024
 short B256 = wait 0.047
 short B512 = wait 0.066
@@ -31,6 +33,7 @@ short B1024 = wait 0.078
 short B2048 = wait 0.085
 
 medium :: BlockSize -> DQ
+medium B1 = wait 0.069 -- HACK(SN): one RTT
 medium B64 = wait 0.143
 medium B256 = wait 0.271
 medium B512 = wait 0.332
@@ -38,6 +41,7 @@ medium B1024 = wait 0.404
 medium B2048 = wait 0.469
 
 long :: BlockSize -> DQ
+long B1 = wait 0.268 -- HACK(SN): one RTT
 long B64 = wait 0.531
 long B256 = wait 1.067
 long B512 = wait 1.598
@@ -67,12 +71,14 @@ lengthProbsNode10 = [(1, 0.40), (2, 3.91), (3, 31.06), (4, 61.85), (5, 2.78)]
 blendedDelay :: BlockSize -> DQ
 blendedDelay b = choices $ map (\(n, p) -> (p, hops n b)) lengthProbsNode10
 
--- REVIEW(SN): B64 is 64kB blocks according to
--- https://github.com/IntersectMBO/cardano-formal-specifications/blob/main/src/performance/app/PraosModel.lhs
+-- NOTE(SN): A block header is ~1000B
 sendRBHeader :: DQ
-sendRBHeader = blendedDelay B64
+sendRBHeader = blendedDelay B1
 
--- REVIEW(SN): B1024 is 1024kB blocks according to
--- https://github.com/IntersectMBO/cardano-formal-specifications/blob/main/src/performance/app/PraosModel.lhs
-sendRBBody :: DQ
-sendRBBody = blendedDelay B1024
+-- NOTE(SN): A CertRB is ~500B
+sendCertRBBody :: DQ
+sendCertRBBody = blendedDelay B1
+
+-- TODO(SN): A full praos block / TxRB can be up to 80kB
+sendTxRBBody :: DQ
+sendTxRBBody = blendedDelay B64

--- a/analysis/deltaq/linear-leios/src/DeltaQ/Praos.hs
+++ b/analysis/deltaq/linear-leios/src/DeltaQ/Praos.hs
@@ -67,8 +67,12 @@ lengthProbsNode10 = [(1, 0.40), (2, 3.91), (3, 31.06), (4, 61.85), (5, 2.78)]
 blendedDelay :: BlockSize -> DQ
 blendedDelay b = choices $ map (\(n, p) -> (p, hops n b)) lengthProbsNode10
 
+-- REVIEW(SN): B64 is 64kB blocks according to
+-- https://github.com/IntersectMBO/cardano-formal-specifications/blob/main/src/performance/app/PraosModel.lhs
 sendRBHeader :: DQ
 sendRBHeader = blendedDelay B64
 
+-- REVIEW(SN): B1024 is 1024kB blocks according to
+-- https://github.com/IntersectMBO/cardano-formal-specifications/blob/main/src/performance/app/PraosModel.lhs
 sendRBBody :: DQ
 sendRBBody = blendedDelay B1024


### PR DESCRIPTION
When reproducing the [results of deltaq report](https://github.com/input-output-hk/ouroboros-leios/blob/main/analysis/deltaq/linear-leios/docs/report.md) this week, I noticed that potentially wrong number were used for transmitted data.