### PR TITLE
sim-rs: wire shared-consensus behaviours into the simulator

### DIFF
--- a/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/baseline-shared-consensus/config.yaml
+++ b/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/baseline-shared-consensus/config.yaml
@@ -1,0 +1,79 @@
+cert-generation-cpu-time-ms-constant: 92.5
+cert-generation-cpu-time-ms-per-node: 0
+cert-size-bytes-constant: 8000
+cert-size-bytes-per-node: 0
+cert-validation-cpu-time-ms-constant: 157.2
+cert-validation-cpu-time-ms-per-node: 0
+cleanup-policies:
+- cleanup-expired-vote
+committee-selection-algorithm: top-stake-fraction
+committee-stake-fraction-threshold: 0.99
+eb-body-avg-size-bytes: 12000000
+eb-body-validation-cpu-time-ms-constant: 0.3539
+eb-body-validation-cpu-time-ms-per-byte: 2.151e-05
+eb-diffusion-strategy: peer-order
+eb-header-validation-cpu-time-ms: 0.4438
+eb-referenced-txs-max-size-bytes: 12000000
+eb-size-bytes-constant: 240
+eb-size-bytes-per-ib: 32
+engine: sequential
+leios-header-diffusion-time-ms: 1000.0
+leios-mempool-sampling-strategy: ordered-by-id
+leios-mempool-size-bytes: null
+leios-stage-active-voting-slots: 1
+leios-stage-length-slots: 4
+leios-variant: shared-consensus
+linear-diffuse-stage-length-slots: 7
+linear-eb-propagation-criteria: eb-received
+linear-vote-stage-length-slots: 4
+non-persistent-vote-bundle-size-bytes-per-eb: 171
+non-persistent-vote-generation-cpu-time-ms: 0.427
+non-persistent-vote-generation-probability: 120
+non-persistent-vote-validation-cpu-time-ms: 1.75
+parallel-threshold: 4
+persistent-vote-bundle-size-bytes-per-eb: 94
+persistent-vote-generation-cpu-time-ms: 0.255
+persistent-vote-generation-probability: 480
+persistent-vote-validation-cpu-time-ms: 0.765
+praos-fallback-enabled: true
+rb-body-legacy-praos-payload-validation-cpu-time-ms-constant: 0.3539
+rb-body-legacy-praos-payload-validation-cpu-time-ms-per-byte: 2.151e-05
+rb-body-max-size-bytes: 90112
+rb-generation-cpu-time-ms: 71.02
+rb-generation-probability: 0.05
+rb-head-size-bytes: 1024
+rb-head-validation-cpu-time-ms: 0.4438
+relay-strategy: request-from-first
+seed: 0
+shard-count: 6
+shard-strategy: zero-latency-clusters
+simulate-transactions: true
+timestamp-resolution-ms: 1.0
+treat-blocks-as-full: false
+tx-batch-window-ms: 10.0
+tx-conflict-fraction: 0
+tx-generation-distribution:
+  distribution: constant
+  value: 7.5
+tx-max-size-bytes: 16384
+tx-overcollateralization-factor-distribution:
+  distribution: constant
+  value: 0
+tx-size-bytes-distribution:
+  distribution: constant
+  value: 1500
+tx-start-time: 60
+tx-stop-time: 960
+tx-validation-cpu-time-ms: 0.6201
+vote-bundle-size-bytes-constant: 0
+vote-bundle-size-bytes-per-eb: 164
+vote-diffusion-max-bodies-to-request: 1
+vote-diffusion-max-headers-to-request: 100
+vote-diffusion-max-window-size: 100
+vote-diffusion-strategy: peer-order
+vote-generation-cpu-time-ms-constant: 0.28
+vote-generation-cpu-time-ms-per-tx: 0
+vote-generation-probability: 600
+vote-threshold: 160
+vote-validation-cpu-time-ms: 2.9
+consensus-behaviours: []

--- a/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/baseline-shared-consensus/summary.txt
+++ b/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/baseline-shared-consensus/summary.txt
@@ -1,0 +1,102 @@
+ INFO praos: sim_cli::events: 120006 transactions(s) were generated in total.
+ INFO praos: sim_cli::events: 88 naive praos block(s) were published.
+ INFO praos: sim_cli::events: 1412 slot(s) had no naive praos blocks.
+ INFO praos: sim_cli::events: 120006 transaction(s) (180.01 MB) finalized in a naive praos block.
+ INFO praos: sim_cli::events: 0 transaction(s) (0 B) did not reach a naive praos block.
+ INFO praos: sim_cli::events: Pool 35 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 37 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 39 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 40 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 42 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 43 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 44 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 45 published 3 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 49 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 50 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 52 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 56 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 57 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 58 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 60 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 62 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 69 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 71 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 73 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 75 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 77 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 80 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 83 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 87 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 91 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 92 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 97 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 100 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 103 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 109 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 118 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 119 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 120 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 121 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 131 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 133 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 352 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 353 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 361 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 363 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 365 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 369 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 370 published 0 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 370 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 374 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 419 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 439 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 443 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 446 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 447 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 467 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 474 published 4 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 481 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 514 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 517 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 519 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 521 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 524 published 3 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 525 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 526 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 531 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 533 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 535 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 538 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 542 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 543 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 548 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 553 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 555 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 556 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 560 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 562 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 745 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 746 published 1 naive praos block(s)
+ INFO leios: sim_cli::events: The average age of the pending transactions is NaNs (stddev NaN).
+ INFO leios: sim_cli::events: 61 EB(s) were generated; on average there were 0.041 EB(s) per slot.
+ INFO leios: sim_cli::events: Each EB contained an average of 4668.787 transaction(s) (stddev 1913.811). 0 EB(s) were empty.
+ INFO leios: sim_cli::events: 35 out of 61 EBs expired before an EB from their stage reached an RB.
+ INFO leios: sim_cli::events: 120006 out of 120006 transaction(s) were included in at least one EB.
+ INFO leios: sim_cli::events: 10589 total votes were generated.
+ INFO leios: sim_cli::events: Each stake pool produced an average of 49.023 vote(s) (stddev 11.399).
+ INFO leios: sim_cli::events: Each EB received an average of 185.772 vote(s) (stddev 54.951).
+ INFO leios: sim_cli::events: There were 0 bundle(s) of votes. Each bundle contained NaN vote(s) (stddev NaN).
+ INFO leios: sim_cli::events: 11769 vote(s) were not generated due to validation failures:
+ INFO leios: sim_cli::events:   LateRBHeader: 2760
+ INFO leios: sim_cli::events:   WrongEB: 9009
+ INFO leios: sim_cli::events: 9 out of 61 EB(s) did not reach the vote threshold (160).
+ INFO leios: sim_cli::events: 28 L1 block(s) had a Leios endorsement.
+ INFO leios: sim_cli::events: 120006 tx(s) (180.01 MB) were referenced by a Leios endorsement.
+ INFO leios: sim_cli::events: 0 tx(s) (0 B) were included directly in a Praos block.
+ INFO leios: sim_cli::events: Spatial efficiency: 180.01 MB/9.35 MB (1924.795%) of Leios bytes were unique transactions.
+ INFO leios: sim_cli::events: 0 tx(s) (0.000%) referenced by a Leios endorsement were redundant.
+ INFO leios: sim_cli::events: Each transaction took an average of 13.536s (stddev 10.353) to be included in an EB.
+ INFO leios: sim_cli::events: Each transaction took an average of 50.149s (stddev 18.241) to be included in a block.
+ INFO network: sim_cli::events: 89884494 TX message(s) were sent. 89884494 of them were received (100.000%).
+ INFO network: sim_cli::events: 45689 EB message(s) were sent. 45689 of them were received (100.000%).
+ INFO network: sim_cli::events: 7931161 Vote message(s) were sent. 7931161 of them were received (100.000%).

