### PR TITLE
fix(antithesis): add snappy to node compile

### DIFF
--- a/antithesis/Dockerfile.cardano-node
+++ b/antithesis/Dockerfile.cardano-node
@@ -1,12 +1,13 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS cardano-node-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-node-build
 
 # From intersectmbo/cardano-node leios-prototype branch
 ARG CARDANO_NODE_VERSION=c53f7c0d9509675d0a5eddb5a45cd53dd09b1bff
 
-RUN git clone https://github.com/intersectmbo/cardano-node.git \
+RUN git init cardano-node \
     && cd cardano-node \
-    && git fetch --all --recurse-submodules --tags \
-    && git checkout ${CARDANO_NODE_VERSION} \
+    && git remote add origin https://github.com/intersectmbo/cardano-node.git \
+    && git fetch --depth 1 origin ${CARDANO_NODE_VERSION} \
+    && git checkout FETCH_HEAD \
     && echo "with-compiler: ghc-${GHC_VERSION}" >> cabal.project.local \
     && echo "tests: False" >> cabal.project.local
 
@@ -37,6 +38,7 @@ RUN apt-get update -y && \
       liblmdb0 \
       libncursesw5 \
       libnuma1 \
+      libsnappy1v5 \
       libsystemd0 \
       libssl3 \
       libtinfo6 \

--- a/antithesis/Dockerfile.cardano-node-bp
+++ b/antithesis/Dockerfile.cardano-node-bp
@@ -7,15 +7,16 @@
 FROM ghcr.io/blinklabs-io/cardano-cli:10.14.0.0-1 AS cardano-cli
 
 # Build cardano-node from leios-prototype branch
-FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS cardano-node-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-node-build
 
 # From intersectmbo/cardano-node leios-prototype branch
 ARG CARDANO_NODE_VERSION_LEIOS=c53f7c0d9509675d0a5eddb5a45cd53dd09b1bff
 
-RUN git clone https://github.com/intersectmbo/cardano-node.git \
+RUN git init cardano-node \
     && cd cardano-node \
-    && git fetch --all --recurse-submodules --tags \
-    && git checkout ${CARDANO_NODE_VERSION_LEIOS} \
+    && git remote add origin https://github.com/intersectmbo/cardano-node.git \
+    && git fetch --depth 1 origin ${CARDANO_NODE_VERSION_LEIOS} \
+    && git checkout FETCH_HEAD \
     && echo "with-compiler: ghc-${GHC_VERSION}" >> cabal.project.local \
     && echo "tests: False" >> cabal.project.local
 
@@ -27,15 +28,16 @@ RUN --mount=type=cache,target=/root/.cabal/store,id=cabal-store-cardano-node \
     && cabal install exe:cardano-node --install-method=copy --installdir=/root/.local/bin/
 
 # Build tx-centrifuge from bench/leios branch
-FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS tx-centrifuge-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS tx-centrifuge-build
 
 # From intersectmbo/cardano-node bench/leios branch
 ARG CARDANO_NODE_VERSION_TXCENT=314ecc8b69bc896d53e262b4777cc4ec5dffc50a
 
-RUN git clone https://github.com/intersectmbo/cardano-node.git \
+RUN git init cardano-node \
     && cd cardano-node \
-    && git fetch --all --tags \
-    && git checkout ${CARDANO_NODE_VERSION_TXCENT} \
+    && git remote add origin https://github.com/intersectmbo/cardano-node.git \
+    && git fetch --depth 1 origin ${CARDANO_NODE_VERSION_TXCENT} \
+    && git checkout FETCH_HEAD \
     && echo "with-compiler: ghc-${GHC_VERSION}" >> cabal.project.local \
     && echo "tests: False" >> cabal.project.local
 
@@ -68,6 +70,7 @@ RUN apt-get update -y && \
       liblmdb0 \
       libncursesw5 \
       libnuma1 \
+      libsnappy1v5 \
       libsystemd0 \
       libssl3 \
       libtinfo6 \


### PR DESCRIPTION
Use latest revision of the Blink Labs Haskell image with the snappy dev package. Add libsnappy1v5 to runtime deps.