### PR TITLE
Nixify formal-spec enhancement step in CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -220,26 +220,11 @@ jobs:
           cp result/leios-design.pdf site/static/ 
           ls -la site/static/leios-design.pdf
 
-      - name: 📚 Build formal-spec HTML documentation
+      - name: 📚 Build enhanced formal-spec HTML documentation
         run: |
-          nix build .#leiosDocs
-          mkdir -p formal-spec-html
-          cp -r result/html/* formal-spec-html/
-          chmod -R +w formal-spec-html/
-          ls -la formal-spec-html/
-
-      - name: 🔄 Enhance formal-spec with interactive features
-        uses: will-break-it/agda-web-docs-lib@v1
-        with:
-          input-dir: formal-spec-html
-          config-file: site/agda-docs.config.json
-          cache-dependency-path: site/package-lock.json
-          node-options: "--max-old-space-size=8192 --expose-gc"
-
-      - name: 📦 Copy enhanced formal-spec to site
-        run: |
+          nix build .#enhancedLeiosDocs -L
           mkdir -p site/static/formal-spec
-          cp -r formal-spec-html/* site/static/formal-spec/
+          cp -r result/* site/static/formal-spec/
           echo "Formal spec files copied:"
           ls -la site/static/formal-spec/ | head -20
 

--- a/nix/agda-web-docs-lib.nix
+++ b/nix/agda-web-docs-lib.nix
@@ -1,0 +1,57 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+pkgs.buildNpmPackage {
+  pname = "agda-web-docs-lib";
+  version = "1.0.8";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "will-break-it";
+    repo = "agda-web-docs-lib";
+    rev = "v1.0.8";
+    hash = "sha256-mTUzYz6ET+bmJ9K6ZbZuFMtkpJDIGkytA8wXgvnp9Xk=";
+  };
+
+  npmDepsHash = "sha256-SObPqlkvsAFfByWj+h8CPfSIBrlGofaObqslGyJtsMM=";
+
+  # Patch copyFileSync calls to chmod the destination writable afterwards.
+  # Without this, files copied from the nix store inherit read-only permissions
+  # and subsequent overwrites fail.
+  postPatch = ''
+    substituteInPlace src/cli.ts \
+      --replace-fail \
+        'fs.copyFileSync(sourcePath, destPath);' \
+        'fs.copyFileSync(sourcePath, destPath); fs.chmodSync(destPath, 0o644);' \
+      --replace-fail \
+        "fs.copyFileSync(searchScriptPath, path.join(outputDir, 'search.js'));" \
+        "fs.copyFileSync(searchScriptPath, path.join(outputDir, 'search.js')); fs.chmodSync(path.join(outputDir, 'search.js'), 0o644);"
+  '';
+
+  # The build script: tsc && cp -r src/styles dist/ && cp -r src/scripts dist/
+  buildPhase = ''
+    npm run build
+  '';
+
+  # Install the CLI and its runtime dependencies
+  dontNpmInstall = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/node_modules/agda-web-docs-lib
+    cp -r dist $out/lib/node_modules/agda-web-docs-lib/
+    cp -r node_modules $out/lib/node_modules/agda-web-docs-lib/
+    cp package.json $out/lib/node_modules/agda-web-docs-lib/
+
+    mkdir -p $out/bin
+    ln -s $out/lib/node_modules/agda-web-docs-lib/dist/cli.js $out/bin/agda-docs
+  '';
+
+  meta = {
+    description = "Library for enhancing Agda-generated HTML documentation with interactive features";
+    homepage = "https://github.com/will-break-it/agda-web-docs-lib";
+    license = lib.licenses.mit;
+    mainProgram = "agda-docs";
+  };
+}

--- a/nix/agda.nix
+++ b/nix/agda.nix
@@ -21,6 +21,40 @@ let
     leiosDocs
     ;
 
+  agda-web-docs-lib = import ./agda-web-docs-lib.nix { inherit pkgs lib; };
+
+  enhancedLeiosDocs = pkgs.stdenv.mkDerivation {
+    name = "enhanced-leios-docs";
+    src = leiosDocs;
+    nativeBuildInputs = [ agda-web-docs-lib ];
+
+    configFile = pkgs.writeText "agda-docs.config.json" (
+      builtins.toJSON {
+        backButtonUrl = "/formal-spec/";
+        modules = [
+          "Leios"
+          "Cardano"
+          "Network"
+          "Ouroboros"
+        ];
+        githubUrl = "https://github.com/input-output-hk/ouroboros-leios-formal-spec";
+      }
+    );
+
+    buildPhase = ''
+      mkdir -p build
+      cp -r html/* build/
+      chmod -R u+w build/
+
+      agda-docs process -i build -c $configFile
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r build/* $out/
+    '';
+  };
+
   agdaWithDeps = agdaWithPkgs.withPackages (p: [
     p.standard-library
     p.standard-library-classes
@@ -72,5 +106,5 @@ in
     ;
 }
 // lib.optionalAttrs (system != "aarch64-linux") {
-  inherit leiosDocs;
+  inherit leiosDocs enhancedLeiosDocs;
 }


### PR DESCRIPTION
This prevents re-building and re-processing of the formal spec html
files when the sources did not change (via a nix cache hit)