--- a/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/lazy-voter-20pct/config.yaml
+++ b/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/lazy-voter-20pct/config.yaml
@@ -1,0 +1,85 @@
+cert-generation-cpu-time-ms-constant: 92.5
+cert-generation-cpu-time-ms-per-node: 0
+cert-size-bytes-constant: 8000
+cert-size-bytes-per-node: 0
+cert-validation-cpu-time-ms-constant: 157.2
+cert-validation-cpu-time-ms-per-node: 0
+cleanup-policies:
+- cleanup-expired-vote
+committee-selection-algorithm: top-stake-fraction
+committee-stake-fraction-threshold: 0.99
+consensus-behaviours:
+- selection:
+    fraction: 0.2
+    kind: stake-fraction
+  spec:
+    kind: lazy-voter
+    reason: declined
+eb-body-avg-size-bytes: 12000000
+eb-body-validation-cpu-time-ms-constant: 0.3539
+eb-body-validation-cpu-time-ms-per-byte: 2.151e-05
+eb-diffusion-strategy: peer-order
+eb-header-validation-cpu-time-ms: 0.4438
+eb-referenced-txs-max-size-bytes: 12000000
+eb-size-bytes-constant: 240
+eb-size-bytes-per-ib: 32
+engine: sequential
+leios-header-diffusion-time-ms: 1000.0
+leios-mempool-sampling-strategy: ordered-by-id
+leios-mempool-size-bytes: null
+leios-stage-active-voting-slots: 1
+leios-stage-length-slots: 4
+leios-variant: shared-consensus
+linear-diffuse-stage-length-slots: 7
+linear-eb-propagation-criteria: eb-received
+linear-vote-stage-length-slots: 4
+non-persistent-vote-bundle-size-bytes-per-eb: 171
+non-persistent-vote-generation-cpu-time-ms: 0.427
+non-persistent-vote-generation-probability: 120
+non-persistent-vote-validation-cpu-time-ms: 1.75
+parallel-threshold: 4
+persistent-vote-bundle-size-bytes-per-eb: 94
+persistent-vote-generation-cpu-time-ms: 0.255
+persistent-vote-generation-probability: 480
+persistent-vote-validation-cpu-time-ms: 0.765
+praos-fallback-enabled: true
+rb-body-legacy-praos-payload-validation-cpu-time-ms-constant: 0.3539
+rb-body-legacy-praos-payload-validation-cpu-time-ms-per-byte: 2.151e-05
+rb-body-max-size-bytes: 90112
+rb-generation-cpu-time-ms: 71.02
+rb-generation-probability: 0.05
+rb-head-size-bytes: 1024
+rb-head-validation-cpu-time-ms: 0.4438
+relay-strategy: request-from-first
+seed: 0
+shard-count: 6
+shard-strategy: zero-latency-clusters
+simulate-transactions: true
+timestamp-resolution-ms: 1.0
+treat-blocks-as-full: false
+tx-batch-window-ms: 10.0
+tx-conflict-fraction: 0
+tx-generation-distribution:
+  distribution: constant
+  value: 7.5
+tx-max-size-bytes: 16384
+tx-overcollateralization-factor-distribution:
+  distribution: constant
+  value: 0
+tx-size-bytes-distribution:
+  distribution: constant
+  value: 1500
+tx-start-time: 60
+tx-stop-time: 960
+tx-validation-cpu-time-ms: 0.6201
+vote-bundle-size-bytes-constant: 0
+vote-bundle-size-bytes-per-eb: 164
+vote-diffusion-max-bodies-to-request: 1
+vote-diffusion-max-headers-to-request: 100
+vote-diffusion-max-window-size: 100
+vote-diffusion-strategy: peer-order
+vote-generation-cpu-time-ms-constant: 0.28
+vote-generation-cpu-time-ms-per-tx: 0
+vote-generation-probability: 600
+vote-threshold: 160
+vote-validation-cpu-time-ms: 2.9

--- a/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/lazy-voter-20pct/summary.txt
+++ b/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0/lazy-voter-20pct/summary.txt
@@ -1,0 +1,105 @@
+ INFO praos: sim_cli::events: 120006 transactions(s) were generated in total.
+ INFO praos: sim_cli::events: 88 naive praos block(s) were published.
+ INFO praos: sim_cli::events: 1412 slot(s) had no naive praos blocks.
+ INFO praos: sim_cli::events: 120006 transaction(s) (180.01 MB) finalized in a naive praos block.
+ INFO praos: sim_cli::events: 0 transaction(s) (0 B) did not reach a naive praos block.
+ INFO praos: sim_cli::events: Pool 35 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 37 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 39 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 40 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 42 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 43 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 44 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 45 published 3 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 49 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 50 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 52 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 56 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 57 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 58 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 60 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 62 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 69 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 71 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 73 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 75 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 77 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 80 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 83 published 0 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 83 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 87 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 91 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 92 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 97 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 100 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 103 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 109 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 118 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 119 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 120 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 121 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 131 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 133 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 352 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 353 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 361 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 363 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 365 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 369 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 370 published 0 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 370 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 374 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 419 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 439 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 443 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 446 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 447 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 467 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 474 published 4 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 481 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 514 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 517 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 519 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 521 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 524 published 3 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 525 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 526 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 531 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 533 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 535 published 0 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 535 failed to publish 1 naive praos block(s) due to slot battles.
+ INFO praos: sim_cli::events: Pool 538 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 542 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 543 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 548 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 553 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 555 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 556 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 560 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 562 published 1 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 745 published 2 naive praos block(s)
+ INFO praos: sim_cli::events: Pool 746 published 1 naive praos block(s)
+ INFO leios: sim_cli::events: The average age of the pending transactions is NaNs (stddev NaN).
+ INFO leios: sim_cli::events: 61 EB(s) were generated; on average there were 0.041 EB(s) per slot.
+ INFO leios: sim_cli::events: Each EB contained an average of 4957.639 transaction(s) (stddev 2044.254). 0 EB(s) were empty.
+ INFO leios: sim_cli::events: 37 out of 61 EBs expired before an EB from their stage reached an RB.
+ INFO leios: sim_cli::events: 120006 out of 120006 transaction(s) were included in at least one EB.
+ INFO leios: sim_cli::events: 8868 total votes were generated.
+ INFO leios: sim_cli::events: Each stake pool produced an average of 41.056 vote(s) (stddev 20.807).
+ INFO leios: sim_cli::events: Each EB received an average of 155.579 vote(s) (stddev 45.618).
+ INFO leios: sim_cli::events: There were 0 bundle(s) of votes. Each bundle contained NaN vote(s) (stddev NaN).
+ INFO leios: sim_cli::events: 13492 vote(s) were not generated due to validation failures:
+ INFO leios: sim_cli::events:   LateRBHeader: 2640
+ INFO leios: sim_cli::events:   WrongEB: 8764
+ INFO leios: sim_cli::events:   Declined: 2088
+ INFO leios: sim_cli::events: 12 out of 61 EB(s) did not reach the vote threshold (160).
+ INFO leios: sim_cli::events: 26 L1 block(s) had a Leios endorsement.
+ INFO leios: sim_cli::events: 120006 tx(s) (180.01 MB) were referenced by a Leios endorsement.
+ INFO leios: sim_cli::events: 0 tx(s) (0 B) were included directly in a Praos block.
+ INFO leios: sim_cli::events: Spatial efficiency: 180.01 MB/9.90 MB (1818.282%) of Leios bytes were unique transactions.
+ INFO leios: sim_cli::events: 0 tx(s) (0.000%) referenced by a Leios endorsement were redundant.
+ INFO leios: sim_cli::events: Each transaction took an average of 13.929s (stddev 10.614) to be included in an EB.
+ INFO leios: sim_cli::events: Each transaction took an average of 53.270s (stddev 19.789) to be included in a block.
+ INFO network: sim_cli::events: 89884494 TX message(s) were sent. 89884494 of them were received (100.000%).
+ INFO network: sim_cli::events: 45689 EB message(s) were sent. 45689 of them were received (100.000%).
+ INFO network: sim_cli::events: 6642132 Vote message(s) were sent. 6642132 of them were received (100.000%).

