### PR TITLE
shared-consensus: let RB body and EB announcement coexist on overflow

### DIFF
--- a/net-rs/net-node/src/mempool.rs
+++ b/net-rs/net-node/src/mempool.rs
@@ -53,21 +53,23 @@ fn to_hash_32(id: Vec<u8>) -> [u8; 32] {
 
 /// Which body the next self-produced RB carries — wire-typed sibling of
 /// [`shared_consensus::production::BodyPath`].
-#[derive(Debug, Clone)]
-pub enum BodyPath {
-    /// Producer-side EB-safety gate fired: the local node holds a
-    /// chain-committed cert for an EB whose body it has not validated
-    /// locally.  The RB body must be empty and no fresh EB announced;
-    /// the cert itself is independent and remains the caller's
-    /// responsibility.
-    Empty,
-    /// RB body inlines these txs; mempool has been drained.
-    Inline(Vec<PendingTx>),
-    /// RB body is empty; the listed manifest is announced via an EB.
-    /// Caller hashes the encoded manifest bytes and finishes the
-    /// drain-and-pin via [`Mempool::produce_eb`] with the resulting
-    /// `EbKey`.
-    Eb { manifest_hashes: Vec<[u8; 32]> },
+///
+/// `inline` becomes the RB body; `manifest_hashes` becomes a fresh EB
+/// announcement attached to the same RB header.  Either may be empty
+/// independently:
+///
+/// - both empty: empty body, no EB (safety gate; or cert + small mempool).
+/// - `inline` non-empty, `manifest_hashes` empty: inline-only body, no EB.
+/// - `inline` empty, `manifest_hashes` non-empty: empty body + EB (cert + overflow).
+/// - both non-empty: inline body + EB residual (no cert + overflow).
+///
+/// `inline` is already drained from the mempool.  The manifest txs are
+/// still in the free pool; the caller commits the EB-pin via
+/// [`Mempool::produce_eb`] once it has the EB key.
+#[derive(Debug, Clone, Default)]
+pub struct BodyPath {
+    pub inline: Vec<PendingTx>,
+    pub manifest_hashes: Vec<[u8; 32]>,
 }
 
 /// I/O-side wrapper around `shared_consensus::mempool::MempoolState`.  Public
@@ -183,16 +185,10 @@ impl Mempool {
     }
 
     /// Run the CIP-0164 overflow rule.  Returns the body path the next
-    /// self-produced RB should take:
-    ///
-    /// - `Empty` when `leios`'s producer-side EB-safety gate is set
-    ///   (chain-committed cert for an EB whose body the local node
-    ///   has not validated).  Mempool is untouched.
-    /// - `Inline(txs)` when the mempool fits in the RB body cap
-    ///   (drained on return).
-    /// - `Eb { manifest_hashes }` when the mempool overflows the cap
-    ///   (mempool untouched; caller commits the drain via
-    ///   [`Mempool::produce_eb`] once it has the EB hash).
+    /// self-produced RB should take: `inline` holds drained tx bodies
+    /// (empty when the safety gate fires or a cert ships in a small
+    /// mempool); `manifest_hashes` holds the residual overflow
+    /// (empty when the mempool fit in the RB body cap).
     ///
     /// `endorsement_present` must reflect whether the caller is about
     /// to attach a Leios certificate to this RB; the body-path
@@ -206,26 +202,22 @@ impl Mempool {
         leios: &shared_consensus::leios::LeiosState,
         endorsement_present: bool,
     ) -> BodyPath {
-        match shared_consensus::production::BodyPath::decide(
+        let con = shared_consensus::production::BodyPath::decide(
             &mut self.state,
             rb_body_max_bytes,
             eb_body_max_bytes,
             leios,
             endorsement_present,
-        ) {
-            shared_consensus::production::BodyPath::Empty => BodyPath::Empty,
-            shared_consensus::production::BodyPath::Inline(txs) => {
-                BodyPath::Inline(txs.into_iter().map(from_con_tx).collect())
-            }
-            shared_consensus::production::BodyPath::Eb { manifest } => BodyPath::Eb {
-                manifest_hashes: manifest.into_iter().map(to_hash_32).collect(),
-            },
+        );
+        BodyPath {
+            inline: con.inline.into_iter().map(from_con_tx).collect(),
+            manifest_hashes: con.manifest.into_iter().map(to_hash_32).collect(),
         }
     }
 
     /// Drain the first `count` free txs into an EB pin under `eb_key`.
-    /// `count` must come from the `BodyPath::Eb` manifest's length so
-    /// the drain matches the size-capped selection.  After this the
+    /// `count` must come from `BodyPath::manifest_hashes.len()` so the
+    /// drain matches the size-capped selection.  After this the
     /// drained txs stay locally available via `has_tx` /
     /// `get_body_by_id` but no longer count toward `total_bytes` /
     /// `drain_up_to` — i.e. they won't be double-included in a

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -277,42 +277,42 @@ impl BlockProducer {
         self.block_count += 1;
 
         // CIP-0164 overflow rule plus producer-side EB-safety gate
-        // both live in shared-consensus (`production::BodyPath`).
+        // both live in shared-consensus (`production::BodyPath`).  The
+        // returned struct's `inline` becomes the RB body and
+        // `manifest_hashes` becomes a fresh EB announcement; either
+        // (or both) may be empty.
         let mut pool = mempool.lock().unwrap();
-        let (txs, announced_eb) = match pool.decide_body_path(
+        let body_path = pool.decide_body_path(
             self.rb_body_max_bytes,
             self.eb_body_max_bytes,
             leios,
             certified_eb,
-        ) {
-            crate::mempool::BodyPath::Empty => (Vec::new(), None),
-            crate::mempool::BodyPath::Inline(txs) => (txs, None),
-            crate::mempool::BodyPath::Eb { manifest_hashes } => {
-                // Encode wire bytes, hash them, then commit the
-                // drain-and-pin under the resulting EB key.  Bodies stay
-                // pinned in the mempool under `eb_pinned` so the producer
-                // can vote for its own EB (MissingTX predicate sees them)
-                // and serve `LeiosFetch BlockTxs` (resolver finds them by
-                // tx_id).
-                let manifest_len = manifest_hashes.len();
-                let eb_data = encode_overflow_eb(slot, &manifest_hashes);
-                let eb_hash = blake2b_256(&eb_data);
-                let eb_key = EbKey {
+        );
+        let txs = body_path.inline;
+        let announced_eb = if body_path.manifest_hashes.is_empty() {
+            None
+        } else {
+            // Encode wire bytes, hash them, then commit the
+            // drain-and-pin under the resulting EB key.  Bodies stay
+            // pinned in the mempool under `eb_pinned` so the producer
+            // can vote for its own EB (MissingTX predicate sees them)
+            // and serve `LeiosFetch BlockTxs` (resolver finds them by
+            // tx_id).
+            let manifest_len = body_path.manifest_hashes.len();
+            let eb_data = encode_overflow_eb(slot, &body_path.manifest_hashes);
+            let eb_hash = blake2b_256(&eb_data);
+            let eb_key = EbKey {
+                slot,
+                hash: eb_hash,
+            };
+            pool.produce_eb(eb_key, manifest_len);
+            Some(ProducedEb {
+                point: Point::Specific {
                     slot,
                     hash: eb_hash,
-                };
-                pool.produce_eb(eb_key, manifest_len);
-                (
-                    Vec::new(),
-                    Some(ProducedEb {
-                        point: Point::Specific {
-                            slot,
-                            hash: eb_hash,
-                        },
-                        data: eb_data,
-                    }),
-                )
-            }
+                },
+                data: eb_data,
+            })
         };
         drop(pool);
 
@@ -789,8 +789,10 @@ mod tests {
             .try_produce_block(100, None, 1, false, &mempool, &empty_leios())
             .unwrap();
 
-        // EB path: RB body is empty, EB is announced.
-        assert_eq!(produced.included_tx_count, 0);
+        // CIP-0164 overflow: drain RB body up to the cap (2 × 500 =
+        // 1000 fits exactly), residual (the third 500-byte tx) is
+        // announced via the EB.
+        assert_eq!(produced.included_tx_count, 2);
         assert!(produced.announced_eb.is_some());
         assert!(produced.body.point().is_some());
 
@@ -805,7 +807,7 @@ mod tests {
         }
         assert_eq!(eb.data.len() as u32, eb_size);
 
-        // Mempool should be drained.
+        // Mempool drained: 2 inline + 1 pinned in the EB closure.
         assert_eq!(mempool.lock().unwrap().len(), 0);
     }
 

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -197,7 +197,10 @@ pub struct ProducedRb {
     pub body: BlockBody,
     /// If the mempool overflowed, the EB manifest to inject into the network.
     pub announced_eb: Option<ProducedEb>,
-    /// Number of transactions included in the RB body (RB path only).
+    /// Number of transactions included inline in the RB body.  Non-zero
+    /// for the pure-RB case and the RB+EB overflow split alike;
+    /// the EB-announcement residual (if any) is counted by
+    /// `announced_eb`, not here.
     pub included_tx_count: usize,
 }
 
@@ -246,12 +249,21 @@ impl BlockProducer {
         self.stake > 0 && self.total_stake > 0
     }
 
-    /// Run the VRF lottery for a Praos ranking block. On win, drains the
-    /// mempool: if pending txs fit in `rb_body_max_bytes`, they go in the
-    /// RB body (RB path). Otherwise the EB-overflow path fires: an EB
-    /// announcement carries a FIFO-ordered manifest capped at
-    /// `eb_body_max_bytes` worth of tx bodies, the RB body is empty,
-    /// and the remainder stays in the mempool for the next RB.
+    /// Run the VRF lottery for a Praos ranking block. On win, asks
+    /// shared-consensus's `production::BodyPath::decide` how to split
+    /// the pending mempool between the RB body and a fresh EB
+    /// announcement:
+    ///
+    /// - All-fits case: every pending tx goes inline into the RB body
+    ///   up to `rb_body_max_bytes`; no EB is announced.
+    /// - Overflow split: txs fill the RB body up to `rb_body_max_bytes`
+    ///   and the residual is announced via a fresh EB whose
+    ///   FIFO-ordered manifest is capped at `eb_body_max_bytes` worth
+    ///   of tx bodies.  Inline RB body and EB announcement coexist;
+    ///   anything past both caps stays in the mempool for the next RB.
+    /// - Empty-for-safety: the producer-side EB-safety gate may force
+    ///   both inline and announcement to be empty (no EB is announced
+    ///   when the chain context can't certify one safely).
     pub fn try_produce_block(
         &mut self,
         slot: u64,

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -1022,7 +1022,8 @@ impl LeiosState {
     /// [`crate::production::BodyPath::decide`].  True iff the local
     /// node holds a chain-committed cert for at least one EB whose
     /// body it has not validated locally; in that state the next
-    /// self-produced RB must emit an empty body.
+    /// self-produced RB must emit an empty body and no fresh EB
+    /// announcement.
     pub fn has_endorsed_unvalidated_eb(&self) -> bool {
         !self.endorsed_unvalidated_ebs.is_empty()
     }

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -476,9 +476,8 @@ impl MempoolState {
     /// next RB.  The pinned bodies stay serveable via LeiosFetch and
     /// visible to the `MissingTX` voting predicate.
     ///
-    /// `count` must come from `BodyPath::Eb { manifest }`'s
-    /// `manifest.len()` — pairing the size-capped manifest selection
-    /// with a matching prefix drain.
+    /// `count` must come from `BodyPath::manifest.len()` — pairing the
+    /// size-capped manifest selection with a matching prefix drain.
     ///
     /// Returns the manifest and any `TxRejected{EbClosurePruned}`
     /// effects emitted when older EB closures aged out of the

--- a/shared-rs/consensus/src/production.rs
+++ b/shared-rs/consensus/src/production.rs
@@ -1,11 +1,12 @@
-//! Producer-side body-path decision: inline-RB vs announce-via-EB vs
-//! empty-for-safety.
+//! Producer-side body-path decision: how the next self-produced RB
+//! distributes mempool txs between its inline body and a fresh EB
+//! announcement.
 //!
-//! CIP-0164 Linear Leios's overflow rule: if the mempool exceeds the
-//! per-RB byte cap, the next RB's body is empty and the txs are
-//! announced via an EB; otherwise the txs go directly into the RB
-//! body.  Both adapters that drive [`crate::praos::PraosState`] need
-//! the same decision; this module owns it.
+//! CIP-0164 Linear Leios's overflow rule: fill the RB body first (it
+//! has lower inclusion latency), and only announce an EB for txs that
+//! cannot fit in the base RB.  [`BodyPath`] returns both pieces so the
+//! caller can write the inline txs into the body **and** announce the
+//! residual via an EB in the same RB.
 //!
 //! Producer-side safety rule (correctness, not optimization): when the
 //! local node holds a chain-committed cert for an EB whose body it
@@ -14,34 +15,46 @@
 //! new RB body — or announcing a fresh EB that races the unvalidated
 //! one — risks a duplicate at apply time, producing a provably-invalid
 //! block.  The gate's state lives in [`crate::leios::LeiosState`]
-//! (`endorsed_unvalidated_ebs`); `decide` reads it and returns
-//! [`BodyPath::Empty`] when set, leaving the mempool untouched.
+//! (`endorsed_unvalidated_ebs`); `decide` reads it and returns the
+//! empty body path with the mempool untouched.
 //!
-//! Wire encoding stays with the consumer.  This crate picks the path and
-//! either drains txs (inline) or returns the manifest (EB).  The
-//! consumer then computes the EB's hash from its wire bytes and
-//! commits the drain-and-pin via [`crate::mempool::MempoolState::produce_eb`].
+//! Wire encoding stays with the consumer.  This module picks the path,
+//! drains the inline portion out of the mempool's free pool, and
+//! returns the manifest for the residual.  The consumer encodes the
+//! manifest into wire bytes, hashes them, and commits the
+//! drain-and-pin via [`crate::mempool::MempoolState::produce_eb`].
 
 use crate::leios::LeiosState;
 use crate::mempool::{MempoolState, PendingTx, TxId};
 
 /// Where the txs for the next self-produced RB end up.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BodyPath {
-    /// The local node holds a chain-committed cert for an EB whose
-    /// body it has not validated locally.  The RB body must be empty
-    /// and no fresh EB may be announced; the cert itself is still
-    /// emitted by the caller.  The mempool is not mutated.
-    Empty,
-    /// The mempool's free pool fits in the RB body cap; these txs are
-    /// drained out for inclusion directly in the RB body.
-    Inline(Vec<PendingTx>),
-    /// The mempool overflowed the cap; every pending tx becomes an
-    /// announced EB reference and the RB body is empty.  The wrapper
-    /// encodes the manifest into wire bytes, hashes them, and finishes
-    /// the move from free pool to `eb_pinned` via
-    /// [`MempoolState::produce_eb`] with the resulting `EbKey`.
-    Eb { manifest: Vec<TxId> },
+///
+/// `inline` becomes the RB body; `manifest` becomes a fresh EB
+/// announcement attached to the same RB header.  The four legal
+/// states encode all CIP-0164-compatible combinations directly:
+///
+/// | `inline` | `manifest` | meaning                                                                |
+/// |----------|------------|------------------------------------------------------------------------|
+/// | empty    | empty      | empty body, no EB (safety gate; or cert + small mempool)               |
+/// | non-emp. | empty      | inline-only body, no EB (no cert, mempool ≤ RB cap)                    |
+/// | empty    | non-emp.   | empty body, EB carries the overflow (cert + overflow)                  |
+/// | non-emp. | non-emp.   | inline body + EB residual (no cert, mempool > RB cap)                  |
+///
+/// `inline` is already drained from the mempool's free pool.  The
+/// `manifest` txs are still in the free pool; the caller commits the
+/// EB-pin via [`MempoolState::produce_eb`] once it has computed the
+/// EB hash from the encoded manifest bytes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BodyPath {
+    /// FIFO-ordered prefix of the mempool drained into the RB body.
+    /// Empty when the safety gate fires, when a cert is being
+    /// attached (cert XOR inline body), or when the mempool is empty.
+    pub inline: Vec<PendingTx>,
+    /// FIFO-ordered tx ids the caller announces as a fresh EB.
+    /// Empty when the mempool fit in the RB body cap (no overflow)
+    /// or when the safety gate fired.  Not yet drained — the caller
+    /// follows up with [`MempoolState::produce_eb`].
+    pub manifest: Vec<TxId>,
 }
 
 impl BodyPath {
@@ -49,7 +62,7 @@ impl BodyPath {
     /// check and (2) the cert-XOR-inline-body rule.
     ///
     /// First consults [`LeiosState::has_endorsed_unvalidated_eb`]; if
-    /// set, short-circuits to [`BodyPath::Empty`] with the mempool
+    /// set, short-circuits to an empty [`BodyPath`] with the mempool
     /// untouched.
     ///
     /// `endorsement_present` is true iff the caller is about to attach
@@ -62,26 +75,23 @@ impl BodyPath {
     ///
     /// Cases (after the EB-safety check):
     ///
-    /// - `endorsement_present = false`, mempool ≤ `rb_body_max_bytes`:
-    ///   drain tx bodies into [`BodyPath::Inline`].  The mempool's
-    ///   free pool shrinks by the returned set.
-    /// - `endorsement_present = false`, mempool > `rb_body_max_bytes`:
-    ///   collect the FIFO-ordered manifest into [`BodyPath::Eb`],
-    ///   capped at `eb_body_max_bytes` worth of tx bodies.  The
-    ///   mempool is NOT mutated yet — the wrapper must follow up
-    ///   with `produce_eb` once it has computed the EB hash from the
-    ///   encoded manifest bytes.  At least one tx is always emitted
-    ///   if the free pool is non-empty, even if the first tx alone
-    ///   exceeds the cap.
-    /// - `endorsement_present = true`, mempool ≤ `rb_body_max_bytes`:
-    ///   [`BodyPath::Empty`].  The cert lands on its own; inline txs
-    ///   are forbidden, and the mempool is too small to motivate an
-    ///   EB.  Mempool untouched; the txs will be drained on a later
-    ///   RB.
-    /// - `endorsement_present = true`, mempool > `rb_body_max_bytes`:
-    ///   [`BodyPath::Eb`].  The cert ships with a fresh EB
-    ///   announcement; both are allowed simultaneously since the
-    ///   announcement lives in the header and the body stays empty.
+    /// - Mempool ≤ `rb_body_max_bytes`, no cert: drain tx bodies into
+    ///   `inline`.  The mempool's free pool shrinks by the returned
+    ///   set; `manifest` is empty.
+    /// - Mempool ≤ `rb_body_max_bytes`, cert: leave the mempool
+    ///   untouched and return all-empty.  The cert lands on its own;
+    ///   the mempool waits for a future slot.
+    /// - Mempool > `rb_body_max_bytes`, no cert: drain
+    ///   `rb_body_max_bytes` worth of txs into `inline`, then collect
+    ///   the FIFO-ordered residual into `manifest`, capped at
+    ///   `eb_body_max_bytes` worth of tx bodies.  If the inline drain
+    ///   absorbed the entire mempool (a single oversize tx exhausts
+    ///   the free pool), `manifest` is empty and no EB is announced.
+    /// - Mempool > `rb_body_max_bytes`, cert: leave `inline` empty
+    ///   (CIP-0164 cert-XOR-inline-body) and collect the FIFO
+    ///   manifest as above.  Cert + EB-announcement is explicitly
+    ///   allowed by the CIP — the announcement is header-side, the
+    ///   body stays empty.
     pub fn decide(
         mempool: &mut MempoolState,
         rb_body_max_bytes: usize,
@@ -90,9 +100,16 @@ impl BodyPath {
         endorsement_present: bool,
     ) -> Self {
         if leios.has_endorsed_unvalidated_eb() {
-            return BodyPath::Empty;
+            return BodyPath::default();
         }
         if mempool.total_bytes > rb_body_max_bytes {
+            // Overflow: fill the RB body first (skipped under cert per
+            // CIP-0164), then announce the residual via a fresh EB.
+            let inline = if endorsement_present {
+                Vec::new()
+            } else {
+                mempool.drain_up_to(rb_body_max_bytes)
+            };
             let mut manifest: Vec<TxId> = Vec::new();
             let mut bytes = 0usize;
             for tx in mempool.txs.iter() {
@@ -106,15 +123,15 @@ impl BodyPath {
                     break;
                 }
             }
-            BodyPath::Eb { manifest }
-        } else if endorsement_present {
-            // Cert + inline-txs would be a CIP-0164 violation; the
-            // mempool is too small to motivate an EB-overflow, so the
-            // RB carries the cert alone and the mempool waits for a
-            // future slot.
-            BodyPath::Empty
+            return BodyPath { inline, manifest };
+        }
+        if endorsement_present {
+            BodyPath::default()
         } else {
-            BodyPath::Inline(mempool.drain_up_to(rb_body_max_bytes))
+            BodyPath {
+                inline: mempool.drain_up_to(rb_body_max_bytes),
+                manifest: Vec::new(),
+            }
         }
     }
 }
@@ -182,40 +199,37 @@ mod tests {
     const EB_CAP: usize = 1 << 30;
 
     #[test]
-    fn inline_when_under_cap() {
+    fn inline_only_when_under_cap() {
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         populate(&mut state, &[(1, 100), (2, 100), (3, 100)]); // 300 bytes total
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        match body {
-            BodyPath::Inline(txs) => {
-                assert_eq!(txs.len(), 3);
-                assert_eq!(state.total_bytes, 0);
-                assert_eq!(state.txs.len(), 0);
-            }
-            other => panic!("expected Inline, got {other:?}"),
-        }
+        assert_eq!(body.inline.len(), 3);
+        assert!(body.manifest.is_empty());
+        assert_eq!(state.total_bytes, 0);
+        assert_eq!(state.txs.len(), 0);
     }
 
     #[test]
-    fn eb_when_over_cap() {
+    fn overflow_fills_body_then_announces_residual() {
+        // Mempool: [200, 200, 200, 200] = 800 bytes, RB cap = 500.
+        // drain_up_to(500) takes [200, 200] (400 ≤ 500; adding the
+        // next would push to 600 > 500 with non-empty result).
+        // Residual = [200, 200] → manifest carries both.
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
-        populate(&mut state, &[(1, 200), (2, 200), (3, 200)]); // 600 bytes total
+        populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200)]);
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        match body {
-            BodyPath::Eb { manifest } => {
-                assert_eq!(manifest.len(), 3);
-                assert_eq!(manifest[0], vec![1u8; 32]);
-                assert_eq!(manifest[1], vec![2u8; 32]);
-                assert_eq!(manifest[2], vec![3u8; 32]);
-                // Mempool unchanged — drain-and-pin is the wrapper's
-                // follow-up commit via produce_eb.
-                assert_eq!(state.txs.len(), 3);
-                assert_eq!(state.total_bytes, 600);
-            }
-            other => panic!("expected Eb, got {other:?}"),
-        }
+        assert_eq!(body.inline.len(), 2);
+        assert_eq!(body.inline[0].tx_id, vec![1u8; 32]);
+        assert_eq!(body.inline[1].tx_id, vec![2u8; 32]);
+        assert_eq!(body.manifest.len(), 2);
+        assert_eq!(body.manifest[0], vec![3u8; 32]);
+        assert_eq!(body.manifest[1], vec![4u8; 32]);
+        // Inline txs drained; manifest txs still in the free pool
+        // pending the wrapper's produce_eb commit.
+        assert_eq!(state.txs.len(), 2);
+        assert_eq!(state.total_bytes, 400);
     }
 
     #[test]
@@ -224,115 +238,128 @@ mod tests {
         let leios = empty_leios();
         populate(&mut state, &[(1, 250), (2, 250)]); // 500 bytes, == cap
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        // total_bytes (500) is NOT > 500 → Inline.
-        assert!(matches!(body, BodyPath::Inline(_)));
+        // total_bytes (500) is NOT > 500 → inline-only.
+        assert_eq!(body.inline.len(), 2);
+        assert!(body.manifest.is_empty());
     }
 
     #[test]
-    fn boundary_one_byte_over_cap_routes_eb() {
+    fn one_byte_over_cap_routes_overflow() {
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         populate(&mut state, &[(1, 250), (2, 251)]); // 501, just over 500
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        assert!(matches!(body, BodyPath::Eb { .. }));
+        // drain_up_to(500) takes [250] (next would be 501 > 500 with
+        // non-empty result).  Residual = [251] → manifest.
+        assert_eq!(body.inline.len(), 1);
+        assert_eq!(body.inline[0].tx_id, vec![1u8; 32]);
+        assert_eq!(body.manifest, vec![vec![2u8; 32]]);
     }
 
     #[test]
-    fn empty_mempool_yields_empty_inline() {
+    fn empty_mempool_yields_all_empty() {
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        match body {
-            BodyPath::Inline(txs) => assert!(txs.is_empty()),
-            other => panic!("expected Inline, got {other:?}"),
-        }
+        assert!(body.inline.is_empty());
+        assert!(body.manifest.is_empty());
     }
 
     #[test]
-    fn eb_manifest_then_produce_eb_commits_drain() {
+    fn overflow_then_produce_eb_commits_drain() {
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
-        populate(&mut state, &[(1, 200), (2, 200), (3, 200)]);
+        populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200)]); // 800
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        let manifest = match body {
-            BodyPath::Eb { manifest } => manifest,
-            other => panic!("expected Eb, got {other:?}"),
-        };
-        // Simulate the wrapper committing.
+        // Inline drained 2; manifest still pending.
+        assert_eq!(state.txs.len(), 2);
+        assert_eq!(state.total_bytes, 400);
         let eb_key = EbKey {
             slot: 7,
             hash: [0xAA; 32],
         };
-        let (committed, _evictions) = state.produce_eb(eb_key, manifest.len());
-        assert_eq!(committed, manifest);
-        assert_eq!(state.txs.len(), 0);
+        let (committed, _evictions) = state.produce_eb(eb_key, body.manifest.len());
+        assert_eq!(committed, body.manifest);
+        assert!(state.txs.is_empty());
         assert_eq!(state.total_bytes, 0);
     }
 
     #[test]
-    fn eb_manifest_capped_by_eb_body_max_bytes() {
-        // Mempool overflows the RB cap, but the EB cap is small enough
-        // that only the FIFO prefix should be selected.
+    fn manifest_capped_by_eb_body_max_bytes() {
+        // Overflow + EB cap small enough that only a FIFO prefix of
+        // the residual ends up in the manifest.
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
-        populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200), (5, 200)]); // 1000 bytes
-        // RB cap 500, EB cap 500 → first 2 txs (400 bytes <= 500, third would push to 600)
+        populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200), (5, 200), (6, 200), (7, 200)]);
+        // 1400 bytes total, RB cap 500 → drain takes [1, 2] (400);
+        // residual = [3..7]. EB cap 500 → manifest = first 2 of
+        // residual = [3, 4] (400 ≤ 500; next would push to 600).
         let body = BodyPath::decide(&mut state, 500, 500, &leios, false);
-        let manifest = match body {
-            BodyPath::Eb { manifest } => manifest,
-            other => panic!("expected Eb, got {other:?}"),
-        };
-        assert_eq!(manifest.len(), 2);
-        assert_eq!(manifest[0], vec![1u8; 32]);
-        assert_eq!(manifest[1], vec![2u8; 32]);
-        // Mempool still has all 5 txs until produce_eb is called.
+        assert_eq!(body.inline.len(), 2);
+        assert_eq!(body.manifest.len(), 2);
+        assert_eq!(body.manifest[0], vec![3u8; 32]);
+        assert_eq!(body.manifest[1], vec![4u8; 32]);
+        // Residual txs 3..7 still in mempool; produce_eb drains the
+        // manifest prefix.
         assert_eq!(state.txs.len(), 5);
         assert_eq!(state.total_bytes, 1000);
-
         let eb_key = EbKey {
             slot: 1,
             hash: [0xAB; 32],
         };
-        let (committed, _) = state.produce_eb(eb_key, manifest.len());
+        let (committed, _) = state.produce_eb(eb_key, body.manifest.len());
         assert_eq!(committed.len(), 2);
-        // Remaining three txs still pending.
         assert_eq!(state.txs.len(), 3);
         assert_eq!(state.total_bytes, 600);
     }
 
     #[test]
-    fn eb_manifest_emits_one_when_first_tx_exceeds_cap() {
+    fn manifest_emits_one_when_first_residual_tx_exceeds_cap() {
+        // [200, 1000, 200]: drain takes [200], residual = [1000, 200].
+        // EB cap 500 → first residual tx is 1000 > 500, but emit it
+        // anyway (the "at least one" rule on a non-empty residual);
+        // the next is then skipped.
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
-        populate(&mut state, &[(1, 1000), (2, 200)]); // first alone > eb cap
+        populate(&mut state, &[(1, 200), (2, 1000), (3, 200)]);
         let body = BodyPath::decide(&mut state, 500, 500, &leios, false);
-        let manifest = match body {
-            BodyPath::Eb { manifest } => manifest,
-            other => panic!("expected Eb, got {other:?}"),
-        };
-        assert_eq!(manifest.len(), 1);
-        assert_eq!(manifest[0], vec![1u8; 32]);
+        assert_eq!(body.inline.len(), 1);
+        assert_eq!(body.manifest.len(), 1);
+        assert_eq!(body.manifest[0], vec![2u8; 32]);
     }
 
     #[test]
-    fn safety_gate_returns_empty_with_mempool_untouched() {
-        // Gate set: a chain-committed cert references an EB the local
-        // node has not validated.  Body must be Empty, mempool intact —
-        // including the overflow case which would normally route to Eb.
+    fn single_oversize_tx_inlines_with_no_eb() {
+        // Mempool = [800], RB cap = 500.  total > cap triggers the
+        // overflow branch.  drain_up_to(500) takes the lone tx (the
+        // "at least one" escape clause), mempool empties.  Residual
+        // is empty → manifest empty → no EB announcement.  An empty
+        // EB is forbidden by CIP-0164, and the struct shape naturally
+        // expresses "inline only" via the empty manifest.
+        let mut state = MempoolState::new(100);
+        let leios = empty_leios();
+        populate(&mut state, &[(1, 800)]);
+        let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
+        assert_eq!(body.inline.len(), 1);
+        assert!(body.manifest.is_empty());
+        assert!(state.txs.is_empty());
+    }
+
+    #[test]
+    fn safety_gate_returns_all_empty_with_mempool_untouched() {
         let mut state = MempoolState::new(100);
         let mut leios = empty_leios();
         leios.endorsed_unvalidated_ebs.insert([0xCC; 32], 7);
         populate(&mut state, &[(1, 400), (2, 400)]); // 800 bytes, overflows 500
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        assert!(matches!(body, BodyPath::Empty));
+        assert!(body.inline.is_empty());
+        assert!(body.manifest.is_empty());
         assert_eq!(state.txs.len(), 2);
         assert_eq!(state.total_bytes, 800);
     }
 
     #[test]
     fn safety_gate_clears_on_validated_eb() {
-        // After the body validates, the gate releases and the regular
-        // overflow rule resumes.
         let mut state = MempoolState::new(100);
         let mut leios = empty_leios();
         leios.endorsed_unvalidated_ebs.insert([0xDD; 32], 7);
@@ -342,51 +369,51 @@ mod tests {
         });
         populate(&mut state, &[(1, 100)]);
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        assert!(matches!(body, BodyPath::Inline(_)));
+        assert_eq!(body.inline.len(), 1);
+        assert!(body.manifest.is_empty());
     }
 
     #[test]
-    fn endorsement_with_small_mempool_returns_empty_not_inline() {
-        // CIP-0164: a cert and inline txs in the same RB body are
-        // mutually exclusive.  With a cert about to attach and the
-        // mempool below the overflow threshold, the only legal body
-        // is empty.
+    fn cert_with_small_mempool_returns_all_empty() {
+        // CIP-0164: cert XOR inline-body.  Mempool below the overflow
+        // threshold → mempool too small to motivate an EB → the only
+        // legal body is empty; mempool waits for a later RB.
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         populate(&mut state, &[(1, 100), (2, 100), (3, 100)]); // 300 bytes < 500
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, true);
-        assert!(matches!(body, BodyPath::Empty));
-        // Mempool must be untouched — the txs wait for a later RB.
+        assert!(body.inline.is_empty());
+        assert!(body.manifest.is_empty());
         assert_eq!(state.txs.len(), 3);
         assert_eq!(state.total_bytes, 300);
     }
 
     #[test]
-    fn endorsement_with_overflowing_mempool_routes_eb() {
-        // A cert in the header coexists with a fresh EB announcement
-        // (the announcement is header-side, body stays empty).  This
-        // path is legal under CIP-0164.
+    fn cert_with_overflowing_mempool_announces_eb_with_empty_body() {
+        // Cert + overflow: inline stays empty (cert XOR inline), the
+        // full mempool overflow lands in the manifest.  Cert ships in
+        // the header alongside the fresh EB announcement — legal
+        // under CIP-0164 (announcement is header-side).
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         populate(&mut state, &[(1, 400), (2, 400)]); // 800 bytes > 500
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, true);
-        match body {
-            BodyPath::Eb { manifest } => {
-                assert_eq!(manifest.len(), 2);
-            }
-            other => panic!("expected Eb, got {other:?}"),
-        }
+        assert!(body.inline.is_empty());
+        assert_eq!(body.manifest.len(), 2);
+        // Cert + inline-body is forbidden, but the mempool is left
+        // intact (manifest commit happens via produce_eb).
+        assert_eq!(state.txs.len(), 2);
+        assert_eq!(state.total_bytes, 800);
     }
 
     #[test]
-    fn no_endorsement_with_small_mempool_inlines() {
-        // Sanity: with no cert this slot, the small-mempool path
-        // still drains into Inline (Praos fallback).
+    fn no_cert_with_small_mempool_inlines() {
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
         populate(&mut state, &[(1, 100)]);
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
-        assert!(matches!(body, BodyPath::Inline(_)));
-        assert_eq!(state.txs.len(), 0);
+        assert_eq!(body.inline.len(), 1);
+        assert!(body.manifest.is_empty());
+        assert!(state.txs.is_empty());
     }
 }

--- a/sim-rs/sim-core/src/sim/shared_consensus.rs
+++ b/sim-rs/sim-core/src/sim/shared_consensus.rs
@@ -791,10 +791,10 @@ impl NodeImpl for SharedConsensus {
 impl SharedConsensus {
     /// Lottery win for slot `slot` (winning draw `vrf`): pick the body
     /// path via [`BodyPath::decide`] and schedule
-    /// `CpuTask::RBBlockGenerated`.  The `Eb` path also commits the
-    /// drain via [`MempoolState::produce_eb`] under a hash derived from
-    /// the EB id — a sim convenience that stands in for real Blake2b
-    /// hashing of wire bytes.
+    /// `CpuTask::RBBlockGenerated`.  A non-empty manifest also commits
+    /// the drain via [`MempoolState::produce_eb`] under a hash derived
+    /// from the EB id — a sim convenience that stands in for real
+    /// Blake2b hashing of wire bytes.
     fn try_produce_rb(&mut self, slot: u64, vrf: u64, out: &mut EventResult) {
         let block_id = BlockId {
             slot,
@@ -841,42 +841,45 @@ impl SharedConsensus {
             &self.leios,
             endorsement_present,
         );
-        let (rb_txs, eb_pair) = match body {
-            BodyPath::Empty => (Vec::new(), None),
-            BodyPath::Inline(pending) => (self.collect_arcs(pending), None),
-            BodyPath::Eb { manifest } => {
-                // Commit the drain — `produce_eb` moves the manifest's
-                // txs into `eb_pinned` under the given EbKey.  We
-                // synthesise a deterministic hash from the producer +
-                // slot since sim doesn't model Blake2b on wire bytes.
-                let eb_id = EndorserBlockId {
+        // `inline` becomes the RB body; `manifest` becomes a fresh EB
+        // announcement.  Both may carry txs in the same RB (CIP-0164
+        // overflow: drain RB body, EB ships the residual).
+        let rb_txs = self.collect_arcs(body.inline);
+        let eb_pair = if body.manifest.is_empty() {
+            None
+        } else {
+            // Commit the drain — `produce_eb` moves the manifest's
+            // txs into `eb_pinned` under the given EbKey.  We
+            // synthesise a deterministic hash from the producer +
+            // slot since sim doesn't model Blake2b on wire bytes.
+            let eb_id = EndorserBlockId {
+                slot,
+                pipeline: 0,
+                producer: self.id,
+            };
+            let eb_hash = synthesize_eb_hash(eb_id);
+            let (_committed, mempool_fx) = self.mempool.produce_eb(
+                EbKey {
                     slot,
-                    pipeline: 0,
-                    producer: self.id,
-                };
-                let eb_hash = synthesize_eb_hash(eb_id);
-                let (_committed, mempool_fx) = self.mempool.produce_eb(
-                    EbKey {
-                        slot,
-                        hash: eb_hash,
-                    },
-                    manifest.len(),
-                );
-                self.apply_mempool_effects(out, mempool_fx);
-                // Pull the body Arcs from `tx_arcs` in manifest order.
-                let txs: Vec<Arc<Transaction>> = manifest
-                    .iter()
-                    .filter_map(|id| self.tx_arcs.get(id).cloned())
-                    .collect();
-                let bytes = self.sim_config.sizes.linear_eb(&txs);
-                let eb = LinearEndorserBlock {
-                    slot,
-                    producer: self.id,
-                    bytes,
-                    txs: txs.clone(),
-                };
-                (Vec::new(), Some((eb, txs)))
-            }
+                    hash: eb_hash,
+                },
+                body.manifest.len(),
+            );
+            self.apply_mempool_effects(out, mempool_fx);
+            // Pull the body Arcs from `tx_arcs` in manifest order.
+            let txs: Vec<Arc<Transaction>> = body
+                .manifest
+                .iter()
+                .filter_map(|id| self.tx_arcs.get(id).cloned())
+                .collect();
+            let bytes = self.sim_config.sizes.linear_eb(&txs);
+            let eb = LinearEndorserBlock {
+                slot,
+                producer: self.id,
+                bytes,
+                txs: txs.clone(),
+            };
+            Some((eb, txs))
         };
 
         let rb = LinearRankingBlock {


### PR DESCRIPTION
## Summary

CIP-0164 §Step 1 says *"EBs should only be announced if a transaction cannot be included in the base RB"* and §Step 5 rule 1 only forbids **cert + inline body** (not EB-announcement + inline body). The intent is to **fill the RB body first** and announce an EB for the residual.

shared-consensus's `BodyPath` was treating the overflow case as XOR (`Inline | Eb`): when `mempool > rb_body_max_bytes`, the body went empty and the full overflow went to a new EB. So when EB certification stalls (lazy voters, RB-too-early, etc.) the mempool stayed in overflow, every subsequent RB body stayed empty, and Praos liveness was lost.

This PR reshapes `BodyPath` so the inline body and EB announcement can carry txs in the same RB. Empty-on-safety-gate and cert-XOR-inline-body are preserved.

## Changes

- `BodyPath` is now a struct `{ inline: Vec<PendingTx>, manifest: Vec<TxId> }`. The four CIP-0164-legal combinations encode directly via which fields are empty; no enum match needed at consumers.
- `BodyPath::decide` overflow branch drains `rb_body_max_bytes` into `inline` (skipped when a cert ships), then collects the FIFO residual into `manifest` capped at `eb_body_max_bytes`. When a single oversize tx exhausts the mempool, `manifest` falls out empty naturally — no defensive branch.
- net-node mempool wrapper + production driver: mirrored to the struct shape; emits the EB iff the manifest is non-empty.
- sim-rs shared_consensus adapter: same.

## Verification

- shared-consensus: 270 unit tests pass (production.rs tests rewritten; added `overflow_fills_body_then_announces_residual` and `single_oversize_tx_inlines_with_no_eb`).
- net-node: 118 tests pass (only `eb_path_on_overflow` adjusted: now asserts `included_tx_count == 2` instead of `0`).
- sim-core: 55 tests pass.

End-to-end check with a 30-node cluster on `sample-cluster-lazy-voter.toml` (lazy fraction bumped to 0.5 → ~55% lazy stake → quorum never reaches the 75% threshold):

```
=== Leios Pipeline (all nodes) ===
  produced endorser:        5    (all logged "(overflow)")
  eb election created:      150
  vote produced:            20
  quorum reached:           0    ← certs never form
```

Every produced RB:
```
tx_count=9 has_eb=true
tx_count=7 has_eb=true
tx_count=7 has_eb=true
...
```

`tx_count` is 7-9 because RB cap is 64KB and txs are 250-16,384 B random (~8KB avg). Before this PR, all of those would have been `tx_count=0 has_eb=true` and no txs would have reached the chain via Praos while certs were failing.

## Test plan

- [x] `cargo test -p shared-consensus`
- [x] `cargo test -p net-node`
- [x] `cargo test` in sim-rs workspace
- [x] 30-node cluster run with forced cert failure (lazy voter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)