### PR TITLE
simple TCP model for sim-rs

### DIFF
--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -607,8 +607,9 @@
       "type": "boolean"
     },
     "tcp-congestion-control": {
-      "description": "Only supported by Haskell simulation.",
-      "type": "boolean"
+      "description": "Use the TCP congestion-window model for all links (slow-start, bandwidth-delay product, ACK pipelining). Supported by both Haskell and Rust simulations.",
+      "type": "boolean",
+      "default": true
     },
     "shard-count": {
       "description": "Number of clock shards for parallel simulation. Each shard advances time independently.\nOnly supported by Rust simulation.",

--- a/sim-rs/sim-cli/src/main.rs
+++ b/sim-rs/sim-cli/src/main.rs
@@ -86,9 +86,11 @@ fn read_config(args: &Args) -> Result<SimConfiguration> {
     };
     topology.validate()?;
 
-    let mut raw_params = Figment::new().merge(Yaml::string(include_str!(
-        "../../parameters/config.default.yaml"
-    )));
+    let mut raw_params = Figment::new()
+        .merge(Yaml::string(include_str!(
+            "../../parameters/config.default.yaml"
+        )))
+        .merge(Yaml::string("tcp-congestion-control: false"));
 
     for params_file in &args.parameters {
         raw_params = raw_params.merge(Yaml::file_exact(params_file));

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -1295,7 +1295,7 @@ fn duration_ms(ms: f64) -> Duration {
 }
 
 fn default_tcp_congestion_control() -> bool {
-    true
+    false
 }
 
 fn default_shard_count() -> usize {

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -176,6 +176,8 @@ pub struct RawParameters {
     pub leios_variant: LeiosVariant,
     pub relay_strategy: RelayStrategy,
     pub simulate_transactions: bool,
+    #[serde(default = "default_tcp_congestion_control")]
+    pub tcp_congestion_control: bool,
     pub timestamp_resolution_ms: f64,
     #[serde(default = "default_shard_count")]
     pub shard_count: usize,
@@ -1200,7 +1202,10 @@ impl SimConfiguration {
             retry_vote_in_window: params.retry_vote_in_window,
             trace_nodes: HashSet::new(),
             nodes: topology.nodes,
-            links: topology.links,
+            links: topology.links.into_iter().map(|mut lc| {
+                lc.use_tcp = params.tcp_congestion_control;
+                lc
+            }).collect(),
             stage_length: params.leios_stage_length_slots,
             max_eb_age: params.eb_max_age_slots,
             late_ib_inclusion: params.leios_late_ib_inclusion,
@@ -1287,6 +1292,10 @@ fn resolve_consensus_behaviours(
 
 fn duration_ms(ms: f64) -> Duration {
     Duration::from_secs_f64(ms / 1000.0)
+}
+
+fn default_tcp_congestion_control() -> bool {
+    true
 }
 
 fn default_shard_count() -> usize {

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -644,6 +644,7 @@ impl From<RawTopology> for Topology {
                         nodes: (ids[0], ids[1]),
                         latency: duration_ms(producer_info.latency_ms),
                         bandwidth_bps: producer_info.bandwidth_bytes_per_second,
+                        use_tcp: false,
                     },
                 );
             }
@@ -1338,6 +1339,9 @@ pub struct LinkConfiguration {
     pub nodes: (NodeId, NodeId),
     pub latency: Duration,
     pub bandwidth_bps: Option<u64>,
+    /// Use the TCP congestion-window model for this link instead of the
+    /// simple bandwidth-sharing model.
+    pub use_tcp: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/sim-rs/sim-core/src/lib.rs
+++ b/sim-rs/sim-core/src/lib.rs
@@ -7,3 +7,4 @@ pub mod probability;
 pub mod rng;
 mod sharding;
 pub mod sim;
+pub mod tcp;

--- a/sim-rs/sim-core/src/network.rs
+++ b/sim-rs/sim-core/src/network.rs
@@ -12,6 +12,7 @@ use crate::{
 pub(crate) mod connection;
 pub(crate) mod coordinator;
 pub mod stats;
+pub(crate) mod tcp_connection;
 
 /// Maps a node ID to its shard index.
 pub type ShardLookup = Arc<HashMap<NodeId, usize>>;
@@ -38,18 +39,21 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
         to: NodeId,
         latency: Duration,
         bandwidth_bps: Option<u64>,
+        use_tcp: bool,
     ) -> Result<()> {
         self.coordinator.add_edge(EdgeConfig {
             from,
             to,
             latency,
             bandwidth_bps,
+            use_tcp,
         });
         self.coordinator.add_edge(EdgeConfig {
             from: to,
             to: from,
             latency,
             bandwidth_bps,
+            use_tcp,
         });
         Ok(())
     }
@@ -61,8 +65,10 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
         to: NodeId,
         latency: Duration,
         bandwidth_bps: Option<u64>,
+        use_tcp: bool,
     ) {
-        self.coordinator.add_edge(EdgeConfig { from, to, latency, bandwidth_bps });
+        self.coordinator
+            .add_edge(EdgeConfig { from, to, latency, bandwidth_bps, use_tcp });
     }
 
     /// Set up direct cross-shard routing: this NC sends directly to target NCs.

--- a/sim-rs/sim-core/src/network/connection.rs
+++ b/sim-rs/sim-core/src/network/connection.rs
@@ -3,7 +3,9 @@ use std::{
     time::Duration,
 };
 
-use crate::clock::Timestamp;
+use crate::{clock::Timestamp, tcp::TcpConnProps};
+
+use super::tcp_connection::{DEFAULT_TCP_BANDWIDTH, TcpConnection};
 
 struct MiniProtocolQueue<T> {
     queue: VecDeque<(T, u64)>,
@@ -543,5 +545,73 @@ mod tests {
             ],
         );
         assert_eq!(conn.next_arrival_time(), None);
+    }
+}
+
+// ── Connection kind ───────────────────────────────────────────────────────────
+
+/// Either a bandwidth-sharing connection or a TCP congestion-window connection.
+///
+/// Both present the same interface so the rest of the network layer can treat
+/// them uniformly.
+pub enum ConnectionKind<TProtocol, TMessage> {
+    /// Fair-bandwidth-sharing model (the existing `Connection`).
+    Simple(Connection<TProtocol, TMessage>),
+    /// TCP congestion-window model (`TcpConnection`).  The `TProtocol` tag is
+    /// accepted for API compatibility but ignored — all protocols share the
+    /// single TCP stream, matching real TCP mux behaviour.
+    Tcp(TcpConnection<TMessage>),
+}
+
+impl<TProtocol: Clone + Ord, TMessage> ConnectionKind<TProtocol, TMessage> {
+    pub fn simple(latency: Duration, bandwidth_bps: Option<u64>) -> Self {
+        Self::Simple(Connection::new(latency, bandwidth_bps))
+    }
+
+    pub fn tcp(latency: Duration, bandwidth_bps: Option<u64>) -> Self {
+        let bandwidth = bandwidth_bps.unwrap_or(DEFAULT_TCP_BANDWIDTH);
+        Self::Tcp(TcpConnection::new(TcpConnProps::new(latency, bandwidth)))
+    }
+
+    pub fn from_config(latency: Duration, bandwidth_bps: Option<u64>, use_tcp: bool) -> Self {
+        if use_tcp {
+            Self::tcp(latency, bandwidth_bps)
+        } else {
+            Self::simple(latency, bandwidth_bps)
+        }
+    }
+
+    pub fn send(
+        &mut self,
+        message: TMessage,
+        bytes: u64,
+        protocol: TProtocol,
+        now: Timestamp,
+    ) {
+        match self {
+            Self::Simple(c) => c.send(message, bytes, protocol, now),
+            Self::Tcp(c) => c.send(message, bytes, now),
+        }
+    }
+
+    pub fn next_arrival_time(&self) -> Option<Timestamp> {
+        match self {
+            Self::Simple(c) => c.next_arrival_time(),
+            Self::Tcp(c) => c.next_arrival_time(),
+        }
+    }
+
+    pub fn recv_many(&mut self, now: Timestamp) -> Vec<(TMessage, Timestamp)> {
+        match self {
+            Self::Simple(c) => c.recv_many(now),
+            Self::Tcp(c) => c.recv_many(now),
+        }
+    }
+
+    pub fn queue_stats(&self) -> (usize, u64) {
+        match self {
+            Self::Simple(c) => c.queue_stats(),
+            Self::Tcp(c) => c.queue_stats(),
+        }
     }
 }

--- a/sim-rs/sim-core/src/network/coordinator.rs
+++ b/sim-rs/sim-core/src/network/coordinator.rs
@@ -16,7 +16,7 @@ use crate::{
     config::NodeId,
 };
 
-use super::connection::Connection;
+use super::connection::ConnectionKind;
 
 /// Tuple sent directly from source NC to target NC for cross-shard messages.
 pub type CrossShardDelivery<TProtocol, TMessage> = (NodeId, NodeId, TProtocol, TMessage, u64, Timestamp);
@@ -24,7 +24,7 @@ pub type CrossShardDelivery<TProtocol, TMessage> = (NodeId, NodeId, TProtocol, T
 pub struct NetworkCoordinator<TProtocol, TMessage> {
     source: mpsc::UnboundedReceiver<Message<TProtocol, TMessage>>,
     sinks: HashMap<NodeId, mpsc::UnboundedSender<(NodeId, TMessage)>>,
-    connections: HashMap<Link, Connection<TProtocol, TMessage>>,
+    connections: HashMap<Link, ConnectionKind<TProtocol, TMessage>>,
     events: PriorityQueue<Link, Reverse<Timestamp>>,
     local_nodes: HashSet<NodeId>,
     /// Per-shard delivery sinks for sending cross-shard messages directly to target NCs.
@@ -45,6 +45,7 @@ pub struct EdgeConfig {
     pub to: NodeId,
     pub latency: Duration,
     pub bandwidth_bps: Option<u64>,
+    pub use_tcp: bool,
 }
 
 impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> NetworkCoordinator<TProtocol, TMessage> {
@@ -90,7 +91,11 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> NetworkCoordinator<TPr
             from: config.from,
             to: config.to,
         };
-        let connection = Connection::new(config.latency, config.bandwidth_bps);
+        let connection = ConnectionKind::from_config(
+            config.latency,
+            config.bandwidth_bps,
+            config.use_tcp,
+        );
         self.connections.insert(link, connection);
     }
 

--- a/sim-rs/sim-core/src/network/tcp_connection.rs
+++ b/sim-rs/sim-core/src/network/tcp_connection.rs
@@ -1,0 +1,108 @@
+//! TCP congestion-window channel — the Rust counterpart of Haskell's
+//! `Chan/TCP.hs`.
+//!
+//! `TcpConnection<TMessage>` models one direction of a full-duplex TCP link.
+//! Callers feed it messages via [`TcpConnection::send`]; the model applies
+//! `forecast_tcp_msg_send` to derive arrival times and queues each message for
+//! later retrieval via [`TcpConnection::recv_many`].
+//!
+//! ## Backpressure / serialisation ordering
+//!
+//! The Haskell implementation uses a one-slot `TMVar` as a send buffer,
+//! preventing the next message from entering the serialiser until the current
+//! one finishes.  Here we achieve the same effect with a `send_cursor`:
+//! whenever a new message arrives we use `max(now, send_cursor)` as the
+//! effective send time so that overlapping sends are automatically queued
+//! behind their predecessor.
+//!
+//! ## Idle reset (RFC 6298 RTO)
+//!
+//! When the connection has been idle for longer than `max(1 s, RTT)` and all
+//! in-flight ACKs have already arrived, the congestion window is reset to the
+//! initial value — matching the Haskell `tcpIdleResetTime` logic.
+
+use std::{collections::VecDeque, time::Duration};
+
+use crate::{
+    clock::Timestamp,
+    tcp::{TcpConnProps, TcpState, forecast_tcp_msg_send},
+};
+
+/// Default bandwidth used when a TCP link has no explicit bandwidth cap.
+/// 1000 kB/s ≈ 8 Mbit/s (matches Haskell `kibibytes 1000`).
+pub const DEFAULT_TCP_BANDWIDTH: u64 = 1024 * 1000;
+
+/// One directional TCP channel.  Pair two of these (one per direction) to
+/// model a full-duplex link.
+pub struct TcpConnection<TMessage> {
+    props: TcpConnProps,
+    state: TcpState,
+    /// Earliest simulation time the serialiser is free for the next message.
+    /// `None` until the first message is sent.
+    send_cursor: Option<Timestamp>,
+    /// Messages awaiting delivery, ordered by arrival time.
+    latency_queue: VecDeque<(TMessage, Timestamp)>,
+}
+
+impl<TMessage> TcpConnection<TMessage> {
+    pub fn new(props: TcpConnProps) -> Self {
+        Self {
+            props,
+            state: TcpState::default(),
+            send_cursor: None,
+            latency_queue: VecDeque::new(),
+        }
+    }
+
+    /// Serialise `message` (`bytes` bytes) into the TCP stream at time `now`.
+    ///
+    /// If the serialiser is still busy from a previous message the send is
+    /// delayed until it is free.  The message is then queued with its computed
+    /// arrival time (`recv_trailing_edge` from the forecast).
+    pub fn send(&mut self, message: TMessage, bytes: u64, now: Timestamp) {
+        let effective_now = match self.send_cursor {
+            Some(cursor) => {
+                // Idle reset: if the link has been quiet for longer than the
+                // RTO threshold and all in-flight ACKs have returned, reset
+                // the congestion window (RFC 6298).
+                let idle_threshold =
+                    Duration::from_secs(1).max(self.props.latency * 2);
+                if now >= cursor + idle_threshold && self.state.all_acks_arrived(now) {
+                    self.state = TcpState::default();
+                }
+                now.max(cursor)
+            }
+            None => now,
+        };
+
+        let old_state = std::mem::replace(&mut self.state, TcpState::default());
+        let (forecast, _, new_state) =
+            forecast_tcp_msg_send(&self.props, old_state, effective_now, bytes);
+        self.state = new_state;
+        self.send_cursor = Some(forecast.send_trailing_edge);
+        self.latency_queue
+            .push_back((message, forecast.recv_trailing_edge));
+    }
+
+    pub fn next_arrival_time(&self) -> Option<Timestamp> {
+        self.latency_queue.front().map(|(_, ts)| *ts)
+    }
+
+    pub fn recv_many(&mut self, now: Timestamp) -> Vec<(TMessage, Timestamp)> {
+        let mut results = Vec::new();
+        while self
+            .latency_queue
+            .front()
+            .is_some_and(|(_, ts)| *ts <= now)
+        {
+            results.push(self.latency_queue.pop_front().unwrap());
+        }
+        results
+    }
+
+    /// Returns `(message_count, queued_bytes)`.
+    /// Byte tracking is not available for the latency queue so bytes is 0.
+    pub fn queue_stats(&self) -> (usize, u64) {
+        (self.latency_queue.len(), 0)
+    }
+}

--- a/sim-rs/sim-core/src/sharding/shard.rs
+++ b/sim-rs/sim-core/src/sharding/shard.rs
@@ -93,15 +93,29 @@ where
         if from_shard == to_shard {
             // Intra-shard: both directions
             networks[from_shard]
-                .set_edge_policy(from, to, link_config.latency, link_config.bandwidth_bps)
+                .set_edge_policy(
+                    from,
+                    to,
+                    link_config.latency,
+                    link_config.bandwidth_bps,
+                    link_config.use_tcp,
+                )
                 .expect("failed to set edge policy");
         } else {
             // Cross-shard: incoming connections on each target shard's NC
             networks[to_shard].add_incoming_edge(
-                from, to, link_config.latency, link_config.bandwidth_bps,
+                from,
+                to,
+                link_config.latency,
+                link_config.bandwidth_bps,
+                link_config.use_tcp,
             );
             networks[from_shard].add_incoming_edge(
-                to, from, link_config.latency, link_config.bandwidth_bps,
+                to,
+                from,
+                link_config.latency,
+                link_config.bandwidth_bps,
+                link_config.use_tcp,
             );
         }
     }

--- a/sim-rs/sim-core/src/sim/sequential.rs
+++ b/sim-rs/sim-core/src/sim/sequential.rs
@@ -16,7 +16,7 @@ use crate::{
     config::{LeiosVariant, NodeId, SimConfiguration},
     events::EventTracker,
     model::Transaction,
-    network::{connection::Connection, stats::NetworkStatsCollector},
+    network::{connection::ConnectionKind, stats::NetworkStatsCollector},
     sim::{
         MiniProtocol, NodeImpl, SimMessage as _,
         common::{CpuTaskWrapper, NodeEvent, self},
@@ -209,7 +209,7 @@ struct CrossShardState<M> {
 pub(super) struct SequentialSimulation<N: NodeImpl> {
     nodes: Vec<NodeState<N>>,
     node_indices: HashMap<NodeId, usize>,
-    connections: HashMap<Link, Connection<MiniProtocol, N::Message>>,
+    connections: HashMap<Link, ConnectionKind<MiniProtocol, N::Message>>,
     event_queue: BinaryHeap<FutureEvent<GlobalEvent<N>>>,
     pending_deliveries: HashSet<Link>,
     tx_generator: TxGeneratorCore,
@@ -550,7 +550,7 @@ impl<N: NodeImpl> SequentialSimulation<N> {
     /// shards no longer leaks into the simulation state trajectory.
     fn drain_cross_shard_safe(
         cs: &mut CrossShardState<N::Message>,
-        connections: &mut HashMap<Link, Connection<MiniProtocol, N::Message>>,
+        connections: &mut HashMap<Link, ConnectionKind<MiniProtocol, N::Message>>,
         pending_deliveries: &mut HashSet<Link>,
         event_queue: &mut BinaryHeap<FutureEvent<GlobalEvent<N>>>,
         timestamp_resolution: Duration,
@@ -589,7 +589,7 @@ impl<N: NodeImpl> SequentialSimulation<N> {
     /// `drain_cross_shard_safe`.
     fn wait_for_cross_shard_and_deliver_safe(
         cs: &mut CrossShardState<N::Message>,
-        connections: &mut HashMap<Link, Connection<MiniProtocol, N::Message>>,
+        connections: &mut HashMap<Link, ConnectionKind<MiniProtocol, N::Message>>,
         pending_deliveries: &mut HashSet<Link>,
         event_queue: &mut BinaryHeap<FutureEvent<GlobalEvent<N>>>,
         timestamp_resolution: Duration,
@@ -614,7 +614,7 @@ impl<N: NodeImpl> SequentialSimulation<N> {
 
     /// Deliver a single cross-shard message into the local connection.
     fn deliver_cross_shard_msg(
-        connections: &mut HashMap<Link, Connection<MiniProtocol, N::Message>>,
+        connections: &mut HashMap<Link, ConnectionKind<MiniProtocol, N::Message>>,
         pending_deliveries: &mut HashSet<Link>,
         event_queue: &mut BinaryHeap<FutureEvent<GlobalEvent<N>>>,
         msg: CrossShardMsg<N::Message>,
@@ -973,7 +973,7 @@ where
         }
 
         // Build connections
-        let mut connections: HashMap<Link, Connection<MiniProtocol, N::Message>> = HashMap::new();
+        let mut connections: HashMap<Link, ConnectionKind<MiniProtocol, N::Message>> = HashMap::new();
         for lc in &config.links {
             let (from, to) = lc.nodes;
             let fs = shard_lookup[&from];
@@ -982,21 +982,21 @@ where
                 // Intra-shard (or single-shard): both directions
                 connections.insert(
                     Link { from, to },
-                    Connection::new(lc.latency, lc.bandwidth_bps),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
                 );
                 connections.insert(
                     Link { from: to, to: from },
-                    Connection::new(lc.latency, lc.bandwidth_bps),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
                 );
             } else if ts == shard_idx {
                 connections.insert(
                     Link { from, to },
-                    Connection::new(lc.latency, lc.bandwidth_bps),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
                 );
             } else if fs == shard_idx {
                 connections.insert(
                     Link { from: to, to: from },
-                    Connection::new(lc.latency, lc.bandwidth_bps),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
                 );
             }
         }

--- a/sim-rs/sim-core/src/tcp.rs
+++ b/sim-rs/sim-core/src/tcp.rs
@@ -1,0 +1,405 @@
+//! TCP congestion-window model.
+//!
+//! A direct port of the Haskell `simulation/src/ModelTCP.hs` module.
+//!
+//! The model forecasts send timing for a stream of messages over a single TCP
+//! connection, accounting for serialisation delay, one-way propagation latency,
+//! and the congestion window.  It does *not* model loss, retransmission, or
+//! delayed ACKs; those are out of scope for the simulation's fidelity target.
+//!
+//! ## Key approximation ("strategic cheat")
+//!
+//! ACK timestamps are anchored to the *receive leading edge*, not the trailing
+//! edge (see [`do_send`]).  In real TCP, per-segment ACKs start arriving one
+//! RTT after the sender begins transmitting; using the trailing edge instead
+//! would defer every window refill by one extra serialisation period, making
+//! the model systematically understate throughput when the congestion window is
+//! large relative to the bandwidth-delay product.
+
+use std::{cmp::Reverse, collections::BinaryHeap, time::Duration};
+
+use crate::clock::Timestamp;
+
+// ── Connection properties ────────────────────────────────────────────────────
+
+/// Fixed characteristics of a TCP link.
+#[derive(Debug, Clone)]
+pub struct TcpConnProps {
+    /// One-way propagation latency.
+    pub latency: Duration,
+    /// Sender serialisation rate (bytes per second).
+    pub bandwidth: u64,
+    /// Receiver window: hard cap on the congestion window size.
+    pub receiver_window: u64,
+}
+
+impl TcpConnProps {
+    /// Construct `TcpConnProps`, auto-sizing the receiver window to at least
+    /// 2 × the bandwidth–delay product so it never constrains throughput.
+    pub fn new(latency: Duration, bandwidth: u64) -> Self {
+        let bdp2 = (bandwidth as f64 * latency.as_secs_f64() * 2.0).ceil() as u64;
+        Self {
+            latency,
+            bandwidth,
+            receiver_window: bdp2.max(10 * SEGMENT_SIZE),
+        }
+    }
+}
+
+/// Canonical TCP maximum segment size (bytes).
+pub const SEGMENT_SIZE: u64 = 1460;
+
+/// Modern TCP initial congestion window: 10 segments (RFC 6928).
+const INITIAL_CONGESTION_WINDOW: u64 = 10 * SEGMENT_SIZE;
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+/// Per-connection mutable sender state.
+pub struct TcpState {
+    congestion_window: u64,
+    available_congestion_window: u64,
+    /// Min-heap of pending ACKs: `(arrival_time, bytes_freed)`.
+    acknowledgements: BinaryHeap<Reverse<(Timestamp, u64)>>,
+}
+
+impl Default for TcpState {
+    fn default() -> Self {
+        Self {
+            congestion_window: INITIAL_CONGESTION_WINDOW,
+            available_congestion_window: INITIAL_CONGESTION_WINDOW,
+            acknowledgements: BinaryHeap::new(),
+        }
+    }
+}
+
+// ── Forecast ─────────────────────────────────────────────────────────────────
+
+/// Timing forecast for one message or fragment.
+#[derive(Debug, Clone)]
+pub struct TcpMsgForecast {
+    /// Sender starts transmitting.
+    pub send_leading_edge: Timestamp,
+    /// Sender finishes transmitting.
+    pub send_trailing_edge: Timestamp,
+    /// First byte arrives at receiver.
+    pub recv_leading_edge: Timestamp,
+    /// Last byte arrives at receiver.
+    pub recv_trailing_edge: Timestamp,
+    /// Last ACK returns to sender.
+    pub acknowledgement: Timestamp,
+    pub size: u64,
+}
+
+/// A complete TCP send event: overall timing plus per-fragment breakdown.
+pub struct TcpEvent<M> {
+    pub msg: M,
+    pub overall: TcpMsgForecast,
+    pub fragments: Vec<TcpMsgForecast>,
+}
+
+// ── Core algorithm ───────────────────────────────────────────────────────────
+
+/// Forecast the timing of sending `msgsize` bytes starting at `now`.
+///
+/// Returns `(overall_forecast, fragment_forecasts, updated_state)`.  The
+/// overall forecast spans the bounding interval across all fragments.
+pub fn forecast_tcp_msg_send(
+    props: &TcpConnProps,
+    mut state: TcpState,
+    now: Timestamp,
+    msgsize: u64,
+) -> (TcpMsgForecast, Vec<TcpMsgForecast>, TcpState) {
+    let mut fragments: Vec<TcpMsgForecast> = Vec::new();
+    let mut now = now;
+    let mut remaining = msgsize;
+
+    loop {
+        if state.available_congestion_window == 0 {
+            (now, state) = wait_for_ack(props, now, state);
+            continue;
+        }
+        let send_size = remaining.min(state.available_congestion_window);
+        let fragment = do_send(props, &mut state, now, send_size);
+        now = fragment.send_trailing_edge;
+        remaining -= send_size;
+        fragments.push(fragment);
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    let merged = merge_adjacent_fragments(fragments);
+    let overall = merged
+        .iter()
+        .cloned()
+        .reduce(merge_forecasts)
+        .expect("at least one fragment");
+    (overall, merged, state)
+}
+
+/// Commit `send_size` bytes into the congestion window, derive timing, and
+/// schedule the returning ACK.  Mutates `state` in-place.
+fn do_send(
+    props: &TcpConnProps,
+    state: &mut TcpState,
+    now: Timestamp,
+    send_size: u64,
+) -> TcpMsgForecast {
+    let send_leading = now;
+    let send_trailing = now + serialisation_time(props.bandwidth, send_size);
+    let recv_leading = send_leading + props.latency;
+    let recv_trailing = send_trailing + props.latency;
+    // Strategic cheat: ACK is anchored to recv_leading, not recv_trailing.
+    // Per-segment ACKs in real TCP start returning after one RTT (2 × latency);
+    // using recv_trailing would add a full serialisation delay on top of that,
+    // understating how quickly the sender can refill the congestion window.
+    let ack_time = recv_leading + props.latency;
+
+    state.available_congestion_window -= send_size;
+    state.acknowledgements.push(Reverse((ack_time, send_size)));
+
+    TcpMsgForecast {
+        send_leading_edge: send_leading,
+        send_trailing_edge: send_trailing,
+        recv_leading_edge: recv_leading,
+        recv_trailing_edge: recv_trailing,
+        acknowledgement: ack_time,
+        size: send_size,
+    }
+}
+
+/// Pop the earliest pending ACK, advance `now` to its arrival time (if it
+/// hasn't arrived yet), process it, and drain any further ACKs that have
+/// already arrived by the new `now`.
+fn wait_for_ack(props: &TcpConnProps, now: Timestamp, mut state: TcpState) -> (Timestamp, TcpState) {
+    let Reverse((ack_ts, ack_bytes)) = state
+        .acknowledgements
+        .pop()
+        .expect("congestion window exhausted with no pending ACKs");
+
+    state = accum_ack(props, state, ack_bytes);
+
+    if ack_ts <= now {
+        // ACK already passed; drain any others that have arrived too.
+        (now, drain_arrived_acks(props, now, state))
+    } else {
+        // Advance time to when this ACK lands; remaining queue is untouched.
+        (ack_ts, state)
+    }
+}
+
+/// Pop and apply all ACKs whose arrival timestamp ≤ `now`.
+fn drain_arrived_acks(props: &TcpConnProps, now: Timestamp, mut state: TcpState) -> TcpState {
+    loop {
+        match state.acknowledgements.peek() {
+            Some(Reverse((ts, _))) if *ts <= now => {
+                let ack_bytes = state.acknowledgements.pop().unwrap().0 .1;
+                state = accum_ack(props, state, ack_bytes);
+            }
+            _ => return state,
+        }
+    }
+}
+
+/// Release `ack_bytes` from the in-flight count.  While the congestion window
+/// has not yet reached the receiver window (slow-start), also grow it.
+fn accum_ack(props: &TcpConnProps, mut state: TcpState, ack_bytes: u64) -> TcpState {
+    if state.congestion_window < props.receiver_window {
+        // Slow-start: each ACK grows the congestion window by the same amount,
+        // capped at the receiver window.
+        let new_cwnd = (state.congestion_window + ack_bytes).min(props.receiver_window);
+        let growth = new_cwnd - state.congestion_window;
+        state.available_congestion_window += ack_bytes + growth;
+        state.congestion_window = new_cwnd;
+    } else {
+        // Steady state: window is maxed at the receiver limit; just free the
+        // bytes that the ACK confirms are no longer in flight.
+        debug_assert_eq!(state.congestion_window, props.receiver_window);
+        state.available_congestion_window += ack_bytes;
+    }
+    state
+}
+
+// ── Forecast helpers ─────────────────────────────────────────────────────────
+
+/// Merge two logically-adjacent forecasts into one spanning both: leading
+/// edges from `a`, trailing edges and ACK from `b`.
+fn merge_forecasts(a: TcpMsgForecast, b: TcpMsgForecast) -> TcpMsgForecast {
+    TcpMsgForecast {
+        send_leading_edge: a.send_leading_edge,
+        send_trailing_edge: b.send_trailing_edge,
+        recv_leading_edge: a.recv_leading_edge,
+        recv_trailing_edge: b.recv_trailing_edge,
+        acknowledgement: b.acknowledgement,
+        size: a.size + b.size,
+    }
+}
+
+/// Collapse contiguous fragments — where the send trailing edge of one equals
+/// the send leading edge of the next — into single forecasts.  This keeps the
+/// fragment count bounded even across many window fills.
+fn merge_adjacent_fragments(fragments: Vec<TcpMsgForecast>) -> Vec<TcpMsgForecast> {
+    let mut merged: Vec<TcpMsgForecast> = Vec::new();
+    for f in fragments {
+        match merged.last_mut() {
+            Some(last) if last.send_trailing_edge == f.send_leading_edge => {
+                last.send_trailing_edge = f.send_trailing_edge;
+                last.recv_trailing_edge = f.recv_trailing_edge;
+                last.acknowledgement = f.acknowledgement;
+                last.size += f.size;
+            }
+            _ => merged.push(f),
+        }
+    }
+    merged
+}
+
+fn serialisation_time(bandwidth: u64, size: u64) -> Duration {
+    Duration::from_secs_f64(size as f64 / bandwidth as f64)
+}
+
+// ── Trace ────────────────────────────────────────────────────────────────────
+
+/// Simulate sending `messages` back-to-back from time 0 and return a trace
+/// of `TcpEvent`s.  The first message starts at `Timestamp::zero()`.
+pub fn trace_tcp_send(props: &TcpConnProps, messages: &[u64]) -> Vec<TcpEvent<()>> {
+    let mut state = TcpState::default();
+    let mut now = Timestamp::zero();
+    let mut events = Vec::with_capacity(messages.len());
+
+    for &msg_size in messages {
+        let (overall, fragments, new_state) = forecast_tcp_msg_send(props, state, now, msg_size);
+        now = overall.send_trailing_edge;
+        state = new_state;
+        events.push(TcpEvent {
+            msg: (),
+            overall,
+            fragments,
+        });
+    }
+
+    events
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bandwidth chosen so that serialisation_time(bandwidth, N) == N nanoseconds,
+    /// making expected timestamps easy to compute exactly.
+    const BW_NS_PER_BYTE: u64 = 1_000_000_000; // 1 GB/s
+
+    fn props_with_latency_ms(latency_ms: u64) -> TcpConnProps {
+        TcpConnProps::new(Duration::from_millis(latency_ms), BW_NS_PER_BYTE)
+    }
+
+    // ── Basic timing ────────────────────────────────────────────────────────
+
+    #[test]
+    fn small_message_fits_in_initial_window() {
+        // 1000 bytes << 14600 byte initial window → one fragment, no waiting.
+        let props = props_with_latency_ms(100);
+        let (overall, fragments, _) =
+            forecast_tcp_msg_send(&props, TcpState::default(), Timestamp::zero(), 1000);
+
+        assert_eq!(fragments.len(), 1, "should be a single fragment");
+        assert_eq!(overall.size, 1000);
+
+        // serial_time = 1000 ns; latency = 100_000_000 ns
+        let serial = Duration::from_nanos(1000);
+        let lat = Duration::from_millis(100);
+
+        assert_eq!(overall.send_leading_edge, Timestamp::zero());
+        assert_eq!(overall.send_trailing_edge, Timestamp::zero() + serial);
+        assert_eq!(overall.recv_leading_edge, Timestamp::zero() + lat);
+        assert_eq!(overall.recv_trailing_edge, Timestamp::zero() + lat + serial);
+        // Strategic cheat: ack = send_leading + 2 * latency (not + serial)
+        assert_eq!(overall.acknowledgement, Timestamp::zero() + lat + lat);
+    }
+
+    #[test]
+    fn timing_invariants_hold_for_every_fragment() {
+        // Send 60 kB over a slow link (100 kB/s, 50 ms RTT) — forces several
+        // window refills via slow-start.
+        let props = TcpConnProps::new(Duration::from_millis(50), 100_000);
+        let (_, fragments, _) =
+            forecast_tcp_msg_send(&props, TcpState::default(), Timestamp::zero(), 60_000);
+
+        for f in &fragments {
+            assert!(f.send_leading_edge <= f.send_trailing_edge);
+            // Leading edges always come from the same sub-fragment, so the
+            // latency relationship holds exactly.
+            assert_eq!(f.recv_leading_edge, f.send_leading_edge + props.latency);
+            assert_eq!(f.recv_trailing_edge, f.send_trailing_edge + props.latency);
+            // After merging, `acknowledgement` belongs to the last sub-fragment
+            // while `send_leading_edge` is from the first, so we can only bound
+            // it from below: ack ≥ send_leading + 2 × latency.
+            assert!(f.acknowledgement >= f.send_leading_edge + props.latency + props.latency);
+        }
+    }
+
+    // ── Fragmentation ────────────────────────────────────────────────────────
+
+    #[test]
+    fn large_message_is_fully_delivered() {
+        // 5× the initial window forces at least one wait-for-ack cycle.
+        let msgsize = 5 * INITIAL_CONGESTION_WINDOW;
+        let props = props_with_latency_ms(100);
+        let (overall, fragments, _) =
+            forecast_tcp_msg_send(&props, TcpState::default(), Timestamp::zero(), msgsize);
+
+        assert_eq!(overall.size, msgsize);
+        assert_eq!(fragments.iter().map(|f| f.size).sum::<u64>(), msgsize);
+        // More than one fragment because the initial window was exhausted.
+        assert!(fragments.len() > 1, "expected fragmentation");
+    }
+
+    #[test]
+    fn adjacent_fragments_are_merged() {
+        // Adjacent fragments (no gap between sends) should be collapsed.
+        let props = props_with_latency_ms(1); // tiny RTT → window refills immediately
+        let (_, fragments, _) =
+            forecast_tcp_msg_send(&props, TcpState::default(), Timestamp::zero(), 5 * INITIAL_CONGESTION_WINDOW);
+
+        // With a 1 ms RTT, the congestion window grows quickly; all contiguous
+        // sends should collapse to a small number of merged fragments.
+        for w in fragments.windows(2) {
+            assert_ne!(
+                w[0].send_trailing_edge, w[1].send_leading_edge,
+                "adjacent fragments should have been merged"
+            );
+        }
+    }
+
+    // ── Trace ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn trace_produces_one_event_per_message() {
+        let props = props_with_latency_ms(50);
+        let messages = vec![1000u64, 2000, 3000];
+        let events = trace_tcp_send(&props, &messages);
+
+        assert_eq!(events.len(), messages.len());
+        for (event, &expected_size) in events.iter().zip(messages.iter()) {
+            assert_eq!(event.overall.size, expected_size);
+        }
+    }
+
+    #[test]
+    fn trace_messages_are_sent_sequentially() {
+        // Each message starts no earlier than the previous one ends.
+        let props = props_with_latency_ms(50);
+        let messages = vec![500u64; 5];
+        let events = trace_tcp_send(&props, &messages);
+
+        for w in events.windows(2) {
+            assert!(
+                w[1].overall.send_leading_edge >= w[0].overall.send_trailing_edge,
+                "message {:?} starts before previous one ends",
+                w[1].overall.send_leading_edge,
+            );
+        }
+    }
+}

--- a/sim-rs/sim-core/src/tcp.rs
+++ b/sim-rs/sim-core/src/tcp.rs
@@ -72,6 +72,16 @@ impl Default for TcpState {
     }
 }
 
+impl TcpState {
+    /// Returns true iff every scheduled ACK has already arrived by `now`.
+    /// Used by `TcpConnection` to decide whether the idle-reset condition holds.
+    pub fn all_acks_arrived(&self, now: Timestamp) -> bool {
+        self.acknowledgements
+            .iter()
+            .all(|Reverse((ts, _))| *ts <= now)
+    }
+}
+
 // ── Forecast ─────────────────────────────────────────────────────────────────
 
 /// Timing forecast for one message or fragment.


### PR DESCRIPTION
- **sim-rs: add TCP congestion-window model**
- **sim-rs: implement TcpConnection (Chan.TCP port)**
- **sim-rs: wire tcp-congestion-control param to TcpConnection**

According to `claude`:

  | Feature | Haskell | Rust |
  |---|---|---|
  | TCP congestion-window model | ✅ | ✅ |
  | Mini-protocol multiplexing | ✅ | ❌ (`multiplex-mini-protocols` is Haskell-only) |
  | Fair bandwidth sharing across mini-protocols | N/A (mux handles it) | ✅ |

I think we need multiplexing to faithfully model TCP traffic on nodes.