--- a/analysis/sims/2026w22-lazy-voter/run.sh
+++ b/analysis/sims/2026w22-lazy-voter/run.sh
@@ -6,8 +6,10 @@
 
 set -eo pipefail
 
-BASE_DIR="/home/prc/leios/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0"
-SIM_CLI="/home/prc/leios/sim-rs/target/release/sim-cli"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$SCRIPT_DIR/NA,0.200/top-stake-fraction/topology-v2/seed-0"
+# Override with SIM_CLI=/path/to/sim-cli if your build lives elsewhere.
+SIM_CLI="${SIM_CLI:-$SCRIPT_DIR/../../../sim-rs/target/release/sim-cli}"
 NETWORK="$BASE_DIR/network.yaml"
 SLOTS=1500
 

--- a/analysis/sims/2026w22-lazy-voter/run.sh
+++ b/analysis/sims/2026w22-lazy-voter/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Sequential runner for the 2026w22 lazy-voter test:
+#  1) shared-consensus baseline (no behaviours)
+#  2) shared-consensus + 20%-stake lazy-voter
+# Both at NA,0.200, top-stake-fraction, seed 0, 1500 slots.
+
+set -eo pipefail
+
+BASE_DIR="/home/prc/leios/analysis/sims/2026w22-lazy-voter/NA,0.200/top-stake-fraction/topology-v2/seed-0"
+SIM_CLI="/home/prc/leios/sim-rs/target/release/sim-cli"
+NETWORK="$BASE_DIR/network.yaml"
+SLOTS=1500
+
+cd "$BASE_DIR"
+
+ulimit -S -v 256000000  # 256 GB virtual cap
+
+for variant in baseline-shared-consensus lazy-voter-20pct; do
+  OUTDIR="$BASE_DIR/$variant"
+  [[ -e "$OUTDIR/done" ]] && { echo "skipping $variant (already done)"; continue; }
+  echo "==[ $(date +%H:%M:%S) ] starting $variant"
+  /usr/bin/time -v -o "$OUTDIR/time.txt" "$SIM_CLI" "$NETWORK" \
+    -p "$OUTDIR/config.yaml" --slots "$SLOTS" \
+    > "$OUTDIR/stdout" 2> "$OUTDIR/stderr"
+  grep -E "^ INFO (praos|leios|network): " "$OUTDIR/stdout" > "$OUTDIR/summary.txt" || true
+  touch "$OUTDIR/done"
+  echo "==[ $(date +%H:%M:%S) ] finished $variant"
+done
+
+echo "==[ $(date +%H:%M:%S) ] all runs complete"

--- a/data/simulation/config.default.yaml
+++ b/data/simulation/config.default.yaml
@@ -281,3 +281,17 @@ cert-generation-cpu-time-ms-per-node: 0
 # vote-spec#"Verify certificate"
 cert-validation-cpu-time-ms-constant: 130.0
 cert-validation-cpu-time-ms-per-node: 0
+
+################################################################################
+# Consensus Behaviours (shared-consensus adapter only)
+################################################################################
+
+# Per-node adversarial / experimental behaviours wired into the
+# shared-consensus engine.  Each entry pairs a `BehaviourSpec` (kind
+# = honest | composite | rb-header-equivocator | lazy-voter) with a
+# `BehaviourSelection` (kind = all | nodes | stake-random |
+# stake-ordered | stake-fraction) picking which nodes run it.
+# Overlapping selections compose; resolution is deterministic for a
+# given `seed`.  Empty (default) means every node runs `honest`.
+# Ignored by engines other than `shared-consensus`.
+consensus-behaviours: []

