### PR TITLE
Stake-weighted quorum for StakeCentile (CIP-164 PR #1196)

### DIFF
--- a/data/simulation/config.default.yaml
+++ b/data/simulation/config.default.yaml
@@ -221,8 +221,14 @@ eb-body-avg-size-bytes: 2500000
 persistent-vote-generation-probability: 400.0
 non-persistent-vote-generation-probability: 100.0
 # vote-spec#"Committee and quorum size"
-# 60% of total vote-generation-probability
-vote-threshold: 300
+# Fraction of expected total weight required for quorum (CIP-0164
+# default is 0.75; legacy sim runs used 0.6 = old absolute 300 / 500).
+# The absolute threshold is derived per committee mode:
+#   wfa-ls             → quorum-weight-fraction × (PV + NPV)
+#   everyone           → quorum-weight-fraction × N nodes
+#   top-stake-fraction → quorum-weight-fraction × total active stake
+# Replaces the old `vote-threshold` knob; see CIP-164 PR #1196.
+quorum-weight-fraction: 0.6
 # vote-spec#"Generate vote"
 persistent-vote-generation-cpu-time-ms: 135e-3
 non-persistent-vote-generation-cpu-time-ms: 280e-3
@@ -251,7 +257,9 @@ vote-validation-cpu-time-ms: 816e-3
 vote-bundle-size-bytes-per-eb: 105
 
 # Committee selection algorithm: "wfa-ls" (default), "everyone", or "top-stake-fraction"
-# For "everyone" or "top-stake-fraction", adjust vote-threshold manually.
+# The same `quorum-weight-fraction` knob applies to all modes; the
+# absolute threshold is derived from it via the mode-specific
+# denominator (see above).
 committee-selection-algorithm: "wfa-ls"
 # Fraction of total stake eligible to vote when using "top-stake-fraction".
 committee-stake-fraction-threshold: 0.95

--- a/data/simulation/config.schema.json
+++ b/data/simulation/config.schema.json
@@ -755,9 +755,8 @@
     "non-persistent-vote-generation-probability": {
       "type": "number"
     },
-    "vote-threshold": {
-      "additionalProperties": false,
-      "properties": {},
+    "quorum-weight-fraction": {
+      "description": "Fraction of expected total weight required for quorum. Replaces the old `vote-threshold` knob. CIP-0164 default 0.75; legacy sim runs used 0.6. For `top-stake-fraction` selection the denominator is total active stake (CIP-164 PR #1196).",
       "type": "number"
     },
     "vote-validation-cpu-time-ms": {

--- a/net-rs/net-node/configs/mainnet.toml
+++ b/net-rs/net-node/configs/mainnet.toml
@@ -19,11 +19,15 @@ rb_generation_probability = 0.05
 vote_generation_probability = 0.8
 stage_length_slots = 20
 
-# Top-stake-fraction committee selection: every pool covered by the
-# top `top_centile_of_stake` of stake casts one weight-1 vote, so the
-# quorum threshold is `floor(0.75 × committee_size)`.  Keeps the
-# threshold proportional to the cluster's actual voter count rather
-# than the wFA-LS reserve, which assumes mainnet-scale pool counts.
+# Top-stake-fraction committee selection (CIP-164 PR #1196): pools
+# covered by the top `top_centile_of_stake` of stake form the committee,
+# and each member's vote weight is its own stake.  Quorum is
+# `quorum_stake_fraction × total_active_stake`, not a fraction of
+# committee head-count — so the threshold scales with real stake
+# concentration rather than the wFA-LS reserve.
+# Invariant: `top_centile_of_stake > quorum_stake_fraction` (σ_c > τ),
+# otherwise the committee cannot meet quorum even unanimously and the
+# node refuses to start.
 [production.committee_selection]
 type = "StakeCentile"
 top_centile_of_stake = 0.99

--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -17,7 +17,7 @@ use shared_consensus::leios::{
 };
 pub use shared_consensus::leios::EbTxMatchOutcome;
 pub use shared_consensus::pipeline::PipelineConfig;
-use shared_consensus::wfa;
+use shared_consensus::committee;
 use net_core::multi_peer::types::{NetworkCommand, NetworkEvent};
 use net_core::types::Point;
 use rand::rngs::StdRng;
@@ -68,9 +68,12 @@ impl LeiosConsensus {
     ) -> Self {
         let total_stake: u64 = stake_registry_entries.iter().map(|e| e.stake).sum();
         let persistent_committee =
-            wfa::build_committee(&committee_selection, stake_registry_entries, committee_seed);
-        let expected_committee_size =
-            wfa::expected_committee_size(&committee_selection, &persistent_committee);
+            committee::build_committee(&committee_selection, stake_registry_entries, committee_seed);
+        let expected_total_weight = committee::expected_total_weight(
+            &committee_selection,
+            &persistent_committee,
+            total_stake,
+        );
         let persistent_seats = persistent_committee.get(&node_id).copied().unwrap_or(0);
         let stake_registry: BTreeMap<String, u64> = stake_registry_entries
             .iter()
@@ -91,20 +94,27 @@ impl LeiosConsensus {
         info!(
             node_id = %node_id,
             persistent_seats,
-            expected_committee_size,
+            expected_total_weight,
             committee_pools = persistent_committee.len(),
             "leios committee initialized"
         );
-        let elections = Elections::new(ElectionsConfig {
+        let elections_config = ElectionsConfig {
             node_id: node_id.clone(),
             pipeline,
             committee_selection,
             persistent_committee,
             stake_registry,
             total_stake,
-            expected_committee_size,
+            expected_total_weight,
             quorum_weight_fraction,
-        });
+        };
+        // σ_c > τ — CIP-164 PR #1196.  Unreachable-quorum configs
+        // produce no certificates; surface the misconfiguration at
+        // boot rather than running silently.
+        if let Err(err) = elections_config.validate() {
+            panic!("leios elections config invalid: {err}");
+        }
+        let elections = Elections::new(elections_config);
         let state = LeiosState::new(node_id, elections, voting_config, pipeline);
         Self {
             state,
@@ -802,7 +812,7 @@ mod tests {
     //
     // Under EveryoneVotes (test_leios mode) every registered pool has 1
     // PV seat, so each PV vote contributes weight 1. The 10-pool test
-    // registry yields expected_committee_size=10; quorum at 0.75 needs
+    // registry yields expected_total_weight=10; quorum at 0.75 needs
     // ≥7 distinct voters. Voter ids in tests must match registry node_ids
     // ("test", "peer-0".."peer-8") for the PV-lookup weight to be 1.
 

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -618,7 +618,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 1000,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         });
         let voting = VotingConfig {

--- a/shared-rs/consensus/CLAUDE.md
+++ b/shared-rs/consensus/CLAUDE.md
@@ -26,7 +26,7 @@ No `tokio`, no networking, no clock reads, no file I/O.
   (`on_block_received`, `retry_select_chain`, …). The state machine
   never calls `Instant::now()` or `SystemTime::now()` itself.
 - Randomness is **deterministic and stake-keyed** — all uses go through
-  `wfa.rs` helpers seeded by `(eb_hash, voter_id)` style inputs. No
+  `committee.rs` helpers seeded by `(eb_hash, voter_id)` style inputs. No
   `from_entropy` / `thread_rng`.
 - Tracing (`info!`, `warn!`) is allowed; it's a side-effect-free sink
   from the state machine's perspective.
@@ -86,7 +86,7 @@ types.rs            Point, Tip with minicbor codec
 peer.rs             PeerId(u64) wrapper
 config.rs           CommitteeSelection enum, StakeEntry
 pipeline.rs         PipelineConfig — phase math (Voting/CertEligible/Expired)
-wfa.rs              wFA + LS committee selection, NPV lottery
+committee.rs        Committee selection (WfaLs, EveryoneVotes, StakeCentile), NPV lottery
 lottery.rs          Praos f_block stake-weighted threshold formula
 aggregation.rs      record_vote, QuorumFormed
 bitmap.rs           sparse BTreeMap<u16, u64> for MsgLeiosBlockTxsRequest

--- a/shared-rs/consensus/README.md
+++ b/shared-rs/consensus/README.md
@@ -14,7 +14,7 @@ implementation.
 | `peer`          | `PeerId(u64)` newtype                                            |
 | `config`        | `CommitteeSelection` enum (WfaLs / EveryoneVotes / StakeCentile) |
 | `pipeline`      | EB lifecycle phases (Voting → CertEligible → expiry)             |
-| `wfa`           | Weighted Fait Accompli + Local Sortition committee selection     |
+| `committee`     | Committee selection (WfaLs, EveryoneVotes, StakeCentile), NPV lottery |
 | `lottery`       | Praos f_block stake-weighted threshold formula                   |
 | `aggregation`   | Per-EB vote tally, quorum detection                              |
 | `bitmap`        | Sparse `BTreeMap<u16, u64>` for `MsgLeiosBlockTxsRequest`        |
@@ -53,7 +53,7 @@ graph TD
         Production[production: BodyPath]
         Elections["Elections<br/>per-EB voting state"]
         Pipeline[PipelineConfig]
-        Wfa[wfa]
+        Committee[committee]
         Lottery[lottery]
         Agg[aggregation]
         ChainTree[chain_tree]
@@ -409,7 +409,7 @@ introduce non-determinism. The constraints:
   emits all `EligibleToVote` (sorted by `eb_hash`) before any
   `Expired`.
 - Time enters as `Instant` parameters, never `Instant::now()`.
-- Randomness flows through `wfa.rs` and `lottery.rs` helpers seeded by
+- Randomness flows through `committee.rs` and `lottery.rs` helpers seeded by
   stable bytes (EB hash, voter id, stake) — there is no `thread_rng`
   or `from_entropy` call anywhere in the crate.
 - Behaviours follow the same rules: they take a seed at construction
@@ -420,7 +420,7 @@ introduce non-determinism. The constraints:
 ```mermaid
 graph TD
     leios --> elections
-    leios --> wfa
+    leios --> committee
     leios --> pipeline
     leios --> aggregation
     leios --> fetch
@@ -439,13 +439,13 @@ graph TD
     production --> mempool
     elections --> aggregation
     elections --> pipeline
-    elections --> wfa
+    elections --> committee
     elections --> config
     aggregation --> pipeline
     chain_tree --> types
     peer_chain --> types
     pipeline --> config
-    wfa --> config
+    committee --> config
     fetch --> bitmap
     fetch --> peer
     fetch --> types

--- a/shared-rs/consensus/src/aggregation.rs
+++ b/shared-rs/consensus/src/aggregation.rs
@@ -82,7 +82,10 @@ pub fn record_vote(
     }
 
     let voted_weight: u64 = election.voter_weights.values().sum();
-    let threshold = (quorum_weight_fraction * expected_total_weight as f64) as u64;
+    // Ceiling so the integer threshold really enforces the doc's
+    // `Σ weight ≥ τ × total`: truncating a 2.25 product to 2 would
+    // accept 2/3 = 66% under a τ = 75% quorum.
+    let threshold = (quorum_weight_fraction * expected_total_weight as f64).ceil() as u64;
     if voted_weight < threshold {
         return None;
     }

--- a/shared-rs/consensus/src/aggregation.rs
+++ b/shared-rs/consensus/src/aggregation.rs
@@ -18,10 +18,15 @@ pub struct QuorumFormed {
 }
 
 /// Record a vote for an EB. Deduplicates by `(voter_id, tag)`. The
-/// `weight` argument is what the aggregator derived for this body —
-/// for PV votes it's the cached persistent-committee seat count; for
-/// NPV votes it's the result of re-running the lottery from the
-/// embedded eligibility signature and the voter's stake.
+/// `weight` argument is what the aggregator derived for this body, in
+/// units matching `expected_total_weight`:
+///
+/// - `WfaLs`: persistent-committee seat count (PV) or the result of
+///   re-running the NPV lottery from the embedded eligibility
+///   signature and the voter's stake.
+/// - `EveryoneVotes`: `1` per voter.
+/// - `StakeCentile`: the voter's stake (`expected_total_weight` is
+///   then `total_active_stake`, matching CIP-164 PR #1196).
 ///
 /// If no election exists for `eb_hash`, a vote-placeholder is created
 /// at `(eb_slot, current_slot)` with `body_validated_locally = false`.
@@ -31,7 +36,7 @@ pub struct QuorumFormed {
 /// EB-safety gate then ensures any cert built from such an aggregate
 /// rides on an empty RB body until the closure validates.
 ///
-/// Quorum: `Σ weight ≥ quorum_fraction × expected_committee_size`.
+/// Quorum: `Σ weight ≥ quorum_weight_fraction × expected_total_weight`.
 /// Returns `Some(QuorumFormed)` exactly once per election.
 #[allow(clippy::too_many_arguments)]
 pub fn record_vote(
@@ -39,9 +44,9 @@ pub fn record_vote(
     eb_hash: &[u8; 32],
     eb_slot: u64,
     voter_id: Vec<u8>,
-    weight: u32,
+    weight: u64,
     quorum_weight_fraction: f64,
-    expected_committee_size: u32,
+    expected_total_weight: u64,
     current_slot: u64,
     pipeline: PipelineConfig,
     node_id: &str,
@@ -76,8 +81,8 @@ pub fn record_vote(
         return None;
     }
 
-    let voted_weight: u64 = election.voter_weights.values().map(|w| *w as u64).sum();
-    let threshold = (quorum_weight_fraction * expected_committee_size as f64) as u64;
+    let voted_weight: u64 = election.voter_weights.values().sum();
+    let threshold = (quorum_weight_fraction * expected_total_weight as f64) as u64;
     if voted_weight < threshold {
         return None;
     }
@@ -117,7 +122,7 @@ mod tests {
 
     /// Default quorum: 75% of 1000 = 750 weight.
     const QUORUM_FRACTION: f64 = 0.75;
-    const EXPECTED_COMMITTEE_SIZE: u32 = 1000;
+    const EXPECTED_TOTAL_WEIGHT: u64 = 1000;
     const EB_SLOT: u64 = 10;
     /// `current_slot = 11`, `eb_slot = 10`, delta_hdr=1 → elapsed=1 lands
     /// at the start of the Voting phase, matching `make_election`'s
@@ -153,7 +158,7 @@ mod tests {
         elections: &mut BTreeMap<[u8; 32], EbElection>,
         hash: &[u8; 32],
         voter_id: Vec<u8>,
-        weight: u32,
+        weight: u64,
     ) {
         record_vote(
             elections,
@@ -162,7 +167,7 @@ mod tests {
             voter_id,
             weight,
             QUORUM_FRACTION,
-            EXPECTED_COMMITTEE_SIZE,
+            EXPECTED_TOTAL_WEIGHT,
             CURRENT_SLOT,
             test_pipeline(),
             "test",
@@ -217,11 +222,11 @@ mod tests {
         elections.insert(hash, election);
 
         // 750 distinct voters × weight 1 each crosses 750 threshold.
-        for i in 0u32..749 {
+        for i in 0u64..749 {
             vote(&mut elections, &hash, i.to_le_bytes().to_vec(), 1);
             assert!(!elections[&hash].quorum_reached);
         }
-        vote(&mut elections, &hash, 749u32.to_le_bytes().to_vec(), 1);
+        vote(&mut elections, &hash, 749u64.to_le_bytes().to_vec(), 1);
         assert!(elections[&hash].quorum_reached);
     }
 
@@ -266,5 +271,44 @@ mod tests {
         vote(&mut elections, &hash, vec![3], 200);
         assert!(elections[&hash].quorum_reached);
         assert_eq!(elections[&hash].voter_weights.len(), 3);
+    }
+
+    /// CIP-164 PR #1196: under stake-weighted quorum the denominator is
+    /// total active stake and per-voter "weight" is the voter's own
+    /// stake.  A small set of large-stake voters can therefore reach
+    /// quorum without majority head-count participation.
+    #[test]
+    fn quorum_reached_when_high_stake_minority_votes() {
+        let mut elections = BTreeMap::new();
+        let (hash, election) = make_election(10);
+        elections.insert(hash, election);
+
+        // Stake distribution [600, 200, 100, 100] = total 1000.
+        // τ = 0.75 → threshold 750 stake-units.
+        vote(&mut elections, &hash, vec![1], 600);
+        assert!(!elections[&hash].quorum_reached);
+        vote(&mut elections, &hash, vec![2], 200);
+        // 800 ≥ 750 — quorum reached with only 2 of 4 voters.
+        assert!(elections[&hash].quorum_reached);
+    }
+
+    /// Mirror of the above: a head-count majority of small-stake voters
+    /// must NOT reach the stake-weighted quorum if their combined stake
+    /// falls short.  This is the security property PR #1196 protects.
+    #[test]
+    fn quorum_blocked_when_low_stake_majority_votes() {
+        let mut elections = BTreeMap::new();
+        let (hash, election) = make_election(10);
+        elections.insert(hash, election);
+
+        // Stake distribution [600, 50 × 8] = total 1000.  All eight
+        // 50-stake voters vote; the 600-stake voter abstains.  Vote
+        // count 8 > 1, but vote stake 400 < threshold 750 — quorum
+        // must NOT fire.
+        for i in 0u64..8 {
+            vote(&mut elections, &hash, i.to_le_bytes().to_vec(), 50);
+        }
+        assert!(!elections[&hash].quorum_reached);
+        assert_eq!(elections[&hash].voter_weights.len(), 8);
     }
 }

--- a/shared-rs/consensus/src/behaviour/behaviours/lazy_voter.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/lazy_voter.rs
@@ -78,7 +78,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 100,
-            expected_committee_size: 1,
+            expected_total_weight: 1,
             quorum_weight_fraction: 0.75,
         });
         let voting = VotingConfig {

--- a/shared-rs/consensus/src/behaviour/behaviours/rb_equivocator.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/rb_equivocator.rs
@@ -146,7 +146,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 100,
-            expected_committee_size: 1,
+            expected_total_weight: 1,
             quorum_weight_fraction: 0.75,
         });
         let voting = VotingConfig {

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -764,7 +764,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 100,
-            expected_committee_size: 1,
+            expected_total_weight: 1,
             quorum_weight_fraction: 0.75,
         });
         let voting = VotingConfig {

--- a/shared-rs/consensus/src/committee.rs
+++ b/shared-rs/consensus/src/committee.rs
@@ -1,15 +1,23 @@
-//! Weighted Fait Accompli (wFA) persistent committee allocation.
+//! Committee selection and the per-vote weight denominator.
 //!
-//! Each node, at the same epoch boundary, runs the same deterministic
-//! stake-weighted lottery to allocate `persistent_voters` seats among the
-//! pools in the stake registry. Identical inputs → identical outputs, so
-//! every node arrives at the same persistent committee without
-//! communication.
+//! Each node, at the same epoch boundary, derives the same committee
+//! from the stake registry under the configured
+//! [`crate::config::CommitteeSelection`].  Three schemes are
+//! supported:
 //!
-//! Algorithm: independent multinomial draws from the cumulative stake
-//! distribution. A pool with stake `s` out of `T` total receives each seat
-//! with probability `s/T`; expected total seats per pool ≈ `N_pv × s/T`.
-//! High-stake pools may win multiple seats; zero-stake pools win none.
+//! - `WfaLs`: weighted Fait Accompli + Local Sortition.  Stake-weighted
+//!   lottery for persistent seats; per-EB NPV draws fill the rest.
+//!   Multi-seat per pool.
+//! - `EveryoneVotes`: every registered node gets one seat regardless
+//!   of stake.  Extreme-test mode that drives the maximum voter set.
+//! - `StakeCentile` (CIP-164 PR #1196): pools sorted by stake
+//!   descending, given one seat each until cumulative stake covers the
+//!   configured top centile.
+//!
+//! `expected_total_weight` returns the quorum denominator in the units
+//! the aggregator sums: seats (WfaLs PV+NPV), node count (Everyone),
+//! or total active stake (StakeCentile).  Per-voter weight is supplied
+//! by `Elections::weight_for`.
 
 use std::collections::BTreeMap;
 
@@ -112,21 +120,34 @@ fn top_centile_committee(
     committee
 }
 
-/// Total expected vote weight per EB across the network. Used as the
-/// denominator for the quorum threshold: `Σ weight ≥ q × this`.
-pub fn expected_committee_size(
+/// Total expected vote weight per EB across the network — the quorum
+/// denominator `Σ weight ≥ quorum_weight_fraction × this`.
+///
+/// Units are mode-dependent and must match the per-voter weights the
+/// aggregator records via `Elections::weight_for`:
+///
+/// - `WfaLs`: persistent seat count + non-persistent voter pool size.
+/// - `EveryoneVotes`: number of committee members (each weighted `1`).
+/// - `StakeCentile` (CIP-164 PR #1196): `total_active_stake` — the
+///   security property the certificate proves is "votes from pools
+///   holding ≥ τ of total active stake have signed", so the
+///   denominator is the network total, not the committee subtotal.
+pub fn expected_total_weight(
     selection: &CommitteeSelection,
     committee: &BTreeMap<String, u32>,
-) -> u32 {
-    let pv: u32 = committee.values().sum();
-    let npv = match selection {
+    total_active_stake: u64,
+) -> u64 {
+    match selection {
         CommitteeSelection::WfaLs {
             non_persistent_voters,
             ..
-        } => *non_persistent_voters,
-        _ => 0,
-    };
-    pv + npv
+        } => {
+            let pv: u64 = committee.values().map(|w| *w as u64).sum();
+            pv + *non_persistent_voters as u64
+        }
+        CommitteeSelection::EveryoneVotes => committee.values().map(|w| *w as u64).sum(),
+        CommitteeSelection::StakeCentile { .. } => total_active_stake,
+    }
 }
 
 /// Construct the deterministic NPV eligibility signature for a given
@@ -345,28 +366,38 @@ mod tests {
         assert!(!committee.contains_key("relay"));
     }
 
-    // -- expected_committee_size --------------------------------------------
+    // -- expected_total_weight ----------------------------------------------
 
     #[test]
-    fn expected_size_wfa_ls_is_pv_plus_npv() {
+    fn expected_weight_wfa_ls_is_pv_plus_npv() {
         let selection = CommitteeSelection::WfaLs {
             persistent_voters: 480,
             non_persistent_voters: 120,
         };
         let mut committee = BTreeMap::new();
         committee.insert("a".to_string(), 480u32);
-        assert_eq!(expected_committee_size(&selection, &committee), 600);
+        assert_eq!(expected_total_weight(&selection, &committee, 0), 600);
     }
 
     #[test]
-    fn expected_size_everyone_no_npv() {
+    fn expected_weight_everyone_no_npv() {
         let mut committee = BTreeMap::new();
         committee.insert("a".to_string(), 1);
         committee.insert("b".to_string(), 1);
         assert_eq!(
-            expected_committee_size(&CommitteeSelection::EveryoneVotes, &committee),
+            expected_total_weight(&CommitteeSelection::EveryoneVotes, &committee, 0),
             2
         );
+    }
+
+    #[test]
+    fn expected_weight_stake_centile_is_total_active_stake() {
+        let selection = CommitteeSelection::StakeCentile {
+            top_centile_of_stake: 0.95,
+        };
+        // Committee contents irrelevant — denominator is the network total.
+        let committee = BTreeMap::new();
+        assert_eq!(expected_total_weight(&selection, &committee, 1_000_000), 1_000_000);
     }
 
     // -- NPV eligibility ----------------------------------------------------

--- a/shared-rs/consensus/src/elections.rs
+++ b/shared-rs/consensus/src/elections.rs
@@ -17,7 +17,7 @@ use tracing::info;
 use crate::aggregation::{self, hex_prefix, QuorumFormed};
 use crate::config::CommitteeSelection;
 use crate::pipeline::{EbElection, PipelineConfig, PipelinePhase};
-use crate::wfa;
+use crate::committee;
 
 /// What the caller should do as a result of a slot tick.
 ///
@@ -49,23 +49,74 @@ pub enum SlotEffect {
     },
 }
 
+/// Returned by [`ElectionsConfig::validate`] for invariant violations
+/// callers want to surface at startup rather than at quorum-check time.
+#[derive(Debug, PartialEq)]
+pub enum ElectionsConfigError {
+    /// CIP-164 PR #1196 requires the committee to cover strictly more
+    /// stake than quorum demands.  At `top_centile_of_stake ≤
+    /// quorum_weight_fraction`, even unanimous participation by the
+    /// committee cannot satisfy the quorum and certification is
+    /// unreachable.
+    StakeCentileQuorumUnreachable { sigma_c: f64, tau: f64 },
+}
+
+impl std::fmt::Display for ElectionsConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StakeCentileQuorumUnreachable { sigma_c, tau } => write!(
+                f,
+                "stake-centile committee must cover more stake than the quorum fraction \
+                 (σ_c={sigma_c} ≤ τ={tau})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ElectionsConfigError {}
+
 /// Configuration for an `Elections` instance.
 pub struct ElectionsConfig {
     pub node_id: String,
     pub pipeline: PipelineConfig,
     pub committee_selection: CommitteeSelection,
     /// Per-pool persistent committee allocation, identical on every node
-    /// (computed via `wfa::build_committee` at startup).
+    /// (computed via `committee::build_committee` at startup).
     pub persistent_committee: BTreeMap<String, u32>,
     /// Network-wide stake registry, used to re-run the NPV lottery for
     /// incoming non-persistent votes.
     pub stake_registry: BTreeMap<String, u64>,
     pub total_stake: u64,
-    /// `Σ persistent_seats + non_persistent_voters`. Quorum threshold base.
-    pub expected_committee_size: u32,
-    /// Fraction of expected committee weight required for quorum
+    /// Quorum denominator in the same units the aggregator sums
+    /// per-voter weights — seats for `WfaLs`, node count for
+    /// `EveryoneVotes`, total active stake for `StakeCentile`.
+    /// Compute via [`committee::expected_total_weight`].
+    pub expected_total_weight: u64,
+    /// Fraction of expected total weight required for quorum
     /// (e.g. 0.75 = 75%).
     pub quorum_weight_fraction: f64,
+}
+
+impl ElectionsConfig {
+    /// Reject configurations that are guaranteed to fail at
+    /// quorum-check time.  Production callers (the sim adapter,
+    /// real-node bootstrap) invoke this before [`Elections::new`];
+    /// test fixtures may construct `Elections` directly when the
+    /// scenario only exercises code below the quorum step.
+    pub fn validate(&self) -> Result<(), ElectionsConfigError> {
+        if let CommitteeSelection::StakeCentile {
+            top_centile_of_stake,
+        } = self.committee_selection
+        {
+            if top_centile_of_stake <= self.quorum_weight_fraction {
+                return Err(ElectionsConfigError::StakeCentileQuorumUnreachable {
+                    sigma_c: top_centile_of_stake,
+                    tau: self.quorum_weight_fraction,
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 pub struct Elections {
@@ -184,7 +235,7 @@ impl Elections {
         eb_hash: &[u8; 32],
         eb_slot: u64,
         voter_key: Vec<u8>,
-        weight: u32,
+        weight: u64,
     ) -> Option<QuorumFormed> {
         aggregation::record_vote(
             &mut self.elections,
@@ -193,34 +244,54 @@ impl Elections {
             voter_key,
             weight,
             self.cfg.quorum_weight_fraction,
-            self.cfg.expected_committee_size,
+            self.cfg.expected_total_weight,
             self.current_slot,
             self.cfg.pipeline,
             &self.cfg.node_id,
         )
     }
 
-    /// Derive the weight to attribute to a decoded vote body.
+    /// Derive the weight to attribute to a decoded vote body, in the
+    /// units `expected_total_weight` is denominated in for this
+    /// committee mode.
     ///
-    /// - `tag == 0` (PV): looks up the voter's persistent-committee seat
-    ///   count (`0` if not seated).
-    /// - `tag == 1` (NPV): re-runs the NPV lottery from the embedded
-    ///   eligibility signature and the voter's stake.  If the voter
-    ///   *also* holds a persistent seat, returns `0` — CIP-0164
-    ///   partitions persistent (indices `[1, n₁]`) and non-persistent
-    ///   candidate (`[i*, |P|]`) pools disjointly, so a verified NPV
-    ///   signature from a persistent-seated voter is spec-violating
-    ///   and must not contribute weight.
-    /// - any other tag, or NPV without a signature: `0`.
-    pub fn weight_for(&self, voter_id: &str, tag: u8, npv_signature: Option<&[u8]>) -> u32 {
-        match (tag, npv_signature) {
-            (0, _) => self
+    /// - `tag == 0` (PV) under `WfaLs`/`EveryoneVotes`: the voter's
+    ///   persistent-committee seat count (`0` if not seated).
+    /// - `tag == 0` (PV) under `StakeCentile` (CIP-164 PR #1196):
+    ///   the voter's stake from the registry, but only if it is on
+    ///   the deterministic committee (otherwise `0`).  The quorum
+    ///   denominator is total active stake, so each member contributes
+    ///   its own stake.
+    /// - `tag == 1` (NPV) under `WfaLs`: re-runs the NPV lottery from
+    ///   the embedded eligibility signature and the voter's stake.  If
+    ///   the voter *also* holds a persistent seat, returns `0` —
+    ///   CIP-0164 partitions persistent (indices `[1, n₁]`) and
+    ///   non-persistent candidate (`[i*, |P|]`) pools disjointly, so a
+    ///   verified NPV signature from a persistent-seated voter is
+    ///   spec-violating and must not contribute weight.
+    /// - NPV tag under non-`WfaLs` modes (no NPV phase), or any other
+    ///   tag, or NPV without a signature: `0`.
+    pub fn weight_for(&self, voter_id: &str, tag: u8, npv_signature: Option<&[u8]>) -> u64 {
+        match (tag, npv_signature, &self.cfg.committee_selection) {
+            (0, _, CommitteeSelection::StakeCentile { .. }) => {
+                if self.cfg.persistent_committee.contains_key(voter_id) {
+                    self.cfg
+                        .stake_registry
+                        .get(voter_id)
+                        .copied()
+                        .unwrap_or(0)
+                } else {
+                    0
+                }
+            }
+            (0, _, _) => self
                 .cfg
                 .persistent_committee
                 .get(voter_id)
                 .copied()
+                .map(u64::from)
                 .unwrap_or(0),
-            (1, Some(sig)) => {
+            (1, Some(sig), CommitteeSelection::WfaLs { .. }) => {
                 if self.cfg.persistent_committee.contains_key(voter_id) {
                     return 0;
                 }
@@ -230,12 +301,12 @@ impl Elections {
                     .get(voter_id)
                     .copied()
                     .unwrap_or(0);
-                wfa::count_npv_wins(
+                committee::count_npv_wins(
                     sig,
                     stake,
                     self.cfg.total_stake,
                     self.cfg.committee_selection.non_persistent_voters(),
-                )
+                ) as u64
             }
             _ => 0,
         }
@@ -334,7 +405,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 0,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         })
     }
@@ -455,7 +526,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 0,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         };
         cfg.persistent_committee.insert("pool-a".to_string(), 5);
@@ -475,12 +546,96 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 1000,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         };
         cfg.stake_registry.insert("pool-a".to_string(), 500);
         let e = Elections::new(cfg);
-        let sig = wfa::npv_eligibility_signature(b"pool-a", &h(0xAB), 1);
+        let sig = committee::npv_eligibility_signature(b"pool-a", &h(0xAB), 1);
         assert_eq!(e.weight_for("pool-a", 1, Some(&sig)), 0);
+    }
+
+    /// CIP-164 PR #1196 invariant: a stake-centile committee that
+    /// covers less stake than the quorum demands cannot produce a
+    /// certificate even with unanimous participation.  Reject at
+    /// startup rather than at quorum-check time.
+    #[test]
+    fn validate_rejects_stake_centile_when_sigma_c_le_tau() {
+        let cfg = ElectionsConfig {
+            node_id: "test".to_string(),
+            pipeline: test_pipeline(),
+            committee_selection: CommitteeSelection::StakeCentile {
+                top_centile_of_stake: 0.75,
+            },
+            persistent_committee: BTreeMap::new(),
+            stake_registry: BTreeMap::new(),
+            total_stake: 1_000_000,
+            expected_total_weight: 1_000_000,
+            quorum_weight_fraction: 0.80,
+        };
+        assert_eq!(
+            cfg.validate(),
+            Err(ElectionsConfigError::StakeCentileQuorumUnreachable {
+                sigma_c: 0.75,
+                tau: 0.80,
+            })
+        );
+    }
+
+    /// Equality (σ_c == τ) is also rejected — at the boundary the
+    /// committee can only just meet quorum if every member votes, and
+    /// CIP-164 PR #1196 requires strict inequality.
+    #[test]
+    fn validate_rejects_stake_centile_at_boundary() {
+        let cfg = ElectionsConfig {
+            node_id: "test".to_string(),
+            pipeline: test_pipeline(),
+            committee_selection: CommitteeSelection::StakeCentile {
+                top_centile_of_stake: 0.75,
+            },
+            persistent_committee: BTreeMap::new(),
+            stake_registry: BTreeMap::new(),
+            total_stake: 1_000_000,
+            expected_total_weight: 1_000_000,
+            quorum_weight_fraction: 0.75,
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    /// σ_c > τ passes — and the check is StakeCentile-only.
+    #[test]
+    fn validate_accepts_stake_centile_when_sigma_c_gt_tau() {
+        let cfg = ElectionsConfig {
+            node_id: "test".to_string(),
+            pipeline: test_pipeline(),
+            committee_selection: CommitteeSelection::StakeCentile {
+                top_centile_of_stake: 0.95,
+            },
+            persistent_committee: BTreeMap::new(),
+            stake_registry: BTreeMap::new(),
+            total_stake: 1_000_000,
+            expected_total_weight: 1_000_000,
+            quorum_weight_fraction: 0.75,
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_ignores_wfa_ls_quorum_relationship() {
+        // WfaLs doesn't carry a σ_c notion; the invariant doesn't apply.
+        let cfg = ElectionsConfig {
+            node_id: "test".to_string(),
+            pipeline: test_pipeline(),
+            committee_selection: CommitteeSelection::WfaLs {
+                persistent_voters: 480,
+                non_persistent_voters: 120,
+            },
+            persistent_committee: BTreeMap::new(),
+            stake_registry: BTreeMap::new(),
+            total_stake: 1_000_000,
+            expected_total_weight: 600,
+            quorum_weight_fraction: 0.99,
+        };
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -35,7 +35,7 @@ use crate::fetch::{
 use crate::peer::PeerId;
 use crate::pipeline::PipelineConfig;
 use crate::types::Point;
-use crate::wfa;
+use crate::committee;
 
 /// How long an in-flight fetch entry remains "active" before being
 /// considered stale and eligible for retry.
@@ -742,12 +742,12 @@ impl LeiosState {
         let npv_signature = if emit_pv || n_npv == 0 {
             None
         } else {
-            let sig = wfa::npv_eligibility_signature(
+            let sig = committee::npv_eligibility_signature(
                 self.node_id.as_bytes(),
                 eb_hash,
                 eb_slot,
             );
-            let wins = wfa::count_npv_wins(
+            let wins = committee::count_npv_wins(
                 &sig,
                 self.voting_config.stake,
                 self.voting_config.total_stake,
@@ -1319,7 +1319,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 0,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         })
     }
@@ -1420,7 +1420,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 1000,
-            expected_committee_size: 600,
+            expected_total_weight: 600,
             quorum_weight_fraction: 0.75,
         });
         let mut state = LeiosState::new("n0".into(), elections, voting, pipeline());
@@ -1463,7 +1463,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 1000,
-            expected_committee_size: 600,
+            expected_total_weight: 600,
             quorum_weight_fraction: 0.75,
         });
         let mut state = LeiosState::new("n0".into(), elections, voting, pipeline());
@@ -1804,7 +1804,7 @@ mod tests {
             persistent_committee: persistent,
             stake_registry: BTreeMap::new(),
             total_stake: 0,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         });
         let mut state = LeiosState::new("n0".into(), elections, cfg(0), pipeline());

--- a/shared-rs/consensus/src/lib.rs
+++ b/shared-rs/consensus/src/lib.rs
@@ -22,7 +22,7 @@ pub mod pipeline;
 pub mod praos;
 pub mod production;
 pub mod types;
-pub mod wfa;
+pub mod committee;
 
 pub use config::{CommitteeSelection, StakeEntry};
 pub use peer::PeerId;

--- a/shared-rs/consensus/src/pipeline.rs
+++ b/shared-rs/consensus/src/pipeline.rs
@@ -40,7 +40,15 @@ pub struct EbElection {
     /// True after this node has cast its vote for this EB.
     pub voted: bool,
     /// Per-voter weight: voter_id+tag → derived weight.
-    pub voter_weights: BTreeMap<Vec<u8>, u32>,
+    ///
+    /// The unit is mode-dependent.  Under `WfaLs` the value is the
+    /// voter's seat count; under `EveryoneVotes` it is `1`; under
+    /// `StakeCentile` it is the voter's stake.  The aggregator sums
+    /// these values and compares against
+    /// `quorum_weight_fraction × expected_total_weight`, where
+    /// `expected_total_weight` is computed in the same units (see
+    /// [`crate::committee::expected_total_weight`]).
+    pub voter_weights: BTreeMap<Vec<u8>, u64>,
     /// True once quorum has been reached.
     pub quorum_reached: bool,
     /// True once `on_validated_eb` has fired for this hash on the local

--- a/shared-rs/consensus/src/production.rs
+++ b/shared-rs/consensus/src/production.rs
@@ -180,7 +180,7 @@ mod tests {
             persistent_committee: BTreeMap::new(),
             stake_registry: BTreeMap::new(),
             total_stake: 1000,
-            expected_committee_size: 100,
+            expected_total_weight: 100,
             quorum_weight_fraction: 0.75,
         });
         let voting = VotingConfig {

--- a/sim-rs/scripts/cip-voting-options.sh
+++ b/sim-rs/scripts/cip-voting-options.sh
@@ -34,7 +34,9 @@ set -euo pipefail
 #   ./scripts/cip-voting-options.sh -S 0,1,2,3,4 -T 0.200 -m wfa-ls     # 5-seed sweep
 #   ./scripts/cip-voting-options.sh --slots 500 -m top-stake-fraction
 #
-# Vote thresholds are auto-computed at QUORUM_FRACTION of expected committee size.
+# Quorum threshold is configured as a fraction (QUORUM_FRACTION, default
+# 0.75 per CIP-0164).  The sim derives the absolute threshold from this
+# and the mode-specific committee denominator at config build time.
 
 usage() {
     sed -n '3,/^$/p' "$0" | sed 's/^# \?//'
@@ -156,15 +158,13 @@ for s in staking:
 print(total_nodes, len(staking), top_n)
 ")
 
-# committee-selection-algorithm values and corresponding vote thresholds.
-# wfa-ls: VRF lottery with 600 total trials (480 persistent + 120 non-persistent), 75% quorum
+# committee-selection-algorithm values.
+# wfa-ls: VRF lottery with 600 total trials (480 persistent + 120 non-persistent)
 # everyone: all nodes vote (1 each)
-# top-stake-fraction: top ${STAKE_FRACTION} of cumulative stake
-declare -A VOTE_THRESHOLDS=(
-    ["wfa-ls"]=450
-    ["everyone"]=$(python3 -c "import math; print(math.ceil($TOTAL_NODES * $QUORUM_FRACTION))")
-    ["top-stake-fraction"]=$(python3 -c "import math; print(math.ceil($TOP_STAKE_NODES * $QUORUM_FRACTION))")
-)
+# top-stake-fraction: top ${STAKE_FRACTION} of cumulative stake (CIP-164 PR #1196)
+# Quorum threshold is the same fraction for all modes; the sim derives
+# the absolute threshold from the mode-specific denominator at config
+# build time.
 
 # Build the engine-specific parameter file.
 WORK=$(mktemp -d)
@@ -191,7 +191,7 @@ esac
 echo "Topology: $TOPOLOGY" >&2
 echo "  Total nodes: $TOTAL_NODES, Staking: $STAKING_NODES" >&2
 echo "  Top ${STAKE_FRACTION} stake: $TOP_STAKE_NODES nodes" >&2
-echo "  Vote thresholds: wfa-ls=${VOTE_THRESHOLDS[wfa-ls]}, everyone=${VOTE_THRESHOLDS[everyone]}, top-stake-fraction=${VOTE_THRESHOLDS[top-stake-fraction]}" >&2
+echo "  Quorum fraction: $QUORUM_FRACTION (CIP-0164 default 0.75)" >&2
 echo "Engine: $ENGINE" >&2
 echo "Slots: $SLOTS" >&2
 echo "Seeds: ${SEEDS[*]}" >&2
@@ -232,7 +232,7 @@ for throughput in "${THROUGHPUTS[@]}"; do
         override="$WORK/override-$mode.yaml"
         {
             echo "committee-selection-algorithm: \"$mode\""
-            echo "vote-threshold: ${VOTE_THRESHOLDS[$mode]}"
+            echo "quorum-weight-fraction: $QUORUM_FRACTION"
             if [[ "$mode" == "wfa-ls" ]]; then
                 # 600 total VRF trials, 80:20 persistent/non-persistent split
                 echo "persistent-vote-generation-probability: 480"

--- a/sim-rs/sim-cli/src/events.rs
+++ b/sim-rs/sim-cli/src/events.rs
@@ -74,7 +74,7 @@ impl EventMonitor {
             pool_ids,
             maximum_ib_age,
             maximum_eb_age: config.max_eb_age,
-            vote_threshold: config.vote_threshold,
+            vote_threshold: config.vote_threshold(),
             events_source: LivenessMonitor::new(config, events_source),
             output_path,
             aggregate: config.aggregate_events,

--- a/sim-rs/sim-cli/src/events/liveness.rs
+++ b/sim-rs/sim-cli/src/events/liveness.rs
@@ -33,7 +33,7 @@ impl LivenessMonitor {
             ibs: BTreeMap::new(),
             ebs: BTreeMap::new(),
             stage_length: config.stage_length,
-            vote_threshold: config.vote_threshold,
+            vote_threshold: config.vote_threshold(),
         }
     }
 

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -328,7 +328,18 @@ pub struct RawParameters {
     pub vote_generation_cpu_time_ms_per_ib: f64,
     pub persistent_vote_validation_cpu_time_ms: f64,
     pub non_persistent_vote_validation_cpu_time_ms: f64,
-    pub vote_threshold: u64,
+    /// Fraction of expected total weight required for quorum
+    /// (CIP-0164 default 0.75).  Replaces the old absolute
+    /// `vote-threshold` knob — the threshold is now derived from the
+    /// committee selection mode:
+    ///
+    /// - `wfa-ls`: threshold = `quorum_weight_fraction × (PV+NPV)`.
+    /// - `everyone`: threshold = `quorum_weight_fraction × N`.
+    /// - `top-stake-fraction` (CIP-164 PR #1196): threshold =
+    ///   `quorum_weight_fraction × total_active_stake`, and per-voter
+    ///   weight is stake (not vote count).
+    #[serde(default = "default_quorum_weight_fraction")]
+    pub quorum_weight_fraction: f64,
     pub vote_bundle_size_bytes_constant: u64,
     pub persistent_vote_bundle_size_bytes_per_eb: u64,
     pub non_persistent_vote_bundle_size_bytes_per_eb: u64,
@@ -438,6 +449,10 @@ pub enum CommitteeSelectionAlgorithm {
 
 fn default_committee_stake_fraction_threshold() -> f64 {
     0.95
+}
+
+fn default_quorum_weight_fraction() -> f64 {
+    0.75
 }
 
 #[derive(Deserialize)]
@@ -1005,7 +1020,13 @@ pub struct SimConfiguration {
     pub max_eb_age: u64,
     pub late_ib_inclusion: bool,
     pub variant: LeiosVariant,
-    pub vote_threshold: u64,
+    /// Quorum fraction (CIP-0164 default 0.75).  Compare votes against
+    /// `quorum_weight_fraction × expected_total_weight`.
+    pub quorum_weight_fraction: f64,
+    /// Quorum denominator in the units the relevant node implementation
+    /// sums per-voter weights.  WfaLs/Everyone: seats or node count.
+    /// TopStakeFraction (CIP-164 PR #1196): `total_stake`.
+    pub expected_total_weight: u64,
     pub(crate) total_stake: u64,
     pub(crate) praos_fallback: bool,
     pub(crate) header_diffusion_time: Duration,
@@ -1068,6 +1089,16 @@ pub struct SimConfiguration {
 }
 
 impl SimConfiguration {
+    /// Absolute quorum threshold in the units the local node
+    /// implementation sums per-voter weights — derived from
+    /// `quorum_weight_fraction × expected_total_weight`.  Replaces the
+    /// old absolute `vote_threshold` config; downstream consumers
+    /// (sim-cli liveness telemetry, per-variant endorsement gates) call
+    /// this where they previously read the field.
+    pub fn vote_threshold(&self) -> u64 {
+        (self.quorum_weight_fraction * self.expected_total_weight as f64) as u64
+    }
+
     pub fn build(params: RawParameters, mut topology: Topology) -> Result<Self> {
         if !params.ib_shards.is_multiple_of(params.ib_shard_group_count) {
             bail!(
@@ -1101,6 +1132,18 @@ impl SimConfiguration {
                 HashSet::new()
             }
             CommitteeSelectionAlgorithm::TopStakeFraction => {
+                // σ_c > τ — CIP-164 PR #1196.  At equality or below
+                // the committee cannot meet the stake quorum even
+                // with unanimous participation.
+                if params.committee_stake_fraction_threshold <= params.quorum_weight_fraction {
+                    bail!(
+                        "top-stake-fraction committee covers σ_c={} of stake which is ≤ \
+                         quorum-weight-fraction τ={}; certification is unreachable \
+                         (CIP-164 PR #1196 requires σ_c > τ)",
+                        params.committee_stake_fraction_threshold,
+                        params.quorum_weight_fraction,
+                    );
+                }
                 let threshold =
                     (total_stake as f64 * params.committee_stake_fraction_threshold) as u64;
                 let mut nodes_by_stake: Vec<_> =
@@ -1119,6 +1162,17 @@ impl SimConfiguration {
                     .map(|(id, _)| id)
                     .collect()
             }
+        };
+        // Quorum denominator matches the per-voter weight unit each
+        // node implementation sums.  WfaLs: persistent + non-persistent
+        // expected vote weight.  Everyone: one seat per topology node.
+        // TopStakeFraction: total active stake (PR #1196).
+        let expected_total_weight: u64 = match params.committee_selection_algorithm {
+            CommitteeSelectionAlgorithm::WfaLs => {
+                (params.persistent_voters + params.non_persistent_voters) as u64
+            }
+            CommitteeSelectionAlgorithm::Everyone => topology.nodes.len() as u64,
+            CommitteeSelectionAlgorithm::TopStakeFraction => total_stake,
         };
         Ok(Self {
             seed: params.seed,
@@ -1161,7 +1215,8 @@ impl SimConfiguration {
             vote_probability: params.persistent_voters + params.non_persistent_voters,
             persistent_voters: params.persistent_voters,
             non_persistent_voters: params.non_persistent_voters,
-            vote_threshold: params.vote_threshold,
+            quorum_weight_fraction: params.quorum_weight_fraction,
+            expected_total_weight,
             vote_slot_length: params.leios_stage_active_voting_slots,
             eb_include_txs_from_previous_stage: params.eb_include_txs_from_previous_stage,
             linear_vote_stage_length: params.linear_vote_stage_length_slots,

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -1096,7 +1096,11 @@ impl SimConfiguration {
     /// (sim-cli liveness telemetry, per-variant endorsement gates) call
     /// this where they previously read the field.
     pub fn vote_threshold(&self) -> u64 {
-        (self.quorum_weight_fraction * self.expected_total_weight as f64) as u64
+        // Ceiling so an integer threshold compared against integer
+        // voted weights enforces `Σ weight ≥ τ × total` exactly —
+        // truncating a 2.25 product to 2 would accept 2/3 = 67% under
+        // a τ = 75% quorum.  Mirrors shared-consensus aggregation.
+        (self.quorum_weight_fraction * self.expected_total_weight as f64).ceil() as u64
     }
 
     pub fn build(params: RawParameters, mut topology: Topology) -> Result<Self> {
@@ -1169,7 +1173,12 @@ impl SimConfiguration {
         // TopStakeFraction: total active stake (PR #1196).
         let expected_total_weight: u64 = match params.committee_selection_algorithm {
             CommitteeSelectionAlgorithm::WfaLs => {
-                (params.persistent_voters + params.non_persistent_voters) as u64
+                // PV / NPV are f64 in the config; round to the nearest
+                // integer rather than truncating so a configured 600.7
+                // doesn't quietly become 600 and so a fractional sub-1
+                // pair doesn't zero the denominator and trivialise the
+                // threshold.
+                (params.persistent_voters + params.non_persistent_voters).round() as u64
             }
             CommitteeSelectionAlgorithm::Everyone => topology.nodes.len() as u64,
             CommitteeSelectionAlgorithm::TopStakeFraction => total_stake,

--- a/sim-rs/sim-core/src/sim/leios.rs
+++ b/sim-rs/sim-core/src/sim/leios.rs
@@ -843,7 +843,7 @@ impl LeiosNode {
 
     fn choose_endorsed_block_for_rb(&self, slot: u64) -> Option<Endorsement> {
         // an EB is eligible to be included on-chain if it has this many votes
-        let vote_threshold = self.sim_config.vote_threshold;
+        let vote_threshold = self.sim_config.vote_threshold();
         // and it is not older than this
         let max_eb_age = self.sim_config.max_eb_age;
         // and if it is not in a pipeline already represented in the chain
@@ -900,7 +900,7 @@ impl LeiosNode {
 
     fn choose_endorsed_block_from_pipeline(&self, pipeline: u64) -> Option<EndorserBlockId> {
         // an EB is eligible for endorsement if it has this many votes
-        let vote_threshold = self.sim_config.vote_threshold;
+        let vote_threshold = self.sim_config.vote_threshold();
 
         // Choose an EB based on, in order,
         //  - the TXs in the EB (more TXs take priority)
@@ -1475,7 +1475,7 @@ impl LeiosNode {
                 .entry(votes.id.producer)
                 .or_default();
             *eb_votes += count;
-            if *eb_votes as u64 >= self.sim_config.vote_threshold {
+            if *eb_votes as u64 >= self.sim_config.vote_threshold() {
                 self.leios
                     .earliest_eb_cert_times_by_pipeline
                     .entry(eb.pipeline)
@@ -1810,7 +1810,7 @@ impl LeiosNode {
                 return Err(NoVoteReason::UncertifiedEBReference);
             };
             let vote_count = votes.values().copied().sum::<usize>() as u64;
-            if vote_count < self.sim_config.vote_threshold {
+            if vote_count < self.sim_config.vote_threshold() {
                 return Err(NoVoteReason::UncertifiedEBReference);
             }
         }
@@ -1828,7 +1828,7 @@ impl LeiosNode {
                 .entry(votes.id.producer)
                 .or_default();
             *eb_votes += count;
-            if *eb_votes as u64 > self.sim_config.vote_threshold {
+            if *eb_votes as u64 > self.sim_config.vote_threshold() {
                 self.leios
                     .earliest_eb_cert_times_by_pipeline
                     .entry(eb.pipeline)

--- a/sim-rs/sim-core/src/sim/linear_leios.rs
+++ b/sim-rs/sim-core/src/sim/linear_leios.rs
@@ -675,7 +675,7 @@ impl LinearLeiosNode {
             let eb_id = *self.leios.ebs_by_rb.get(&rb_id)?;
             let votes = self.leios.votes_by_eb.get(&eb_id)?;
             let total_votes = votes.values().copied().sum::<usize>();
-            if (total_votes as u64) < self.sim_config.vote_threshold {
+            if (total_votes as u64) < self.sim_config.vote_threshold() {
                 // Not enough votes. No endorsement.
                 return None;
             }
@@ -1427,9 +1427,12 @@ impl LinearLeiosNode {
                     .count()
             }
             CommitteeSelectionAlgorithm::Everyone => 1,
+            // CIP-164 PR #1196: certificate weight is the voter's own
+            // stake; the receiver sums these and compares against
+            // `quorum_weight_fraction × total_active_stake`.
             CommitteeSelectionAlgorithm::TopStakeFraction => {
                 if self.sim_config.vote_eligible_nodes.contains(&self.id) {
-                    1
+                    self.sim_config.nodes[self.id.to_inner()].stake as usize
                 } else {
                     0
                 }

--- a/sim-rs/sim-core/src/sim/shared_consensus.rs
+++ b/sim-rs/sim-core/src/sim/shared_consensus.rs
@@ -81,7 +81,7 @@ use shared_consensus::{
     praos::{ParsedHeaderInfo, PraosEffect, PraosState},
     production::BodyPath,
     types::Point,
-    wfa,
+    committee,
 };
 
 use crate::{
@@ -188,15 +188,15 @@ fn derive_committee_selection(sim_config: &SimConfiguration) -> CommitteeSelecti
     }
 }
 
-/// Quorum fraction = `vote_threshold / expected_committee_size`.  Sim
-/// stores quorum as an absolute vote count; shared-consensus wants the same
-/// boundary as a fraction of expected total weight.  Falls back to
-/// 0.75 (CIP-0164 default) when the divisor is zero.
-fn derive_quorum_fraction(sim_config: &SimConfiguration, expected: u32) -> f64 {
-    if expected == 0 {
+/// Quorum fraction passes straight through.  Sim stores it as a
+/// fraction `quorum_weight_fraction` (e.g. 0.75 = CIP-0164 default);
+/// shared-consensus consumes the same shape.  Falls back to 0.75 only
+/// if the sim left it at zero.
+fn derive_quorum_fraction(sim_config: &SimConfiguration) -> f64 {
+    if sim_config.quorum_weight_fraction <= 0.0 {
         return 0.75;
     }
-    sim_config.vote_threshold as f64 / expected as f64
+    sim_config.quorum_weight_fraction
 }
 
 /// Canonical mapping from sim's `TransactionId` to shared-consensus's opaque
@@ -443,14 +443,17 @@ impl NodeImpl for SharedConsensus {
         let stake_registry = build_stake_registry(&sim_config);
         let committee_selection = derive_committee_selection(&sim_config);
         let persistent_committee =
-            wfa::build_committee(&committee_selection, &stake_registry, sim_config.seed);
-        let expected_committee_size =
-            wfa::expected_committee_size(&committee_selection, &persistent_committee);
+            committee::build_committee(&committee_selection, &stake_registry, sim_config.seed);
         let total_stake: u64 = stake_registry.iter().map(|e| e.stake).sum();
+        let expected_total_weight = committee::expected_total_weight(
+            &committee_selection,
+            &persistent_committee,
+            total_stake,
+        );
 
         let pipeline = derive_pipeline(&sim_config);
-        let quorum_weight_fraction = derive_quorum_fraction(&sim_config, expected_committee_size);
-        let elections = Elections::new(ElectionsConfig {
+        let quorum_weight_fraction = derive_quorum_fraction(&sim_config);
+        let elections_config = ElectionsConfig {
             node_id: config.name.clone(),
             pipeline,
             committee_selection: committee_selection.clone(),
@@ -460,9 +463,16 @@ impl NodeImpl for SharedConsensus {
                 .map(|e| (e.node_id.clone(), e.stake))
                 .collect(),
             total_stake,
-            expected_committee_size,
+            expected_total_weight,
             quorum_weight_fraction,
-        });
+        };
+        // σ_c > τ — CIP-164 PR #1196.  Sim configs that violate this
+        // produce no certs; surface the misconfiguration at startup
+        // rather than letting the run silently fail.
+        if let Err(err) = elections_config.validate() {
+            panic!("shared-consensus elections config invalid: {err}");
+        }
+        let elections = Elections::new(elections_config);
 
         let persistent_seats = persistent_committee.get(&config.name).copied().unwrap_or(0);
         // Sim collapses PV / NPV byte budgets into a single
@@ -2111,7 +2121,7 @@ impl SharedConsensus {
                 self.leios.voting_config.persistent_seats,
             ),
             (false, Some(sig)) => {
-                let npv_wins = shared_consensus::wfa::count_npv_wins(
+                let npv_wins = shared_consensus::committee::count_npv_wins(
                     &sig,
                     self.leios.voting_config.stake,
                     self.leios.voting_config.total_stake,

--- a/sim-rs/sim-core/src/sim/stracciatella.rs
+++ b/sim-rs/sim-core/src/sim/stracciatella.rs
@@ -863,7 +863,7 @@ impl StracciatellaLeiosNode {
                 return Err(NoVoteReason::UncertifiedEBReference);
             };
             let vote_count = votes.values().copied().sum::<usize>() as u64;
-            if vote_count < self.sim_config.vote_threshold {
+            if vote_count < self.sim_config.vote_threshold() {
                 return Err(NoVoteReason::UncertifiedEBReference);
             }
         }
@@ -881,7 +881,7 @@ impl StracciatellaLeiosNode {
                 .entry(votes.id.producer)
                 .or_default();
             *eb_votes += count;
-            if *eb_votes as u64 > self.sim_config.vote_threshold {
+            if *eb_votes as u64 > self.sim_config.vote_threshold() {
                 self.leios
                     .earliest_eb_cert_times_by_pipeline
                     .entry(eb.pipeline)
@@ -939,7 +939,7 @@ impl StracciatellaLeiosNode {
                 .entry(votes.id.producer)
                 .or_default();
             *eb_votes += count;
-            if *eb_votes as u64 >= self.sim_config.vote_threshold {
+            if *eb_votes as u64 >= self.sim_config.vote_threshold() {
                 self.leios
                     .earliest_eb_cert_times_by_pipeline
                     .entry(eb.pipeline)
@@ -957,7 +957,7 @@ impl StracciatellaLeiosNode {
 
     fn choose_endorsed_block_for_rb(&self, slot: u64) -> Option<Endorsement> {
         // an EB is eligible to be included on-chain if it has this many votes
-        let vote_threshold = self.sim_config.vote_threshold;
+        let vote_threshold = self.sim_config.vote_threshold();
         // and it is not older than this
         let max_eb_age = self.sim_config.max_eb_age;
         // and if it is not in a pipeline already represented in the chain
@@ -1001,7 +1001,7 @@ impl StracciatellaLeiosNode {
 
     fn choose_endorsed_block_from_pipeline(&self, pipeline: u64) -> Option<EndorserBlockId> {
         // an EB is eligible for endorsement if it has this many votes
-        let vote_threshold = self.sim_config.vote_threshold;
+        let vote_threshold = self.sim_config.vote_threshold();
 
         // Choose an EB based on, in order,
         //  - the TXs in the EB (more TXs take priority)

--- a/sim-rs/sim-core/src/sim/tests/linear_leios.rs
+++ b/sim-rs/sim-core/src/sim/tests/linear_leios.rs
@@ -42,8 +42,12 @@ fn new_sim_config_with(
         value: tx_size as f64,
     };
     params.tx_max_size_bytes = tx_size;
-    // it takes two votes to certify an EB
-    params.vote_threshold = 2;
+    // it takes two votes to certify an EB.  Pin the committee to two
+    // virtual voters and demand 100% to reach a threshold of exactly 2,
+    // independent of the default-config probabilities.
+    params.persistent_voters = 2.0;
+    params.non_persistent_voters = 0.0;
+    params.quorum_weight_fraction = 1.0;
     customize(&mut params);
     let topology = topology.into();
     Arc::new(SimConfiguration::build(params, topology).unwrap())
@@ -648,6 +652,11 @@ fn top_stake_fraction_should_select_voters() {
     let config = new_sim_config_with(topology, |params| {
         params.committee_selection_algorithm = CommitteeSelectionAlgorithm::TopStakeFraction;
         params.committee_stake_fraction_threshold = 0.75;
+        // σ_c > τ is the CIP-164 PR #1196 invariant; relax τ here
+        // since this test exercises membership selection, not quorum
+        // reachability (the make_sim_config default of 1.0 would
+        // trigger the startup check).
+        params.quorum_weight_fraction = 0.5;
     });
 
     // big (500) + medium (300) = 800 >= 750 (75% of 1000), so small is excluded
@@ -691,4 +700,94 @@ fn top_stake_fraction_should_select_voters() {
         .map(|q| q.tasks.iter().any(|t| matches!(t, CpuTask::VTBundleGenerated(..))))
         .unwrap_or(false);
     assert!(!has_vote_task, "small node should not have generated a vote");
+}
+
+/// CIP-164 PR #1196: under TopStakeFraction the per-voter contribution
+/// to a VoteBundle is the voter's own stake, and the absolute quorum
+/// threshold is `quorum_weight_fraction × total_active_stake`.
+///
+/// Topology: stakes 600/300/100, σ_c = 0.95 → all three eligible.
+/// τ = 0.75 → threshold 750 stake-units.
+/// - "big" alone (600) < 750 — no quorum.
+/// - "big" + "medium" (900) ≥ 750 — quorum.  Reached with 2/3 voters
+///   even though no single voter is a majority.
+#[test]
+fn top_stake_fraction_uses_stake_weighted_quorum() {
+    let topology = new_topology(vec![
+        ("big", new_node(Some(600), vec!["medium", "small"])),
+        ("medium", new_node(Some(300), vec!["big", "small"])),
+        ("small", new_node(Some(100), vec!["big", "medium"])),
+    ]);
+    let config = new_sim_config_with(topology, |params| {
+        params.committee_selection_algorithm = CommitteeSelectionAlgorithm::TopStakeFraction;
+        params.committee_stake_fraction_threshold = 0.95;
+        params.quorum_weight_fraction = 0.75;
+    });
+
+    // Quorum denominator is total active stake; threshold = τ × total.
+    assert_eq!(config.expected_total_weight, 1000);
+    assert_eq!(config.vote_threshold(), 750);
+
+    let mut sim = TestDriver::new_with_config(config);
+    let big = sim.id_for("big");
+    let medium = sim.id_for("medium");
+    let small = sim.id_for("small");
+
+    // big produces an RB and EB.
+    let txs: [_; 3] = sim.produce_txs(big, false);
+    for tx in &txs {
+        sim.expect_tx_sent(big, medium, tx.clone());
+        sim.expect_tx_sent(big, small, tx.clone());
+    }
+    sim.win_next_rb_lottery(big, 0);
+    sim.next_slot();
+    let (rb, eb) = sim.expect_cpu_task_matching(big, is_new_rb_task);
+    let eb = eb.expect("node did not produce EB");
+
+    sim.expect_rb_and_eb_sent(big, medium, rb.clone(), Some(eb.clone()));
+    sim.expect_rb_and_eb_sent(big, small, rb.clone(), Some(eb.clone()));
+    sim.expect_eb_validated(medium, eb.clone());
+    sim.expect_eb_validated(small, eb.clone());
+
+    sim.advance_time_to(sim.now() + (sim.config.header_diffusion_time * 3));
+
+    // Per-voter weight in the VoteBundle is the voter's stake.
+    let votes_big = sim.expect_cpu_task_matching(big, is_new_vote_task);
+    assert_eq!(*votes_big.ebs.first_key_value().unwrap().1, 600);
+    let votes_medium = sim.expect_cpu_task_matching(medium, is_new_vote_task);
+    assert_eq!(*votes_medium.ebs.first_key_value().unwrap().1, 300);
+    let votes_small = sim.expect_cpu_task_matching(small, is_new_vote_task);
+    assert_eq!(*votes_small.ebs.first_key_value().unwrap().1, 100);
+
+    // Sanity: head-count majority of small voters ({medium, small} =
+    // 2/3 of nodes) carries only 400 stake, below the 750 threshold.
+    // The PR #1196 security property is that such a coalition does
+    // NOT certify.
+    let low_stake_majority = (votes_medium.ebs.first_key_value().unwrap().1
+        + votes_small.ebs.first_key_value().unwrap().1) as u64;
+    assert!(low_stake_majority < sim.config.vote_threshold());
+}
+
+/// PR #1196 invariant σ_c > τ must be enforced at config load.
+#[test]
+fn sim_config_rejects_top_stake_fraction_when_sigma_c_le_tau() {
+    let topology = new_topology(vec![
+        ("big", new_node(Some(600), vec!["medium"])),
+        ("medium", new_node(Some(400), vec!["big"])),
+    ]);
+    let mut params: crate::config::RawParameters =
+        serde_yaml::from_slice(include_bytes!("../../../../parameters/config.default.yaml"))
+            .unwrap();
+    params.leios_variant = crate::config::LeiosVariant::LinearWithTxReferences;
+    params.committee_selection_algorithm = CommitteeSelectionAlgorithm::TopStakeFraction;
+    params.committee_stake_fraction_threshold = 0.75;
+    params.quorum_weight_fraction = 0.80; // σ_c=0.75 ≤ τ=0.80
+
+    let topology: crate::config::Topology = topology.into();
+    let err = SimConfiguration::build(params, topology).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("σ_c") && msg.contains("τ"),
+        "expected σ_c/τ violation, got: {msg}"
+    );
 }


### PR DESCRIPTION
## Summary

- Brings shared-consensus and sim-rs in line with [CIP-164 PR #1196](https://github.com/cardano-foundation/CIPs/pull/1196): under StakeCentile / TopStakeFraction committee selection, quorum is `Σ voter_stake ≥ τ × total_active_stake`, not a head-count fraction.
- `voter_weights` is now mode-polymorphic — seats for WfaLs, 1 for Everyone, voter stake for StakeCentile — so the existing `quorum_weight_fraction` knob applies uniformly. No new config field on the shared-consensus side; sim-rs's `vote-threshold: u64` becomes `quorum-weight-fraction: f64`.
- σ_c > τ enforced at startup in both `ElectionsConfig::validate` and `SimConfiguration::build`; production callers panic on an unreachable quorum.
- `shared-rs/consensus/src/wfa.rs` renamed to `committee.rs` since wFA^LS is one of three schemes now.

## Why the change

In stake-truncated committees the old head-count quorum (`Σ seats ≥ τ × |committee|`) lets a coalition of many small-stake committee members satisfy quorum without representing the stake the diffusion-period safety argument relies on. PR #1196 §"Quorum as a stake threshold" makes the predicate stake-denominated so the certificate directly proves the security property.

## Behavior

| Mode                | per-voter `weight`   | denominator                              |
| ------------------- | -------------------- | ---------------------------------------- |
| `WfaLs`             | seats (unchanged)    | PV+NPV seats (unchanged)                 |
| `EveryoneVotes`     | 1 (unchanged)        | N nodes (unchanged)                      |
| `StakeCentile` ⬅ new | voter's stake        | `total_active_stake`                     |

Behaviour for `WfaLs` and `EveryoneVotes` is byte-identical.

## Smoke

25-node equal-stake cluster (`sample-cluster.toml` + `mainnet.toml` default StakeCentile σ_c=0.99, τ=0.75):

```
quorum reached  voted_weight=760  threshold=750  voters=19
quorum reached  voted_weight=760  threshold=750  voters=19
quorum reached  voted_weight=760  threshold=750  voters=19
```

19 voters × 40 stake = 760 ≥ 0.75 × 1000 = 750. Numbers reconcile; same accept/reject as the old head-count rule in equal-stake topologies, but the *measured quantity* now reflects what the security argument requires (and would diverge meaningfully under heterogeneous stake).

σ_c ≤ τ misconfiguration rejected at startup with a clear message that cites the PR.

## Test plan

- [x] `cargo test -p shared-consensus` — 276 passed (6 new: stake-weighted quorum scenarios + σ_c > τ rejection across the three valid combinations)
- [x] `cargo test` in sim-rs — 62 passed across binaries (2 new: `top_stake_fraction_uses_stake_weighted_quorum`, `sim_config_rejects_top_stake_fraction_when_sigma_c_le_tau`)
- [x] `cargo test -p net-node` in net-rs — 118 passed
- [x] `cargo clippy --all-targets` clean across all three workspaces
- [x] End-to-end smoke: TopStakeFraction sim run reports `voted_weight` in stake units; misconfigured σ_c=0.75, τ=0.80 fails at startup with the cited error
- [x] End-to-end smoke: 25-node net-rs cluster + UI sustains quorum with the new arithmetic (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)