--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -1,6 +1,95 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BehaviourSpec": {
+      "description": "Per-node consensus behaviour.  Tagged enum (kind = honest|composite|rb-header-equivocator|lazy-voter).",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "type": "object",
+          "properties": { "kind": { "const": "honest", "type": "string" } }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "children"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "composite", "type": "string" },
+            "children": { "type": "array", "items": { "$ref": "#/definitions/BehaviourSpec" } }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "rb-header-equivocator", "type": "string" },
+            "ways": { "type": "number", "default": 2 }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "lazy-voter", "type": "string" },
+            "reason": {
+              "default": "Declined",
+              "description": "NoVote reason recorded for telemetry on each abstention.",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "BehaviourSelection": {
+      "description": "Which nodes a behaviour applies to.  Tagged enum (kind = all|nodes|stake-random|stake-ordered|stake-fraction).  Stake-aware variants ignore zero-stake nodes; selection is deterministic for a given seed.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "type": "object",
+          "properties": { "kind": { "const": "all", "type": "string" } }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "nodes", "type": "string" },
+            "indices": { "type": "array", "items": { "type": "number" } }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "count"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "stake-random", "type": "string" },
+            "count": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "count"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "stake-ordered", "type": "string" },
+            "count": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["kind", "fraction"],
+          "type": "object",
+          "properties": {
+            "kind": { "const": "stake-fraction", "type": "string" },
+            "fraction": { "type": "number" }
+          }
+        }
+      ]
+    },
     "CleanupPolicies": {
       "anyOf": [
         {
@@ -374,6 +463,20 @@
     "ib-shards": {
       "description": "The total number of shards available for IBs.\nMust be divisible by ib_shard_group_count.\n\nOnly supported by Rust simulation.",
       "type": "number"
+    },
+    "consensus-behaviours": {
+      "default": [],
+      "description": "Per-node adversarial / experimental behaviours wired into the shared-consensus engine.\nEach entry pairs a BehaviourSpec (kind = honest|composite|rb-header-equivocator|lazy-voter)\nwith a BehaviourSelection (kind = all|nodes|stake-random|stake-ordered|stake-fraction)\npicking which nodes run it.  Overlapping selections compose.\nDeterministic for a given seed.  Ignored by engines other than `shared-consensus`.",
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "required": ["spec", "selection"],
+        "type": "object",
+        "properties": {
+          "spec": { "$ref": "#/definitions/BehaviourSpec" },
+          "selection": { "$ref": "#/definitions/BehaviourSelection" }
+        }
+      }
     },
     "late-eb-attack": {
       "$ref": "#/definitions/LateEBAttackConfig",

--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -25,7 +25,7 @@
           "type": "object",
           "properties": {
             "kind": { "const": "rb-header-equivocator", "type": "string" },
-            "ways": { "type": "number", "default": 2 }
+            "ways": { "type": "integer", "minimum": 2, "default": 2 }
           }
         },
         {
@@ -35,7 +35,7 @@
           "properties": {
             "kind": { "const": "lazy-voter", "type": "string" },
             "reason": {
-              "default": "Declined",
+              "default": "declined",
               "description": "NoVote reason recorded for telemetry on each abstention.",
               "type": "string"
             }
@@ -58,7 +58,7 @@
           "type": "object",
           "properties": {
             "kind": { "const": "nodes", "type": "string" },
-            "indices": { "type": "array", "items": { "type": "number" } }
+            "indices": { "type": "array", "items": { "type": "integer", "minimum": 0 } }
           }
         },
         {
@@ -67,7 +67,7 @@
           "type": "object",
           "properties": {
             "kind": { "const": "stake-random", "type": "string" },
-            "count": { "type": "number" }
+            "count": { "type": "integer", "minimum": 0 }
           }
         },
         {
@@ -76,7 +76,7 @@
           "type": "object",
           "properties": {
             "kind": { "const": "stake-ordered", "type": "string" },
-            "count": { "type": "number" }
+            "count": { "type": "integer", "minimum": 0 }
           }
         },
         {

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -80,6 +80,7 @@ pub struct RbVariantInput {
 pub mod delay;
 pub mod outbound;
 pub mod registry;
+pub mod selection;
 
 pub mod behaviours {
     //! Concrete [`super::Behaviour`] implementations.  Each lives in its
@@ -94,6 +95,7 @@ pub mod behaviours {
 pub use delay::DelayQueue;
 pub use outbound::{Outbound, OutboundDecision, OwnedOutbound};
 pub use registry::{build, build_handle, seed_from_node_id, swap_handle, BehaviourSpec};
+pub use selection::{resolve_selection, resolve_specs, BehaviourSelection};
 
 // `BehaviourHandle` is defined at the top of this module.
 

--- a/shared-rs/consensus/src/behaviour/registry.rs
+++ b/shared-rs/consensus/src/behaviour/registry.rs
@@ -108,7 +108,7 @@ pub fn build(spec: &BehaviourSpec, seed: u64) -> Box<dyn Behaviour> {
 /// Mix `seed` with `child_index` to give each composite child a
 /// distinct deterministic stream.  Uses Blake2b to avoid linear
 /// correlations between sibling seeds.
-fn child_seed(seed: u64, idx: usize) -> u64 {
+pub(crate) fn child_seed(seed: u64, idx: usize) -> u64 {
     let mut h = blake2b_simd::Params::new().hash_length(8).to_state();
     h.update(&seed.to_le_bytes());
     h.update(&(idx as u64).to_le_bytes());

--- a/shared-rs/consensus/src/behaviour/selection.rs
+++ b/shared-rs/consensus/src/behaviour/selection.rs
@@ -125,6 +125,10 @@ pub fn resolve_selection(
 /// from this resolver behaves the same as a hand-written
 /// [`BehaviourSpec::Composite`].
 ///
+/// `seed` is salted per item via [`child_seed`](super::registry::child_seed),
+/// so two `StakeRandom` items pick independent subsets rather than the
+/// same shuffle (or nested prefixes when their `count` differs).
+///
 /// Nodes not picked by any item are absent from the returned map; the
 /// caller treats those as honest.
 pub fn resolve_specs(
@@ -133,8 +137,9 @@ pub fn resolve_specs(
     seed: Option<u64>,
 ) -> BTreeMap<usize, BehaviourSpec> {
     let mut out: BTreeMap<usize, BehaviourSpec> = BTreeMap::new();
-    for (spec, selection) in items {
-        let picked = resolve_selection(selection, stakes, seed);
+    for (item_idx, (spec, selection)) in items.iter().enumerate() {
+        let item_seed = seed.map(|s| super::registry::child_seed(s, item_idx));
+        let picked = resolve_selection(selection, stakes, item_seed);
         for idx in picked {
             match out.remove(&idx) {
                 None => {
@@ -382,6 +387,45 @@ mod tests {
         }
         assert!(matches!(out.get(&1), Some(BehaviourSpec::LazyVoter { .. })));
         assert!(matches!(out.get(&2), Some(BehaviourSpec::LazyVoter { .. })));
+    }
+
+    #[test]
+    fn resolve_specs_salts_seed_per_item_so_stake_random_items_are_independent() {
+        // Two StakeRandom items with the same count would otherwise see
+        // the same shuffle and pick the same nodes.  Per-item salting
+        // via child_seed should give independent subsets.
+        let stakes = vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        let items = vec![
+            (
+                BehaviourSpec::LazyVoter {
+                    reason: crate::leios::NoVoteReason::Declined,
+                },
+                BehaviourSelection::StakeRandom { count: 3 },
+            ),
+            (
+                BehaviourSpec::RbHeaderEquivocator { ways: 2 },
+                BehaviourSelection::StakeRandom { count: 3 },
+            ),
+        ];
+        let out = resolve_specs(&items, &stakes, Some(7));
+        let lazy: BTreeSet<usize> = out
+            .iter()
+            .filter_map(|(idx, spec)| match spec {
+                BehaviourSpec::LazyVoter { .. } => Some(*idx),
+                _ => None,
+            })
+            .collect();
+        let equiv: BTreeSet<usize> = out
+            .iter()
+            .filter_map(|(idx, spec)| match spec {
+                BehaviourSpec::RbHeaderEquivocator { .. } => Some(*idx),
+                _ => None,
+            })
+            .collect();
+        assert_ne!(
+            lazy, equiv,
+            "two StakeRandom items with same count should select different subsets"
+        );
     }
 
     #[test]

--- a/shared-rs/consensus/src/behaviour/selection.rs
+++ b/shared-rs/consensus/src/behaviour/selection.rs
@@ -1,0 +1,412 @@
+//! Behaviour selection — pick which nodes in a multi-node deployment
+//! run a given [`BehaviourSpec`].
+//!
+//! Consumers (sim-rs, net-cluster) hold a list of `(spec, selection)`
+//! pairs describing an experiment and ask this module to materialise
+//! the per-node assignment.  The module is sans-IO: it takes a stake
+//! vector indexed in node order and returns indices into that vector.
+//!
+//! All variants are deterministic for a given seed so re-runs land on
+//! the same nodes.  Stake-aware variants (`StakeRandom`, `StakeOrdered`,
+//! `StakeFraction`) ignore zero-stake nodes — under mainnet-shaped
+//! topologies these are relays that don't vote and aren't meaningful
+//! targets for behaviour assignment.
+//!
+//! [`BehaviourSpec`]: super::BehaviourSpec
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rand::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::BehaviourSpec;
+
+/// Which subset of nodes runs a configured behaviour.
+///
+/// Serialised as a tagged TOML/YAML table:
+///
+/// ```toml
+/// [behaviour_selection]
+/// kind = "stake-fraction"
+/// fraction = 0.2
+/// ```
+///
+/// All variants are deterministic for a given seed so re-runs land on
+/// the same nodes.  Stake-aware variants ignore zero-stake nodes
+/// (e.g. relays under `mainnet-shaped` topologies).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum BehaviourSelection {
+    /// Attach the behaviour to every node.
+    All,
+    /// Attach the behaviour to a hand-listed set of node indices.
+    Nodes {
+        #[serde(default)]
+        indices: Vec<usize>,
+    },
+    /// Pick `count` random nodes (deterministically, seeded) from those
+    /// with `stake > 0`.  Useful for "this many adversaries somewhere
+    /// in the voting set" without concentrating on the largest pools.
+    StakeRandom { count: usize },
+    /// Pick `count` nodes from those with `stake > 0`, ordered by stake
+    /// descending and tie-broken by index ascending.  Targets the
+    /// largest pools first.
+    StakeOrdered { count: usize },
+    /// Pick the smallest prefix of stake-bearing nodes (ordered by
+    /// stake descending, tie-broken by index ascending) whose
+    /// cumulative stake covers `fraction` of the total stake.  Same
+    /// shape as CIP-0164 top-stake committee selection
+    /// (`top_centile_of_stake`) — `fraction = 0.2` makes 20% of the
+    /// *voting weight* run the behaviour, regardless of how many nodes
+    /// that turns out to be.
+    StakeFraction { fraction: f64 },
+}
+
+/// Resolve a [`BehaviourSelection`] to the concrete set of node
+/// indices it picks.  `seed` is the deterministic RNG seed for
+/// `StakeRandom`; the other variants ignore it.
+pub fn resolve_selection(
+    selection: &BehaviourSelection,
+    stakes: &[u64],
+    seed: Option<u64>,
+) -> BTreeSet<usize> {
+    match selection {
+        BehaviourSelection::All => (0..stakes.len()).collect(),
+        BehaviourSelection::Nodes { indices } => indices
+            .iter()
+            .copied()
+            .filter(|&i| i < stakes.len())
+            .collect(),
+        BehaviourSelection::StakeOrdered { count } => {
+            stake_ranked(stakes).into_iter().take(*count).collect()
+        }
+        BehaviourSelection::StakeRandom { count } => {
+            let mut bearers: Vec<usize> = stakes
+                .iter()
+                .enumerate()
+                .filter(|(_, &s)| s > 0)
+                .map(|(i, _)| i)
+                .collect();
+            let mut rng = StdRng::seed_from_u64(seed.unwrap_or(0));
+            bearers.shuffle(&mut rng);
+            bearers.into_iter().take(*count).collect()
+        }
+        BehaviourSelection::StakeFraction { fraction } => {
+            let total: u128 = stakes.iter().map(|&s| s as u128).sum();
+            if total == 0 {
+                return BTreeSet::new();
+            }
+            let f = fraction.clamp(0.0, 1.0);
+            let target = (total as f64 * f).ceil() as u128;
+            let mut chosen = BTreeSet::new();
+            let mut acc: u128 = 0;
+            for (idx, stake) in stake_ranked_with_stake(stakes) {
+                if acc >= target {
+                    break;
+                }
+                chosen.insert(idx);
+                acc += stake as u128;
+            }
+            chosen
+        }
+    }
+}
+
+/// Resolve a list of `(spec, selection)` items to a per-node
+/// [`BehaviourSpec`] assignment.
+///
+/// Items are walked in declaration order.  When two items select the
+/// same node, the specs **compose** rather than override: the entry
+/// becomes [`BehaviourSpec::Composite`] with the existing spec followed
+/// by the new one.  This matches the documented composite-dispatch
+/// semantics (first non-`Continue` wins) and the
+/// [`build`](super::build) helper's seeding contract — children are
+/// re-seeded via `child_seed(seed, idx)`, so a composed assignment
+/// from this resolver behaves the same as a hand-written
+/// [`BehaviourSpec::Composite`].
+///
+/// Nodes not picked by any item are absent from the returned map; the
+/// caller treats those as honest.
+pub fn resolve_specs(
+    items: &[(BehaviourSpec, BehaviourSelection)],
+    stakes: &[u64],
+    seed: Option<u64>,
+) -> BTreeMap<usize, BehaviourSpec> {
+    let mut out: BTreeMap<usize, BehaviourSpec> = BTreeMap::new();
+    for (spec, selection) in items {
+        let picked = resolve_selection(selection, stakes, seed);
+        for idx in picked {
+            match out.remove(&idx) {
+                None => {
+                    out.insert(idx, spec.clone());
+                }
+                Some(existing) => {
+                    let composed = match existing {
+                        BehaviourSpec::Composite { children: mut kids } => {
+                            kids.push(spec.clone());
+                            BehaviourSpec::Composite { children: kids }
+                        }
+                        other => BehaviourSpec::Composite {
+                            children: vec![other, spec.clone()],
+                        },
+                    };
+                    out.insert(idx, composed);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Stake-bearing nodes sorted by stake descending, ties broken by
+/// index ascending.  Returns indices only; pair with
+/// [`stake_ranked_with_stake`] when you also need the stake.
+fn stake_ranked(stakes: &[u64]) -> Vec<usize> {
+    stake_ranked_with_stake(stakes)
+        .into_iter()
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn stake_ranked_with_stake(stakes: &[u64]) -> Vec<(usize, u64)> {
+    let mut ranked: Vec<(usize, u64)> = stakes
+        .iter()
+        .enumerate()
+        .filter(|(_, &s)| s > 0)
+        .map(|(i, &s)| (i, s))
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_picks_every_node() {
+        let set = resolve_selection(&BehaviourSelection::All, &[0, 5, 0, 5, 0], None);
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn nodes_verbatim() {
+        let set = resolve_selection(
+            &BehaviourSelection::Nodes {
+                indices: vec![1, 3],
+            },
+            &[1, 1, 1, 1],
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![1, 3]);
+    }
+
+    #[test]
+    fn nodes_drops_out_of_range() {
+        let set = resolve_selection(
+            &BehaviourSelection::Nodes {
+                indices: vec![0, 99, 2],
+            },
+            &[1, 1, 1],
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0, 2]);
+    }
+
+    #[test]
+    fn stake_ordered_filters_zero_stake_and_takes_top_n() {
+        let stakes = vec![10, 100, 50, 0, 200];
+        let set =
+            resolve_selection(&BehaviourSelection::StakeOrdered { count: 2 }, &stakes, None);
+        // Sorted desc by stake: 4 (200), 1 (100), 2 (50), 0 (10); top 2 = {1, 4}.
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![1, 4]);
+    }
+
+    #[test]
+    fn stake_ordered_count_zero_returns_empty() {
+        let set = resolve_selection(
+            &BehaviourSelection::StakeOrdered { count: 0 },
+            &[10, 10, 10],
+            None,
+        );
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn stake_ordered_count_exceeds_pool_takes_all_bearers() {
+        let stakes = vec![10, 0, 20, 0, 30];
+        let set = resolve_selection(
+            &BehaviourSelection::StakeOrdered { count: 99 },
+            &stakes,
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn stake_random_is_deterministic_for_seed() {
+        let stakes = vec![10, 0, 20, 0, 30, 0, 40, 0, 50];
+        let mk = |seed: u64| -> BTreeSet<usize> {
+            resolve_selection(&BehaviourSelection::StakeRandom { count: 2 }, &stakes, Some(seed))
+        };
+        assert_eq!(mk(42), mk(42));
+        let a = mk(42);
+        let b = mk(43);
+        assert_ne!(a, b, "seed should change the selection");
+        let bearers: BTreeSet<usize> = [0, 2, 4, 6, 8].into_iter().collect();
+        for node in &a {
+            assert!(bearers.contains(node));
+        }
+    }
+
+    #[test]
+    fn stake_random_count_zero_returns_empty() {
+        let set = resolve_selection(
+            &BehaviourSelection::StakeRandom { count: 0 },
+            &[10, 20, 30],
+            Some(0),
+        );
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn stake_fraction_picks_smallest_prefix_covering_target() {
+        let stakes = vec![100, 100, 100, 100, 100];
+        let set = resolve_selection(
+            &BehaviourSelection::StakeFraction { fraction: 0.4 },
+            &stakes,
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0, 1]);
+    }
+
+    #[test]
+    fn stake_fraction_with_uneven_pools() {
+        let stakes = vec![10, 100, 50, 200];
+        let set = resolve_selection(
+            &BehaviourSelection::StakeFraction { fraction: 0.5 },
+            &stakes,
+            None,
+        );
+        // 200 alone (idx 3) already covers 50% of 360 = 180.
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![3]);
+    }
+
+    #[test]
+    fn stake_fraction_skips_relays() {
+        let stakes = vec![100, 100, 100, 0, 0, 0, 0];
+        let set = resolve_selection(
+            &BehaviourSelection::StakeFraction { fraction: 0.3 },
+            &stakes,
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0]);
+    }
+
+    #[test]
+    fn stake_fraction_zero_returns_empty() {
+        let set = resolve_selection(
+            &BehaviourSelection::StakeFraction { fraction: 0.0 },
+            &[100, 100],
+            None,
+        );
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn stake_fraction_one_picks_all_bearers() {
+        let stakes = vec![10, 0, 20, 0, 30];
+        let set = resolve_selection(
+            &BehaviourSelection::StakeFraction { fraction: 1.0 },
+            &stakes,
+            None,
+        );
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn resolve_specs_empty_items_returns_empty() {
+        let out = resolve_specs(&[], &[1, 1, 1], None);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn resolve_specs_disjoint_selections_produce_plain_specs() {
+        let items = vec![
+            (
+                BehaviourSpec::LazyVoter {
+                    reason: crate::leios::NoVoteReason::Declined,
+                },
+                BehaviourSelection::Nodes { indices: vec![0] },
+            ),
+            (
+                BehaviourSpec::RbHeaderEquivocator { ways: 2 },
+                BehaviourSelection::Nodes { indices: vec![1] },
+            ),
+        ];
+        let out = resolve_specs(&items, &[1, 1, 1], None);
+        assert!(matches!(out.get(&0), Some(BehaviourSpec::LazyVoter { .. })));
+        assert!(matches!(
+            out.get(&1),
+            Some(BehaviourSpec::RbHeaderEquivocator { ways: 2 })
+        ));
+        assert!(out.get(&2).is_none());
+    }
+
+    #[test]
+    fn resolve_specs_overlapping_selections_compose() {
+        let items = vec![
+            (
+                BehaviourSpec::LazyVoter {
+                    reason: crate::leios::NoVoteReason::Declined,
+                },
+                BehaviourSelection::All,
+            ),
+            (
+                BehaviourSpec::RbHeaderEquivocator { ways: 2 },
+                BehaviourSelection::Nodes { indices: vec![0] },
+            ),
+        ];
+        let out = resolve_specs(&items, &[1, 1, 1], None);
+        // Node 0: composed; nodes 1, 2: plain LazyVoter.
+        match out.get(&0) {
+            Some(BehaviourSpec::Composite { children }) => {
+                assert_eq!(children.len(), 2);
+                assert!(matches!(children[0], BehaviourSpec::LazyVoter { .. }));
+                assert!(matches!(
+                    children[1],
+                    BehaviourSpec::RbHeaderEquivocator { ways: 2 }
+                ));
+            }
+            other => panic!("expected Composite at node 0, got {:?}", other),
+        }
+        assert!(matches!(out.get(&1), Some(BehaviourSpec::LazyVoter { .. })));
+        assert!(matches!(out.get(&2), Some(BehaviourSpec::LazyVoter { .. })));
+    }
+
+    #[test]
+    fn resolve_specs_three_way_overlap_appends_to_existing_composite() {
+        // Three items, all selecting node 0 — composite should grow
+        // linearly, not nest.
+        let items = vec![
+            (
+                BehaviourSpec::LazyVoter {
+                    reason: crate::leios::NoVoteReason::Declined,
+                },
+                BehaviourSelection::Nodes { indices: vec![0] },
+            ),
+            (
+                BehaviourSpec::RbHeaderEquivocator { ways: 2 },
+                BehaviourSelection::Nodes { indices: vec![0] },
+            ),
+            (BehaviourSpec::Honest, BehaviourSelection::Nodes { indices: vec![0] }),
+        ];
+        let out = resolve_specs(&items, &[1], None);
+        match out.get(&0) {
+            Some(BehaviourSpec::Composite { children }) => {
+                assert_eq!(children.len(), 3);
+            }
+            other => panic!("expected Composite with 3 children, got {:?}", other),
+        }
+    }
+}

--- a/sim-rs/parameters/lazy-20pct.yaml
+++ b/sim-rs/parameters/lazy-20pct.yaml
@@ -1,0 +1,15 @@
+# Demonstration: lazy-voter abstention on the top 20% of stake-weighted
+# nodes under the shared-consensus engine.  Layered on top of
+# config.default.yaml via figment (-p parameters/lazy-20pct.yaml).
+leios-variant: shared-consensus
+timestamp-resolution-ms: 0.05
+leios-header-diffusion-time-ms: 3000.0
+linear-tx-max-age-slots: 23
+
+consensus-behaviours:
+  - spec:
+      kind: lazy-voter
+      reason: declined
+    selection:
+      kind: stake-fraction
+      fraction: 0.2

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -348,6 +348,29 @@ pub struct RawParameters {
     // attacks,
     pub late_eb_attack: Option<RawLateEBAttackConfig>,
     pub late_tx_attack: Option<RawLateTXAttackConfig>,
+
+    /// Per-node consensus behaviours wired into the shared-consensus
+    /// engine.  Each entry pairs a [`BehaviourSpec`] with a
+    /// [`BehaviourSelection`] picking which nodes run it; overlapping
+    /// selections compose via [`BehaviourSpec::Composite`].  Resolution
+    /// is deterministic for a given `seed`.  Empty (default) means
+    /// every node runs [`BehaviourSpec::Honest`].  Only consumed by the
+    /// shared-consensus adapter; ignored by other engines.
+    ///
+    /// [`BehaviourSpec`]: shared_consensus::behaviour::BehaviourSpec
+    /// [`BehaviourSelection`]: shared_consensus::behaviour::BehaviourSelection
+    /// [`BehaviourSpec::Composite`]: shared_consensus::behaviour::BehaviourSpec::Composite
+    /// [`BehaviourSpec::Honest`]: shared_consensus::behaviour::BehaviourSpec::Honest
+    #[serde(default)]
+    pub consensus_behaviours: Vec<ConsensusBehaviourEntry>,
+}
+
+/// One row of [`RawParameters::consensus_behaviours`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ConsensusBehaviourEntry {
+    pub spec: shared_consensus::behaviour::BehaviourSpec,
+    pub selection: shared_consensus::behaviour::BehaviourSelection,
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
@@ -998,6 +1021,7 @@ pub struct SimConfiguration {
     pub(crate) ib_generation_probability: f64,
     pub(crate) eb_generation_probability: f64,
     pub(crate) committee_selection: CommitteeSelectionAlgorithm,
+    pub(crate) committee_stake_fraction_threshold: f64,
     pub(crate) vote_eligible_nodes: HashSet<NodeId>,
     /// Sum of `persistent_voters + non_persistent_voters`.  Linear
     /// uses this as a single VRF-lottery probability per (voter, EB).
@@ -1031,6 +1055,16 @@ pub struct SimConfiguration {
     pub(crate) tx_batch_window: Option<Duration>,
     /// Shared network stats collector (set by sequential engine, read by nodes).
     pub network_stats: Option<Arc<crate::network::stats::NetworkStatsCollector>>,
+
+    /// Per-node consensus behaviour assignment.  Resolved once at
+    /// build time from [`RawParameters::consensus_behaviours`].  Nodes
+    /// absent from the map run [`BehaviourSpec::Honest`] (the default
+    /// installed by `LeiosState::new`).  Only consumed by the
+    /// shared-consensus adapter.
+    ///
+    /// [`BehaviourSpec::Honest`]: shared_consensus::behaviour::BehaviourSpec::Honest
+    pub(crate) consensus_behaviour_specs:
+        BTreeMap<NodeId, shared_consensus::behaviour::BehaviourSpec>,
 }
 
 impl SimConfiguration {
@@ -1056,6 +1090,11 @@ impl SimConfiguration {
             );
         }
         let total_stake: u64 = topology.nodes.iter().map(|n| n.stake).sum();
+        let consensus_behaviour_specs = resolve_consensus_behaviours(
+            &params.consensus_behaviours,
+            &topology.nodes,
+            params.seed,
+        );
         let attacks = AttackConfig::build(&params, &mut topology);
         let vote_eligible_nodes = match params.committee_selection_algorithm {
             CommitteeSelectionAlgorithm::WfaLs | CommitteeSelectionAlgorithm::Everyone => {
@@ -1117,6 +1156,7 @@ impl SimConfiguration {
             ib_generation_probability: params.ib_generation_probability,
             eb_generation_probability: params.eb_generation_probability,
             committee_selection: params.committee_selection_algorithm,
+            committee_stake_fraction_threshold: params.committee_stake_fraction_threshold,
             vote_eligible_nodes,
             vote_probability: params.persistent_voters + params.non_persistent_voters,
             persistent_voters: params.persistent_voters,
@@ -1142,8 +1182,42 @@ impl SimConfiguration {
             attacks,
             tx_batch_window: params.tx_batch_window_ms.map(duration_ms),
             network_stats: None,
+            consensus_behaviour_specs,
         })
     }
+}
+
+/// Resolve `[(spec, selection)]` against the node list in `NodeId`
+/// order.  Stakes are read in the same order, so the
+/// `BTreeMap<usize, BehaviourSpec>` returned by
+/// [`shared_consensus::behaviour::resolve_specs`] maps directly onto
+/// `NodeId`s.
+fn resolve_consensus_behaviours(
+    items: &[ConsensusBehaviourEntry],
+    nodes: &[NodeConfiguration],
+    seed: u64,
+) -> BTreeMap<NodeId, shared_consensus::behaviour::BehaviourSpec> {
+    if items.is_empty() {
+        return BTreeMap::new();
+    }
+    // NodeIds are assigned by topology enumeration order; assert that
+    // for the slice we receive so the index translation below is sound.
+    debug_assert!(
+        nodes.iter().enumerate().all(|(i, n)| n.id.to_inner() == i),
+        "expected NodeConfiguration ordering by NodeId"
+    );
+    let stakes: Vec<u64> = nodes.iter().map(|n| n.stake).collect();
+    let pairs: Vec<(
+        shared_consensus::behaviour::BehaviourSpec,
+        shared_consensus::behaviour::BehaviourSelection,
+    )> = items
+        .iter()
+        .map(|e| (e.spec.clone(), e.selection.clone()))
+        .collect();
+    shared_consensus::behaviour::resolve_specs(&pairs, &stakes, Some(seed))
+        .into_iter()
+        .map(|(idx, spec)| (nodes[idx].id, spec))
+        .collect()
 }
 
 fn duration_ms(ms: f64) -> Duration {
@@ -1220,5 +1294,111 @@ impl NodeBehaviours {
             }
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod consensus_behaviour_tests {
+    use super::*;
+    use shared_consensus::behaviour::{BehaviourSelection, BehaviourSpec};
+
+    fn node(id: usize, name: &str, stake: u64) -> NodeConfiguration {
+        NodeConfiguration {
+            id: NodeId::new(id),
+            name: name.to_string(),
+            stake,
+            location: None,
+            cpu_multiplier: 1.0,
+            cores: None,
+            tx_conflict_fraction: None,
+            tx_generation_weight: None,
+            consumers: Vec::new(),
+            behaviours: NodeBehaviours::default(),
+        }
+    }
+
+    #[test]
+    fn empty_items_returns_empty_map() {
+        let nodes = vec![node(0, "a", 1), node(1, "b", 1)];
+        let out = resolve_consensus_behaviours(&[], &nodes, 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn stake_fraction_maps_to_correct_node_ids() {
+        let nodes = vec![
+            node(0, "a", 100),
+            node(1, "b", 100),
+            node(2, "c", 100),
+            node(3, "d", 0), // relay
+        ];
+        let items = vec![ConsensusBehaviourEntry {
+            spec: BehaviourSpec::LazyVoter {
+                reason: shared_consensus::leios::NoVoteReason::Declined,
+            },
+            selection: BehaviourSelection::StakeFraction { fraction: 0.4 },
+        }];
+        let out = resolve_consensus_behaviours(&items, &nodes, 0);
+        // total 300, target 120 → cover with 2 nodes (100 + 100).
+        let picked: Vec<NodeId> = out.keys().copied().collect();
+        assert_eq!(picked, vec![NodeId::new(0), NodeId::new(1)]);
+        for (_, spec) in &out {
+            assert!(matches!(spec, BehaviourSpec::LazyVoter { .. }));
+        }
+    }
+
+    #[test]
+    fn overlapping_selections_compose_per_node() {
+        let nodes = vec![node(0, "a", 100), node(1, "b", 100)];
+        let items = vec![
+            ConsensusBehaviourEntry {
+                spec: BehaviourSpec::LazyVoter {
+                    reason: shared_consensus::leios::NoVoteReason::Declined,
+                },
+                selection: BehaviourSelection::All,
+            },
+            ConsensusBehaviourEntry {
+                spec: BehaviourSpec::RbHeaderEquivocator { ways: 2 },
+                selection: BehaviourSelection::Nodes { indices: vec![0] },
+            },
+        ];
+        let out = resolve_consensus_behaviours(&items, &nodes, 0);
+        match out.get(&NodeId::new(0)) {
+            Some(BehaviourSpec::Composite { children }) => {
+                assert_eq!(children.len(), 2);
+                assert!(matches!(children[0], BehaviourSpec::LazyVoter { .. }));
+                assert!(matches!(
+                    children[1],
+                    BehaviourSpec::RbHeaderEquivocator { ways: 2 }
+                ));
+            }
+            other => panic!("expected Composite at node 0, got {:?}", other),
+        }
+        assert!(matches!(
+            out.get(&NodeId::new(1)),
+            Some(BehaviourSpec::LazyVoter { .. })
+        ));
+    }
+
+    #[test]
+    fn stake_random_is_deterministic_across_calls() {
+        let nodes: Vec<_> = (0..10)
+            .map(|i| node(i, &format!("n{i}"), if i % 2 == 0 { 100 } else { 0 }))
+            .collect();
+        let items = vec![ConsensusBehaviourEntry {
+            spec: BehaviourSpec::LazyVoter {
+                reason: shared_consensus::leios::NoVoteReason::Declined,
+            },
+            selection: BehaviourSelection::StakeRandom { count: 2 },
+        }];
+        let a = resolve_consensus_behaviours(&items, &nodes, 42);
+        let b = resolve_consensus_behaviours(&items, &nodes, 42);
+        let c = resolve_consensus_behaviours(&items, &nodes, 43);
+        assert_eq!(a.keys().collect::<Vec<_>>(), b.keys().collect::<Vec<_>>());
+        assert_ne!(a.keys().collect::<Vec<_>>(), c.keys().collect::<Vec<_>>());
+        // never picks zero-stake nodes
+        for id in a.keys() {
+            assert!(id.to_inner() % 2 == 0);
+        }
     }
 }

--- a/sim-rs/sim-core/src/sim/shared_consensus.rs
+++ b/sim-rs/sim-core/src/sim/shared_consensus.rs
@@ -13,9 +13,18 @@
 //! and the byte-equivalent event-stream determinism check in W2.5 line
 //! up directly.
 //!
-//! Adversary hooks are intentionally absent — they re-enter as a
-//! follow-on wrapper layer once the protocol-level equivalence in W2.6
-//! is verified.
+//! ## Behaviours
+//!
+//! Each node installs a [`shared_consensus::behaviour::BehaviourHandle`]
+//! on its `LeiosState`, `PraosState`, and `MempoolState` — the same
+//! handle on all three so stateful behaviours (e.g.
+//! `RbHeaderEquivocator`'s peer-partition map) observe events from
+//! every layer.  Specs come from the `consensus-behaviours` YAML
+//! parameter, resolved once at [`SimConfiguration::build`] via
+//! [`shared_consensus::behaviour::resolve_specs`], and looked up
+//! per-node here.  Nodes not in the map run [`HonestBehaviour`].  The
+//! assignment is static for the lifetime of the sim — there is no
+//! analog of net-node's runtime `swap_handle` path.
 //!
 //! # YAML config knobs the adapter reads
 //!
@@ -47,7 +56,6 @@
 //! | shared-consensus field                  | Value | Rationale                                         |
 //! |-------------------------------|-------|---------------------------------------------------|
 //! | `WfaLs.non_persistent_voters` | `0`   | sim collapses PV/NPV into one probability         |
-//! | `StakeCentile.top_centile_of_stake` | `0.95` | sim's `committee-stake-fraction-threshold` isn't propagated to `SimConfiguration` |
 //! | `PraosState` `k`              | `2160` | sim doesn't model security parameter           |
 //! | Fetch policies (RB/EB/EB-txs/votes) | YAML `fetch-policy.{block,eb,eb-txs,votes}` (default `lowest-rtt` everywhere, matching `LeiosState::new`).  RTT oracle is `UniformRtt(0)` — sim drives fetches via its own `Message` enum |
 
@@ -174,11 +182,8 @@ fn derive_committee_selection(sim_config: &SimConfiguration) -> CommitteeSelecti
             }
         }
         A::Everyone => CommitteeSelection::EveryoneVotes,
-        // Sim's `committee_stake_fraction_threshold` isn't propagated
-        // through to `SimConfiguration` — use the spec default 0.95
-        // until/unless that wire-up lands.
         A::TopStakeFraction => CommitteeSelection::StakeCentile {
-            top_centile_of_stake: 0.95,
+            top_centile_of_stake: sim_config.committee_stake_fraction_threshold,
         },
     }
 }
@@ -342,6 +347,15 @@ pub struct SharedConsensus {
     /// set of EBs blocked on it.  An admitted tx is looked up here so
     /// every blocked EB can re-check coverage and release if complete.
     missing_tx_index: BTreeMap<TransactionId, std::collections::BTreeSet<EndorserBlockId>>,
+
+    /// Shared per-node behaviour handle.  The same `Arc<Mutex<…>>` is
+    /// installed on `leios`, `praos`, and `mempool` above so stateful
+    /// behaviours observe events from every layer through one instance.
+    /// Stored here for clarity and to anchor the Arc beyond the three
+    /// state-machine holders.  The sim never swaps the inner trait
+    /// object after construction (see module docs).
+    #[allow(dead_code)]
+    behaviour_handle: shared_consensus::behaviour::BehaviourHandle,
 }
 
 enum VoteState {
@@ -478,8 +492,26 @@ impl NodeImpl for SharedConsensus {
         // pruning depth comfortably beyond any sim run length.
         let mut praos = PraosState::new(config.name.clone(), 2160);
         praos.set_fetch_policy(fp.block.into_block_policy());
-        let mempool = MempoolState::new(sim_config.mempool_size_bytes as usize);
+        let mut mempool = MempoolState::new(sim_config.mempool_size_bytes as usize);
         let node_names = sim_config_nodes_to_names(&sim_config);
+
+        // Per-node behaviour install.  Look up the resolved spec
+        // (resolve_specs ran once at SimConfiguration::build) and
+        // share a single handle across leios/praos/mempool — stateful
+        // behaviours like RbHeaderEquivocator carry per-peer state
+        // that has to be visible from every layer.
+        let behaviour_spec = sim_config
+            .consensus_behaviour_specs
+            .get(&config.id)
+            .cloned()
+            .unwrap_or_default();
+        let behaviour_seed =
+            shared_consensus::behaviour::seed_from_node_id(&config.name);
+        let behaviour_handle =
+            shared_consensus::behaviour::build_handle(&behaviour_spec, behaviour_seed);
+        leios.behaviour = behaviour_handle.clone();
+        praos.behaviour = behaviour_handle.clone();
+        mempool.behaviour = behaviour_handle.clone();
 
         Self {
             id: config.id,
@@ -509,6 +541,7 @@ impl NodeImpl for SharedConsensus {
             noted_no_vote: std::collections::BTreeSet::new(),
             eb_pending_txs: BTreeMap::new(),
             missing_tx_index: BTreeMap::new(),
+            behaviour_handle,
         }
     }
 


### PR DESCRIPTION
## Summary

Lands the per-node `Behaviour` install on sim-rs's `shared-consensus` engine, so adversarial / abstention scenarios (lazy voter, RB-header equivocator, …) can be driven from YAML — no per-node topology edits.

- **Lift `BehaviourSelection` into shared-consensus.** New `shared-rs/consensus/src/behaviour/selection.rs` exposes `BehaviourSelection` (`all | nodes | stake-random | stake-ordered | stake-fraction`) and `resolve_selection`, both moved out of net-cluster.  Adds a higher-level `resolve_specs` helper that turns a list of `(spec, selection)` into a per-node assignment, composing overlapping picks via `BehaviourSpec::Composite`.  17 unit tests cover variants, determinism, composition, and zero-stake filtering.  (Note: I only touched the leios-repo copy of `shared-rs/consensus/`; the net-rs copy will need the same diff.)
- **New sim-rs parameter** `consensus-behaviours: Vec<{spec, selection}>` on `RawParameters` (kebab-case YAML); default empty = every node `Honest`, matching prior behaviour exactly.  Resolved once at `SimConfiguration::build` keyed by `NodeId` in topology-enumeration order so re-runs land on the same nodes.  Static for the sim lifetime — no analog of net-node's runtime `swap_handle`.
- **Install in `SharedConsensus::new`.** A single `BehaviourHandle` (seeded from `seed_from_node_id(name)`) assigned to `leios.behaviour`, `praos.behaviour`, and `mempool.behaviour` — one Arc across all three so stateful behaviours (e.g. `RbHeaderEquivocator`'s peer-partition map) observe events from every layer.
- **Drive-by fix:** `committee-stake-fraction-threshold` now reaches the adapter.  `derive_committee_selection` was hardcoding `top_centile_of_stake: 0.95`; threshold is now read from `sim_config.committee_stake_fraction_threshold`.  Past shared-consensus top-stake-fraction runs were silently using 0.95 regardless of the configured threshold.
- **Schema + fixture:** hand-updated `data/simulation/config.schema.json` with `BehaviourSpec` / `BehaviourSelection` definitions; default `consensus-behaviours: []` in `config.default.yaml`; example at `sim-rs/parameters/lazy-20pct.yaml`.

End-to-end test under `analysis/sims/2026w22-lazy-voter/` — NA,0.200, top-stake-fraction (0.99), seed 0, 1500 slots, 750-node topology, paired baseline vs. 20%-stake lazy-voter runs:

| Metric | shared-consensus baseline | + 20% lazy-voter | 2026w18 linear reference |
|---|---|---|---|
| RBs / EBs | 88 / 61 | 88 / 61 | 88 / 61 |
| Total votes | 10589 | **8868** (-16.2%) | 10624 |
| Avg votes / EB | 185.77 | **155.58** | 174.16 |
| EBs below threshold | 9/61 | **12/61** | — |
| Endorsed L1 blocks | 28 | **26** | 27 |
| NoVote: Declined | 0 | **2088** | 0 |

Baseline tracks the 2026w18 `linear-with-tx-references` baseline tightly — engine swap is not responsible for the abstention deltas.  The 20%-stake LazyVoter surfaces a clean `Declined` column in the NoVote telemetry and bounds quorum impact to 3 extra threshold misses and 2 fewer certificates over 1500 slots.

## Scope notes

- Only the `shared-consensus` engine reads `consensus-behaviours`.  Linear's `NodeBehaviours` (`ib_equivocation` / `withhold_txs` / `generate_conflicts`) is a separate, untouched surface.
- No per-node topology override (only parameter-level items).  Net-cluster's cluster-scale `BehaviourSelection` shape is better suited than hand-authoring 750 topology entries.
- No dynamic / runtime swap.

## Test plan

- [x] `cargo test -p shared-consensus` — 269 existing + 17 new selection tests pass
- [x] `cargo test -p sim-core` — 59 lib tests (incl. 4 new resolver tests) pass
- [x] Baseline shared-consensus NA,0.200 top-stake-fraction run matches 2026w18 linear reference
- [x] 20% lazy-voter run surfaces 2088 `Declined` vote-fails and a 16.2% net vote drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)