### PR TITLE
tcp-model: analytic TCP envelope for sim-rs links

### DIFF
--- a/shared-rs/Cargo.lock
+++ b/shared-rs/Cargo.lock
@@ -3,6 +3,111 @@
 version = 4
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minicbor"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +123,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -51,6 +186,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shared-consensus"
+version = "0.1.0"
+dependencies = [
+ "blake2b_simd",
+ "minicbor",
+ "rand",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,7 +239,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/shared-rs/Cargo.lock
+++ b/shared-rs/Cargo.lock
@@ -211,6 +211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +228,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tcp-model"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/shared-rs/Cargo.lock
+++ b/shared-rs/Cargo.lock
@@ -3,111 +3,6 @@
 version = 4
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "libc"
-version = "0.2.186"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "memchr"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "minicbor"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
-dependencies = [
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,36 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -186,31 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
-name = "shared-consensus"
-version = "0.1.0"
-dependencies = [
- "blake2b_simd",
- "minicbor",
- "rand",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,40 +74,8 @@ dependencies = [
 name = "tcp-model"
 version = "0.1.0"
 dependencies = [
- "rand",
  "serde",
  "smallvec",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -275,35 +83,3 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/shared-rs/Cargo.toml
+++ b/shared-rs/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["consensus"]
+members = ["consensus", "tcp-model"]

--- a/shared-rs/tcp-model/Cargo.toml
+++ b/shared-rs/tcp-model/Cargo.toml
@@ -5,6 +5,5 @@ edition = "2021"
 description = "Analytic envelope model of TCP transport effects (slow-start, idle reset, packet loss) for Cardano Leios network simulators."
 
 [dependencies]
-rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1", features = ["serde"] }

--- a/shared-rs/tcp-model/Cargo.toml
+++ b/shared-rs/tcp-model/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tcp-model"
+version = "0.1.0"
+edition = "2021"
+description = "Analytic envelope model of TCP transport effects (slow-start, idle reset, packet loss) for Cardano Leios network simulators."
+
+[dependencies]
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+smallvec = { version = "1", features = ["serde"] }

--- a/shared-rs/tcp-model/src/config.rs
+++ b/shared-rs/tcp-model/src/config.rs
@@ -1,0 +1,122 @@
+//! Per-link configuration for the envelope model.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::curve::Curve;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LinkEnvelopeCfg {
+    pub mss_bytes: u64,
+    pub initial_cwnd_segments: u32,
+    pub idle_reset_threshold: Duration,
+    pub rto: Duration,
+    pub loss_prob_per_segment: f64,
+    pub loss_bw_depth: f64,
+    pub cold_bw_depth: f64,
+    pub cold_release: Duration,
+    pub cold_release_shape: Curve,
+    pub loss_release: Duration,
+    pub loss_release_shape: Curve,
+}
+
+impl LinkEnvelopeCfg {
+    /// Defaults derived from the link's nominal one-way latency and bandwidth.
+    /// Requires `bps > 0` and `latency` strictly positive — for a disabled
+    /// envelope use [`Self::disabled`] instead.
+    pub fn defaults_for(latency: Duration, bps: u64) -> Self {
+        assert!(bps > 0, "bps must be > 0");
+        assert!(!latency.is_zero(), "latency must be > 0");
+
+        let mss_bytes: u64 = 1460;
+        let initial_cwnd_segments: u32 = 10;
+        let iw_bytes = (initial_cwnd_segments as u64) * mss_bytes;
+        let latency_s = latency.as_secs_f64();
+        let bdp_bytes = (bps as f64) * latency_s;
+
+        // Cold/idle envelope: depth = IW / (2·BDP), release = log2(2·BDP/IW)·2L.
+        // If IW already covers 2·BDP, slow-start has nothing to do.
+        let (cold_bw_depth, cold_release) = if bdp_bytes * 2.0 <= iw_bytes as f64 {
+            (1.0, Duration::ZERO)
+        } else {
+            let depth = (iw_bytes as f64) / (2.0 * bdp_bytes);
+            let rtts = (2.0 * bdp_bytes / iw_bytes as f64).log2();
+            let release = Duration::from_secs_f64(rtts * 2.0 * latency_s);
+            (depth.clamp(1e-6, 1.0), release)
+        };
+
+        // Loss envelope (AIMD shape): bw halves at the moment of loss and
+        // recovers linearly over BDP/(2·MSS) RTTs.
+        let loss_rtts = bdp_bytes / 2.0 / mss_bytes as f64;
+        let loss_release = Duration::from_secs_f64(loss_rtts.max(0.0) * 2.0 * latency_s);
+
+        let threshold = Duration::from_secs(1).max(2 * latency);
+
+        Self {
+            mss_bytes,
+            initial_cwnd_segments,
+            idle_reset_threshold: threshold,
+            rto: threshold,
+            loss_prob_per_segment: 0.0,
+            loss_bw_depth: 0.5,
+            cold_bw_depth,
+            cold_release,
+            cold_release_shape: Curve::Geometric,
+            loss_release,
+            loss_release_shape: Curve::Linear,
+        }
+    }
+
+    /// A configuration that fires no envelopes: cold/idle envelopes have unit
+    /// depth and zero release, loss probability is zero.
+    pub fn disabled() -> Self {
+        Self {
+            mss_bytes: 1460,
+            initial_cwnd_segments: 10,
+            idle_reset_threshold: Duration::MAX,
+            rto: Duration::ZERO,
+            loss_prob_per_segment: 0.0,
+            loss_bw_depth: 1.0,
+            cold_bw_depth: 1.0,
+            cold_release: Duration::ZERO,
+            cold_release_shape: Curve::Step,
+            loss_release: Duration::ZERO,
+            loss_release_shape: Curve::Step,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_for_typical_long_haul_link() {
+        let cfg = LinkEnvelopeCfg::defaults_for(Duration::from_millis(150), 1_000_000);
+        // BDP = 150_000 bytes; IW = 14_600 bytes; depth ≈ 14600/300000.
+        assert!((cfg.cold_bw_depth - 14_600.0 / 300_000.0).abs() < 1e-9);
+        // log2(300000/14600) ≈ 4.36 RTTs × 300ms ≈ 1.308s.
+        let expected = (300_000.0_f64 / 14_600.0).log2() * 0.3;
+        assert!((cfg.cold_release.as_secs_f64() - expected).abs() < 1e-6);
+        assert_eq!(cfg.idle_reset_threshold, Duration::from_secs(1));
+        assert_eq!(cfg.rto, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn fast_link_skips_slow_start() {
+        // 1 ms latency, 1 Gbps → BDP = 125_000 bytes, 2·BDP = 250_000; IW = 14_600.
+        // 2·BDP > IW, so slow-start still applies. Use a degenerate case instead.
+        let cfg = LinkEnvelopeCfg::defaults_for(Duration::from_micros(1), 1_000_000);
+        assert_eq!(cfg.cold_bw_depth, 1.0);
+        assert_eq!(cfg.cold_release, Duration::ZERO);
+    }
+
+    #[test]
+    fn disabled_has_no_effect_parameters() {
+        let cfg = LinkEnvelopeCfg::disabled();
+        assert_eq!(cfg.cold_bw_depth, 1.0);
+        assert_eq!(cfg.loss_prob_per_segment, 0.0);
+        assert_eq!(cfg.idle_reset_threshold, Duration::MAX);
+    }
+}

--- a/shared-rs/tcp-model/src/config.rs
+++ b/shared-rs/tcp-model/src/config.rs
@@ -73,7 +73,7 @@ impl LinkEnvelopeCfg {
     /// uniform random `u ∈ [0, 1)` and pass `u < msg_loss_prob(bytes)` as
     /// the `loss_drawn` argument to [`crate::LinkState::on_send`].
     pub fn msg_loss_prob(&self, bytes: u64) -> f64 {
-        if self.loss_prob_per_segment <= 0.0 || bytes == 0 {
+        if self.loss_prob_per_segment <= 0.0 || bytes == 0 || self.mss_bytes == 0 {
             return 0.0;
         }
         let segments = bytes.div_ceil(self.mss_bytes) as f64;

--- a/shared-rs/tcp-model/src/config.rs
+++ b/shared-rs/tcp-model/src/config.rs
@@ -68,6 +68,18 @@ impl LinkEnvelopeCfg {
         }
     }
 
+    /// Effective per-message loss probability under independent per-segment
+    /// drops. Returns `0.0` when either input is zero. Consumers draw a
+    /// uniform random `u ∈ [0, 1)` and pass `u < msg_loss_prob(bytes)` as
+    /// the `loss_drawn` argument to [`crate::LinkState::on_send`].
+    pub fn msg_loss_prob(&self, bytes: u64) -> f64 {
+        if self.loss_prob_per_segment <= 0.0 || bytes == 0 {
+            return 0.0;
+        }
+        let segments = bytes.div_ceil(self.mss_bytes) as f64;
+        1.0 - (1.0 - self.loss_prob_per_segment).powf(segments)
+    }
+
     /// A configuration that fires no envelopes: cold/idle envelopes have unit
     /// depth and zero release, loss probability is zero.
     pub fn disabled() -> Self {
@@ -118,5 +130,21 @@ mod tests {
         assert_eq!(cfg.cold_bw_depth, 1.0);
         assert_eq!(cfg.loss_prob_per_segment, 0.0);
         assert_eq!(cfg.idle_reset_threshold, Duration::MAX);
+    }
+
+    #[test]
+    fn msg_loss_prob_scales_with_segment_count() {
+        let mut cfg = LinkEnvelopeCfg::defaults_for(Duration::from_millis(100), 1_000_000);
+        cfg.loss_prob_per_segment = 0.001;
+        // Single-segment message: p_msg ≈ p_seg.
+        assert!((cfg.msg_loss_prob(1000) - 0.001).abs() < 1e-9);
+        // Ten-segment message: 1 - (1 - 0.001)^10 ≈ 0.00996.
+        assert!((cfg.msg_loss_prob(10 * cfg.mss_bytes) - 0.009955_f64).abs() < 1e-5);
+    }
+
+    #[test]
+    fn msg_loss_prob_zero_when_disabled() {
+        let cfg = LinkEnvelopeCfg::disabled();
+        assert_eq!(cfg.msg_loss_prob(1_000_000), 0.0);
     }
 }

--- a/shared-rs/tcp-model/src/curve.rs
+++ b/shared-rs/tcp-model/src/curve.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum Curve {
     Step,
     Linear,

--- a/shared-rs/tcp-model/src/curve.rs
+++ b/shared-rs/tcp-model/src/curve.rs
@@ -1,0 +1,106 @@
+//! Shapes for the onset and release of an [`Envelope`](crate::envelope::Envelope).
+//!
+//! A [`CurveSegment`] interpolates between two scalar values over a fixed
+//! duration. Three shapes are supported:
+//!
+//! - [`Curve::Step`]: constant at `start` until the segment expires, then `end`.
+//! - [`Curve::Linear`]: arithmetic interpolation.
+//! - [`Curve::Geometric`]: log-space interpolation (`start^(1-t) * end^t`).
+//!   Useful for bandwidth-multiplier curves whose natural shape is exponential
+//!   (e.g. TCP slow-start). Degenerate when either endpoint is zero — in that
+//!   case the segment is held at zero for all `t > 0` regardless of the
+//!   intended shape, so callers should keep both endpoints in `(0, 1]`.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Curve {
+    Step,
+    Linear,
+    Geometric,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct CurveSegment {
+    pub duration: Duration,
+    pub shape: Curve,
+}
+
+impl CurveSegment {
+    pub fn new(duration: Duration, shape: Curve) -> Self {
+        Self { duration, shape }
+    }
+
+    /// Interpolate from `start` to `end` over this segment, given the time
+    /// elapsed since the segment began. Returns `end` once `elapsed` meets
+    /// or exceeds the segment duration.
+    pub fn interp(&self, start: f64, end: f64, elapsed: Duration) -> f64 {
+        if self.duration.is_zero() || elapsed >= self.duration {
+            return end;
+        }
+        let t = elapsed.as_secs_f64() / self.duration.as_secs_f64();
+        match self.shape {
+            Curve::Step => start,
+            Curve::Linear => start + t * (end - start),
+            Curve::Geometric => start.powf(1.0 - t) * end.powf(t),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const D: Duration = Duration::from_millis(1000);
+
+    fn approx(a: f64, b: f64, eps: f64) {
+        assert!((a - b).abs() < eps, "{a} != {b} (eps {eps})");
+    }
+
+    #[test]
+    fn step_holds_start_until_end() {
+        let seg = CurveSegment::new(D, Curve::Step);
+        assert_eq!(seg.interp(1.0, 0.1, Duration::ZERO), 1.0);
+        assert_eq!(seg.interp(1.0, 0.1, Duration::from_millis(500)), 1.0);
+        assert_eq!(seg.interp(1.0, 0.1, Duration::from_millis(999)), 1.0);
+        assert_eq!(seg.interp(1.0, 0.1, D), 0.1);
+        assert_eq!(seg.interp(1.0, 0.1, Duration::from_millis(1500)), 0.1);
+    }
+
+    #[test]
+    fn linear_endpoints_and_midpoint() {
+        let seg = CurveSegment::new(D, Curve::Linear);
+        approx(seg.interp(1.0, 0.1, Duration::ZERO), 1.0, 1e-12);
+        approx(seg.interp(1.0, 0.1, D), 0.1, 1e-12);
+        approx(seg.interp(1.0, 0.1, Duration::from_millis(500)), 0.55, 1e-12);
+    }
+
+    #[test]
+    fn geometric_midpoint_is_geometric_mean() {
+        let seg = CurveSegment::new(D, Curve::Geometric);
+        approx(seg.interp(1.0, 0.01, Duration::ZERO), 1.0, 1e-12);
+        approx(seg.interp(1.0, 0.01, D), 0.01, 1e-12);
+        approx(
+            seg.interp(1.0, 0.01, Duration::from_millis(500)),
+            (1.0_f64 * 0.01).sqrt(),
+            1e-12,
+        );
+    }
+
+    #[test]
+    fn geometric_collapses_when_endpoint_is_zero() {
+        let seg = CurveSegment::new(D, Curve::Geometric);
+        // start = 0: held at 0 for all t > 0, jumps to end at t = duration
+        assert_eq!(seg.interp(0.0, 1.0, Duration::ZERO), 0.0);
+        assert_eq!(seg.interp(0.0, 1.0, Duration::from_millis(500)), 0.0);
+        assert_eq!(seg.interp(0.0, 1.0, D), 1.0);
+    }
+
+    #[test]
+    fn zero_duration_returns_end_immediately() {
+        let seg = CurveSegment::new(Duration::ZERO, Curve::Linear);
+        assert_eq!(seg.interp(1.0, 0.5, Duration::ZERO), 0.5);
+    }
+}

--- a/shared-rs/tcp-model/src/envelope.rs
+++ b/shared-rs/tcp-model/src/envelope.rs
@@ -1,5 +1,12 @@
 //! A single transport event represented as overlaid bandwidth and latency
 //! envelopes that decay back to their nominal values.
+//!
+//! There is at most one [`Envelope`] active per directed link at any moment
+//! — TCP has a single cwnd per connection, and a new event (loss or idle
+//! reset) re-triggers the envelope from whatever multiplier the link is
+//! currently sitting at. Composing event effects is therefore an in-place
+//! replacement (capturing the current mult as the next envelope's
+//! `bw_start`), not a stack of overlaid contributions.
 
 use std::time::Duration;
 
@@ -8,6 +15,11 @@ use crate::curve::CurveSegment;
 #[derive(Clone, Copy, Debug)]
 pub struct Envelope {
     pub fired_at: Duration,
+    /// Multiplier at `fired_at`. For a cold/idle envelope this is `1.0`. For
+    /// a loss event that fires mid-recovery it is the multiplier that was in
+    /// effect just before the loss — the new envelope picks up from there.
+    pub bw_start: f64,
+    /// Multiplier at the end of the onset segment (the "bottom" of the dip).
     pub bw_depth: f64,
     pub bw_onset: CurveSegment,
     pub bw_release: CurveSegment,
@@ -26,7 +38,7 @@ impl Envelope {
             return 1.0;
         };
         if elapsed < self.bw_onset.duration {
-            self.bw_onset.interp(1.0, self.bw_depth, elapsed)
+            self.bw_onset.interp(self.bw_start, self.bw_depth, elapsed)
         } else {
             let since_release = elapsed - self.bw_onset.duration;
             if since_release < self.bw_release.duration {
@@ -72,6 +84,7 @@ mod tests {
     fn env() -> Envelope {
         Envelope {
             fired_at: ms(1000),
+            bw_start: 1.0,
             bw_depth: 0.1,
             bw_onset: CurveSegment::new(Duration::ZERO, Curve::Step),
             bw_release: CurveSegment::new(ms(500), Curve::Linear),
@@ -116,6 +129,25 @@ mod tests {
         assert_eq!(e.delivery_floor_at(ms(900)), None);
         assert_eq!(e.delivery_floor_at(ms(1200)), None);
         assert_eq!(e.delivery_floor_at(ms(1500)), None);
+    }
+
+    #[test]
+    fn loss_during_recovery_starts_from_current_mult() {
+        // A loss firing while bw is already at 0.4 (mid recovery from
+        // something earlier) should hold at 0.4 through the stall window,
+        // then drop to 0.4 * 0.5 = 0.2, then recover linearly to 1.0.
+        let e = Envelope {
+            fired_at: ms(1000),
+            bw_start: 0.4,
+            bw_depth: 0.2,
+            bw_onset: CurveSegment::new(ms(1000), Curve::Step), // RTO stall
+            bw_release: CurveSegment::new(ms(2000), Curve::Linear),
+            lat_stall: ms(1000),
+        };
+        assert!((e.bw_mult_at(ms(1500)) - 0.4).abs() < 1e-12);     // mid-stall
+        assert!((e.bw_mult_at(ms(2000)) - 0.2).abs() < 1e-12);     // stall end → depth
+        assert!((e.bw_mult_at(ms(3000)) - 0.6).abs() < 1e-12);     // halfway recovery
+        assert!((e.bw_mult_at(ms(4000)) - 1.0).abs() < 1e-12);     // fully recovered
     }
 
     #[test]

--- a/shared-rs/tcp-model/src/envelope.rs
+++ b/shared-rs/tcp-model/src/envelope.rs
@@ -1,0 +1,129 @@
+//! A single transport event represented as overlaid bandwidth and latency
+//! envelopes that decay back to their nominal values.
+
+use std::time::Duration;
+
+use crate::curve::CurveSegment;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Envelope {
+    pub fired_at: Duration,
+    pub bw_depth: f64,
+    pub bw_onset: CurveSegment,
+    pub bw_release: CurveSegment,
+    /// Width of the delivery-floor window. Any arrival landing in
+    /// `[fired_at, fired_at + lat_stall]` is bumped to its end. Zero means
+    /// no latency effect.
+    pub lat_stall: Duration,
+}
+
+impl Envelope {
+    /// Bandwidth multiplier contributed by this envelope at absolute time `t`
+    /// (`Duration` since the link epoch). Returns `1.0` once the envelope has
+    /// fully released.
+    pub fn bw_mult_at(&self, t: Duration) -> f64 {
+        let Some(elapsed) = t.checked_sub(self.fired_at) else {
+            return 1.0;
+        };
+        if elapsed < self.bw_onset.duration {
+            self.bw_onset.interp(1.0, self.bw_depth, elapsed)
+        } else {
+            let since_release = elapsed - self.bw_onset.duration;
+            if since_release < self.bw_release.duration {
+                self.bw_release.interp(self.bw_depth, 1.0, since_release)
+            } else {
+                1.0
+            }
+        }
+    }
+
+    /// If `t` falls inside the stall window, the absolute time to which
+    /// arrivals should be deferred; otherwise `None`.
+    pub fn delivery_floor_at(&self, t: Duration) -> Option<Duration> {
+        if self.lat_stall.is_zero() {
+            return None;
+        }
+        let stall_end = self.fired_at + self.lat_stall;
+        if t < self.fired_at || t >= stall_end {
+            None
+        } else {
+            Some(stall_end)
+        }
+    }
+
+    /// True once both bandwidth phases have completed and the stall window
+    /// has closed — the envelope can be dropped from active state.
+    pub fn is_expired_at(&self, t: Duration) -> bool {
+        let bw_end = self.fired_at + self.bw_onset.duration + self.bw_release.duration;
+        let stall_end = self.fired_at + self.lat_stall;
+        t >= bw_end && t >= stall_end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::curve::Curve;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    fn env() -> Envelope {
+        Envelope {
+            fired_at: ms(1000),
+            bw_depth: 0.1,
+            bw_onset: CurveSegment::new(Duration::ZERO, Curve::Step),
+            bw_release: CurveSegment::new(ms(500), Curve::Linear),
+            lat_stall: ms(200),
+        }
+    }
+
+    #[test]
+    fn bw_mult_before_fired_is_unit() {
+        assert_eq!(env().bw_mult_at(ms(500)), 1.0);
+    }
+
+    #[test]
+    fn bw_mult_step_onset_jumps_to_depth() {
+        // Zero-duration onset → release begins at fired_at with mult = depth.
+        let e = env();
+        assert!((e.bw_mult_at(ms(1000)) - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bw_mult_linear_release_midpoint() {
+        let e = env();
+        // 250ms into the 500ms release, halfway between 0.1 and 1.0.
+        assert!((e.bw_mult_at(ms(1250)) - 0.55).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bw_mult_after_release_returns_unit() {
+        let e = env();
+        assert_eq!(e.bw_mult_at(ms(1600)), 1.0);
+    }
+
+    #[test]
+    fn delivery_floor_inside_window() {
+        let e = env();
+        assert_eq!(e.delivery_floor_at(ms(1100)), Some(ms(1200)));
+    }
+
+    #[test]
+    fn delivery_floor_outside_window() {
+        let e = env();
+        assert_eq!(e.delivery_floor_at(ms(900)), None);
+        assert_eq!(e.delivery_floor_at(ms(1200)), None);
+        assert_eq!(e.delivery_floor_at(ms(1500)), None);
+    }
+
+    #[test]
+    fn expiration_requires_both_bw_and_stall_to_close() {
+        let mut e = env();
+        e.lat_stall = ms(800);
+        assert!(!e.is_expired_at(ms(1400))); // bw done at 1500, stall ends 1800
+        assert!(!e.is_expired_at(ms(1700)));
+        assert!(e.is_expired_at(ms(1800)));
+    }
+}

--- a/shared-rs/tcp-model/src/lib.rs
+++ b/shared-rs/tcp-model/src/lib.rs
@@ -1,0 +1,18 @@
+//! Analytic envelope model of TCP transport effects.
+//!
+//! Provides per-link state that captures the *effects* of three transport
+//! events on bandwidth and latency without simulating a TCP state machine:
+//!
+//! - **Cold start**: a slow-start ramp on first use of a link.
+//! - **Idle reset**: the same ramp re-paid after a silent gap.
+//! - **Loss**: a head-of-line stall for one RTO, followed by AIMD-style
+//!   bandwidth recovery.
+//!
+//! Each event produces an [`Envelope`] with a bandwidth-multiplier curve
+//! (depth, onset, release) and an additive latency stall. Envelopes overlay
+//! on a per-link basis; the consumer queries [`LinkState::bw_mult`] and
+//! [`LinkState::delivery_floor`] at message-send time to determine the
+//! effective bandwidth and any HoL delivery floor.
+//!
+//! The crate is pure: no I/O, no async, no time source. Times are passed in
+//! as [`std::time::Duration`] since a consumer-chosen link epoch.

--- a/shared-rs/tcp-model/src/lib.rs
+++ b/shared-rs/tcp-model/src/lib.rs
@@ -16,3 +16,13 @@
 //!
 //! The crate is pure: no I/O, no async, no time source. Times are passed in
 //! as [`std::time::Duration`] since a consumer-chosen link epoch.
+
+pub mod config;
+pub mod curve;
+pub mod envelope;
+pub mod link;
+
+pub use config::LinkEnvelopeCfg;
+pub use curve::{Curve, CurveSegment};
+pub use envelope::Envelope;
+pub use link::LinkState;

--- a/shared-rs/tcp-model/src/link.rs
+++ b/shared-rs/tcp-model/src/link.rs
@@ -1,12 +1,15 @@
 //! Per-link envelope state.
 //!
-//! Each directed link carries its own [`LinkState`]. Consumers call
-//! [`LinkState::on_send`] before queueing a new message: this prunes expired
-//! envelopes, fires a cold-start or idle-reset envelope when appropriate, and
-//! pushes a loss envelope if the caller's pre-drawn `loss_drawn` flag is set.
-//! At any other moment they can query [`LinkState::bw_mult`] (the multiplier
-//! on nominal bandwidth) and [`LinkState::delivery_floor`] (an absolute time
-//! below which arrivals must not be reported).
+//! Each directed link carries its own [`LinkState`] holding at most one
+//! [`Envelope`] — TCP has a single cwnd per connection, and loss or idle
+//! events *re-trigger* the envelope rather than overlay onto a stack.
+//! Consumers call [`LinkState::on_send`] before queueing a new message:
+//! that prunes the envelope if it has fully released, fires a cold/idle
+//! envelope when applicable, and replaces the envelope with a fresh loss
+//! event when the caller's pre-drawn `loss_drawn` flag is set. Replacement
+//! captures the current multiplier as the new envelope's `bw_start` so the
+//! ramp continues smoothly from wherever the link was at the moment of the
+//! event.
 //!
 //! Randomness is the consumer's responsibility: see
 //! [`LinkEnvelopeCfg::msg_loss_prob`] for the per-message probability to
@@ -25,7 +28,7 @@ const INTEGRATE_STEPS: u32 = 16;
 pub struct LinkState {
     cfg: LinkEnvelopeCfg,
     last_traffic: Option<Duration>,
-    active: SmallVec<[Envelope; 4]>,
+    current: Option<Envelope>,
 }
 
 impl LinkState {
@@ -33,7 +36,7 @@ impl LinkState {
         Self {
             cfg,
             last_traffic: None,
-            active: SmallVec::new(),
+            current: None,
         }
     }
 
@@ -41,58 +44,71 @@ impl LinkState {
         &self.cfg
     }
 
-    /// Product of every active envelope's bandwidth multiplier at `t`.
+    /// Multiplier on nominal bandwidth at time `t`. `1.0` when no envelope
+    /// is active or the active envelope has fully released.
     pub fn bw_mult(&self, t: Duration) -> f64 {
-        self.active.iter().map(|e| e.bw_mult_at(t)).product()
+        self.current.as_ref().map(|e| e.bw_mult_at(t)).unwrap_or(1.0)
     }
 
-    /// Latest stall-window end-time among active envelopes whose stall window
-    /// covers `t`. If none, returns `t` itself — the arrival is unaffected.
+    /// Stall-window end-time if `t` lies inside an active stall, else `t`.
     pub fn delivery_floor(&self, t: Duration) -> Duration {
-        self.active
-            .iter()
-            .filter_map(|e| e.delivery_floor_at(t))
-            .max()
+        self.current
+            .as_ref()
+            .and_then(|e| e.delivery_floor_at(t))
             .unwrap_or(t)
     }
 
-    /// Called before a new message is queued for transmission. Drops expired
-    /// envelopes, fires a cold or idle envelope when applicable, and pushes
-    /// a loss envelope when the caller's pre-drawn `loss_drawn` is true.
-    /// Envelopes whose depth and durations make them immediately expired
-    /// (e.g. when the config is [`LinkEnvelopeCfg::disabled`]) are never
-    /// retained — callers can rely on [`Self::has_active_envelopes`] being
-    /// false in that case. `_bytes` is currently unused but kept for symmetry
-    /// with [`LinkEnvelopeCfg::msg_loss_prob`].
+    /// Called before a new message is queued for transmission. Clears the
+    /// envelope if it has fully released, fires a cold/idle envelope when
+    /// applicable, and replaces it with a fresh loss envelope (capturing
+    /// the current mult as `bw_start`) when `loss_drawn` is true. Envelopes
+    /// that would be born immediately expired (e.g. under
+    /// [`LinkEnvelopeCfg::disabled`]) are dropped at birth — callers can
+    /// rely on [`Self::has_active_envelopes`] being false in that case.
     pub fn on_send(&mut self, t: Duration, _bytes: u64, loss_drawn: bool) {
-        self.active.retain(|e| !e.is_expired_at(t));
+        if self.current.as_ref().is_some_and(|e| e.is_expired_at(t)) {
+            self.current = None;
+        }
 
-        let trigger_cold = match self.last_traffic {
-            None => true,
-            Some(prev) => t.checked_sub(prev).is_some_and(|gap| gap > self.cfg.idle_reset_threshold),
-        };
+        let trigger_cold = self.current.is_none()
+            && match self.last_traffic {
+                None => true,
+                Some(prev) => t
+                    .checked_sub(prev)
+                    .is_some_and(|gap| gap > self.cfg.idle_reset_threshold),
+            };
         if trigger_cold {
             let env = self.cold_envelope(t);
             if !env.is_expired_at(t) {
-                self.active.push(env);
+                self.current = Some(env);
             }
         }
 
         if loss_drawn {
-            let env = self.loss_envelope(t);
+            let mult_now = self.bw_mult(t);
+            // Preserve any unfinished stall window from a prior loss event —
+            // a new loss can extend it but never shorten it.
+            let existing_stall_end = self
+                .current
+                .as_ref()
+                .map(|e| e.fired_at + e.lat_stall)
+                .filter(|end| *end > t)
+                .unwrap_or(t);
+            let new_stall_end = t + self.cfg.rto;
+            let lat_stall = existing_stall_end.max(new_stall_end) - t;
+            let env = self.loss_envelope(t, mult_now, lat_stall);
             if !env.is_expired_at(t) {
-                self.active.push(env);
+                self.current = Some(env);
             }
         }
 
         self.last_traffic = Some(t);
     }
 
-    /// True iff at least one envelope is currently in [`Self::on_send`]'s
-    /// active stack. Useful for consumers that want to take a faster path
-    /// when the link is unperturbed.
+    /// True iff an envelope is currently in effect. Plural in the name is a
+    /// historical hold-over from a stacked design; there is at most one.
     pub fn has_active_envelopes(&self) -> bool {
-        !self.active.is_empty()
+        self.current.is_some()
     }
 
     /// Smallest `t ≥ t0` such that [`Self::bytes_deliverable`]`(bps, t0, t)`
@@ -127,18 +143,18 @@ impl LinkState {
         hi
     }
 
-    /// Integrates `bps · bw_mult(s)` over `[t0, t1]`. Sub-divides at every
-    /// active envelope's phase transition, then applies a composite trapezoid
-    /// rule with [`INTEGRATE_STEPS`] sub-steps inside each phase-stable piece
-    /// so that geometric release curves are approximated accurately enough
-    /// for sim-realism use.
+    /// Integrates `bps · bw_mult(s)` over `[t0, t1]`. Sub-divides at the
+    /// active envelope's phase transitions, then applies a composite
+    /// trapezoid rule with [`INTEGRATE_STEPS`] sub-steps inside each
+    /// phase-stable piece so that geometric release curves integrate
+    /// accurately enough for sim-realism use.
     pub fn bytes_deliverable(&self, bps: u64, t0: Duration, t1: Duration) -> u64 {
         if t1 <= t0 || bps == 0 {
             return 0;
         }
-        let mut breaks: SmallVec<[Duration; 16]> = SmallVec::new();
+        let mut breaks: SmallVec<[Duration; 4]> = SmallVec::new();
         breaks.push(t0);
-        for e in &self.active {
+        if let Some(e) = &self.current {
             let onset_end = e.fired_at + e.bw_onset.duration;
             let release_end = onset_end + e.bw_release.duration;
             for b in [e.fired_at, onset_end, release_end] {
@@ -171,6 +187,7 @@ impl LinkState {
     fn cold_envelope(&self, t: Duration) -> Envelope {
         Envelope {
             fired_at: t,
+            bw_start: 1.0,
             bw_depth: self.cfg.cold_bw_depth,
             bw_onset: CurveSegment::new(Duration::ZERO, Curve::Step),
             bw_release: CurveSegment::new(self.cfg.cold_release, self.cfg.cold_release_shape),
@@ -178,15 +195,18 @@ impl LinkState {
         }
     }
 
-    fn loss_envelope(&self, t: Duration) -> Envelope {
+    fn loss_envelope(&self, t: Duration, start_mult: f64, lat_stall: Duration) -> Envelope {
+        let depth = (start_mult * self.cfg.loss_bw_depth).max(1e-6).min(start_mult);
         Envelope {
             fired_at: t,
-            bw_depth: self.cfg.loss_bw_depth,
-            // Onset holds bw at 1.0 throughout the RTO stall (delivery floor
-            // masks any transmission), then steps to depth as recovery begins.
+            bw_start: start_mult,
+            bw_depth: depth,
+            // Onset holds bw at `start_mult` through the RTO stall (delivery
+            // floor masks any transmission anyway), then steps to depth as
+            // recovery begins.
             bw_onset: CurveSegment::new(self.cfg.rto, Curve::Step),
             bw_release: CurveSegment::new(self.cfg.loss_release, self.cfg.loss_release_shape),
-            lat_stall: self.cfg.rto,
+            lat_stall,
         }
     }
 }
@@ -204,7 +224,7 @@ mod tests {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
         let mut s = LinkState::new(cfg);
         s.on_send(ms(0), 1500, false);
-        assert_eq!(s.active.len(), 1);
+        assert!(s.has_active_envelopes());
         // Step onset → mult at t=0 is `depth`, well below 1.0.
         assert!(s.bw_mult(ms(0)) < 0.2);
     }
@@ -214,34 +234,55 @@ mod tests {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
         let mut s = LinkState::new(cfg);
         s.on_send(ms(0), 1500, false);
+        let original_fired = s.current.as_ref().unwrap().fired_at;
         let cold_release_end = ms(0) + s.cfg.cold_release;
-        // Second send inside the cold envelope's recovery and well inside
-        // the idle threshold: only the original envelope is active.
         s.on_send(cold_release_end / 2, 1500, false);
-        assert_eq!(s.active.len(), 1);
+        // Still the original cold envelope — no re-trigger.
+        assert_eq!(s.current.as_ref().unwrap().fired_at, original_fired);
     }
 
     #[test]
-    fn long_idle_gap_re_fires_cold_envelope() {
+    fn long_idle_gap_re_fires_cold_envelope_after_release() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
         let mut s = LinkState::new(cfg);
         s.on_send(ms(0), 1500, false);
-        let before = s.active.len();
-        let later = s.cfg.idle_reset_threshold + ms(100);
+        // Past the cold envelope's release end AND past the idle threshold.
+        let later = s.cfg.cold_release + s.cfg.idle_reset_threshold + ms(100);
         s.on_send(later, 1500, false);
-        // A new cold envelope has been pushed; the old one may still be
-        // mid-release if its recovery is longer than the idle threshold.
-        assert!(s.active.len() > before);
+        let env = s.current.as_ref().unwrap();
+        assert_eq!(env.fired_at, later);
         assert!(s.bw_mult(later) < 0.2);
     }
 
     #[test]
-    fn loss_drawn_pushes_loss_envelope() {
+    fn loss_replaces_envelope_and_picks_up_from_current_mult() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
         let mut s = LinkState::new(cfg);
+        // Fire cold envelope, advance partway through its recovery.
+        s.on_send(ms(0), 1500, false);
+        let t_loss = s.cfg.cold_release / 2;
+        let mult_before_loss = s.bw_mult(t_loss);
+        assert!(mult_before_loss > s.cfg.cold_bw_depth && mult_before_loss < 1.0);
+        s.on_send(t_loss, 1500, true);
+        let env = s.current.as_ref().unwrap();
+        assert_eq!(env.fired_at, t_loss);
+        // bw_start captured the recovery-phase multiplier; depth halved it.
+        assert!((env.bw_start - mult_before_loss).abs() < 1e-9);
+        assert!((env.bw_depth - mult_before_loss * 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn back_to_back_losses_extend_stall_window() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg);
+        let rto = s.cfg.rto;
         s.on_send(ms(0), 1500, true);
-        // Cold + loss envelopes both active.
-        assert_eq!(s.active.len(), 2);
+        // Stall ends at t = rto.
+        assert_eq!(s.delivery_floor(rto / 2), rto);
+        // Second loss 200ms later → new stall ends at 200ms + rto, which is
+        // longer than the prior end. The replacement must honour that.
+        s.on_send(ms(200), 1500, true);
+        assert_eq!(s.delivery_floor(ms(300)), ms(200) + rto);
     }
 
     #[test]

--- a/shared-rs/tcp-model/src/link.rs
+++ b/shared-rs/tcp-model/src/link.rs
@@ -1,0 +1,282 @@
+//! Per-link envelope state.
+//!
+//! Each directed link carries its own [`LinkState`]. Consumers call
+//! [`LinkState::on_send`] before queueing a new message: this prunes expired
+//! envelopes, fires a cold-start or idle-reset envelope when appropriate, and
+//! draws packet loss. At any other moment they can query
+//! [`LinkState::bw_mult`] (the multiplier on nominal bandwidth) and
+//! [`LinkState::delivery_floor`] (an absolute time below which arrivals must
+//! not be reported).
+
+use std::time::Duration;
+
+use rand::Rng;
+use rand::rngs::StdRng;
+use smallvec::SmallVec;
+
+use crate::config::LinkEnvelopeCfg;
+use crate::curve::{Curve, CurveSegment};
+use crate::envelope::Envelope;
+
+const INTEGRATE_STEPS: u32 = 16;
+
+pub struct LinkState {
+    cfg: LinkEnvelopeCfg,
+    rng: StdRng,
+    last_traffic: Option<Duration>,
+    active: SmallVec<[Envelope; 4]>,
+}
+
+impl LinkState {
+    pub fn new(cfg: LinkEnvelopeCfg, rng: StdRng) -> Self {
+        Self {
+            cfg,
+            rng,
+            last_traffic: None,
+            active: SmallVec::new(),
+        }
+    }
+
+    pub fn cfg(&self) -> &LinkEnvelopeCfg {
+        &self.cfg
+    }
+
+    /// Product of every active envelope's bandwidth multiplier at `t`.
+    pub fn bw_mult(&self, t: Duration) -> f64 {
+        self.active.iter().map(|e| e.bw_mult_at(t)).product()
+    }
+
+    /// Latest stall-window end-time among active envelopes whose stall window
+    /// covers `t`. If none, returns `t` itself — the arrival is unaffected.
+    pub fn delivery_floor(&self, t: Duration) -> Duration {
+        self.active
+            .iter()
+            .filter_map(|e| e.delivery_floor_at(t))
+            .max()
+            .unwrap_or(t)
+    }
+
+    /// Called before a new message is queued for transmission. Drops expired
+    /// envelopes, fires a cold or idle envelope when applicable, and draws a
+    /// loss event whose probability scales with the message's segment count.
+    pub fn on_send(&mut self, t: Duration, bytes: u64) {
+        self.active.retain(|e| !e.is_expired_at(t));
+
+        let trigger_cold = match self.last_traffic {
+            None => true,
+            Some(prev) => t.checked_sub(prev).is_some_and(|gap| gap > self.cfg.idle_reset_threshold),
+        };
+        if trigger_cold {
+            self.active.push(self.cold_envelope(t));
+        }
+
+        if self.draw_loss(bytes) {
+            self.active.push(self.loss_envelope(t));
+        }
+
+        self.last_traffic = Some(t);
+    }
+
+    /// Integrates `bps · bw_mult(s)` over `[t0, t1]`. Sub-divides at every
+    /// active envelope's phase transition, then applies a composite trapezoid
+    /// rule with [`INTEGRATE_STEPS`] sub-steps inside each phase-stable piece
+    /// so that geometric release curves are approximated accurately enough
+    /// for sim-realism use.
+    pub fn bytes_deliverable(&self, bps: u64, t0: Duration, t1: Duration) -> u64 {
+        if t1 <= t0 || bps == 0 {
+            return 0;
+        }
+        let mut breaks: SmallVec<[Duration; 16]> = SmallVec::new();
+        breaks.push(t0);
+        for e in &self.active {
+            let onset_end = e.fired_at + e.bw_onset.duration;
+            let release_end = onset_end + e.bw_release.duration;
+            for b in [e.fired_at, onset_end, release_end] {
+                if b > t0 && b < t1 {
+                    breaks.push(b);
+                }
+            }
+        }
+        breaks.push(t1);
+        breaks.sort();
+        breaks.dedup();
+
+        let bps_f = bps as f64;
+        let mut bytes = 0.0;
+        for window in breaks.windows(2) {
+            let (a, b) = (window[0], window[1]);
+            let span = (b - a).as_secs_f64();
+            let dt = span / INTEGRATE_STEPS as f64;
+            let mut prev = self.bw_mult(a);
+            for i in 1..=INTEGRATE_STEPS {
+                let next_t = a + Duration::from_secs_f64(dt * i as f64);
+                let next = self.bw_mult(next_t);
+                bytes += bps_f * (prev + next) * 0.5 * dt;
+                prev = next;
+            }
+        }
+        bytes.max(0.0) as u64
+    }
+
+    fn cold_envelope(&self, t: Duration) -> Envelope {
+        Envelope {
+            fired_at: t,
+            bw_depth: self.cfg.cold_bw_depth,
+            bw_onset: CurveSegment::new(Duration::ZERO, Curve::Step),
+            bw_release: CurveSegment::new(self.cfg.cold_release, self.cfg.cold_release_shape),
+            lat_stall: Duration::ZERO,
+        }
+    }
+
+    fn loss_envelope(&self, t: Duration) -> Envelope {
+        Envelope {
+            fired_at: t,
+            bw_depth: self.cfg.loss_bw_depth,
+            // Onset holds bw at 1.0 throughout the RTO stall (delivery floor
+            // masks any transmission), then steps to depth as recovery begins.
+            bw_onset: CurveSegment::new(self.cfg.rto, Curve::Step),
+            bw_release: CurveSegment::new(self.cfg.loss_release, self.cfg.loss_release_shape),
+            lat_stall: self.cfg.rto,
+        }
+    }
+
+    fn draw_loss(&mut self, bytes: u64) -> bool {
+        if self.cfg.loss_prob_per_segment <= 0.0 || bytes == 0 {
+            return false;
+        }
+        let segments = bytes.div_ceil(self.cfg.mss_bytes) as f64;
+        let p_msg = 1.0 - (1.0 - self.cfg.loss_prob_per_segment).powf(segments);
+        self.rng.gen::<f64>() < p_msg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    fn rng() -> StdRng {
+        StdRng::seed_from_u64(0xC0FFEE)
+    }
+
+    #[test]
+    fn fresh_link_fires_cold_envelope_on_first_send() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(0), 1500);
+        assert_eq!(s.active.len(), 1);
+        // Step onset → mult at t=0 is `depth`, well below 1.0.
+        assert!(s.bw_mult(ms(0)) < 0.2);
+    }
+
+    #[test]
+    fn second_send_within_idle_threshold_does_not_re_fire() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(0), 1500);
+        let cold_release_end = ms(0) + s.cfg.cold_release;
+        // Second send inside the cold envelope's recovery and well inside
+        // the idle threshold: only the original envelope is active.
+        s.on_send(cold_release_end / 2, 1500);
+        assert_eq!(s.active.len(), 1);
+    }
+
+    #[test]
+    fn long_idle_gap_re_fires_cold_envelope() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(0), 1500);
+        let before = s.active.len();
+        let later = s.cfg.idle_reset_threshold + ms(100);
+        s.on_send(later, 1500);
+        // A new cold envelope has been pushed; the old one may still be
+        // mid-release if its recovery is longer than the idle threshold.
+        assert!(s.active.len() > before);
+        assert!(s.bw_mult(later) < 0.2);
+    }
+
+    #[test]
+    fn loss_disabled_by_default() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg, rng());
+        for i in 0..1000 {
+            s.on_send(ms(i * 10), 1500);
+        }
+        // Without loss, only one envelope at a time is active (cold/idle).
+        assert!(s.active.len() <= 1);
+    }
+
+    #[test]
+    fn loss_certain_always_fires() {
+        let mut cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        cfg.loss_prob_per_segment = 1.0;
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(0), 1500);
+        // Cold + loss envelopes both active.
+        assert_eq!(s.active.len(), 2);
+    }
+
+    #[test]
+    fn delivery_floor_unblocked_outside_stall() {
+        let mut cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        cfg.loss_prob_per_segment = 1.0;
+        let rto = cfg.rto;
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(100), 1500);
+        // Inside the rto stall → floor at fired_at + rto.
+        assert_eq!(s.delivery_floor(ms(500)), ms(100) + rto);
+        // After stall → no floor.
+        assert_eq!(s.delivery_floor(ms(2000)), ms(2000));
+    }
+
+    #[test]
+    fn bytes_deliverable_zero_envelopes_is_linear() {
+        let cfg = LinkEnvelopeCfg::disabled();
+        let s = LinkState::new(cfg, rng());
+        let bytes = s.bytes_deliverable(1_000_000, ms(0), ms(100));
+        // 100ms at 1MB/s = 100_000 bytes.
+        assert_eq!(bytes, 100_000);
+    }
+
+    #[test]
+    fn bytes_deliverable_under_cold_envelope_is_below_linear() {
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
+        let mut s = LinkState::new(cfg, rng());
+        s.on_send(ms(0), 1);
+        let bytes = s.bytes_deliverable(1_000_000, ms(0), ms(200));
+        // 200ms at 1MB/s, depth ≈ 0.05 ramping up → much less than 200_000.
+        assert!(bytes < 100_000, "got {bytes}");
+    }
+
+    #[test]
+    fn slow_start_ramp_matches_analytic_estimate() {
+        // 300ms latency, 1 MiB/s, 1 MB cold message. Analytic transfer time
+        // through slow-start is ~3.4s (vs ~1.0s with full bw); add latency
+        // for total arrival around 3.7s. Compare to a binary search over
+        // `bytes_deliverable` and assert the integrator lands in a sane band.
+        let lat = ms(300);
+        let bps: u64 = 1_024_000;
+        let mut s = LinkState::new(LinkEnvelopeCfg::defaults_for(lat, bps), rng());
+        s.on_send(Duration::ZERO, 1);
+
+        let target: u64 = 1_048_576;
+        let (mut lo, mut hi) = (Duration::ZERO, Duration::from_secs(10));
+        while hi - lo > Duration::from_micros(500) {
+            let mid = (lo + hi) / 2;
+            if s.bytes_deliverable(bps, Duration::ZERO, mid) < target {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let transfer = lo;
+        assert!(
+            transfer >= Duration::from_millis(3000) && transfer <= Duration::from_millis(3800),
+            "transfer {transfer:?} outside [3.0s, 3.8s]"
+        );
+    }
+}

--- a/shared-rs/tcp-model/src/link.rs
+++ b/shared-rs/tcp-model/src/link.rs
@@ -3,15 +3,17 @@
 //! Each directed link carries its own [`LinkState`]. Consumers call
 //! [`LinkState::on_send`] before queueing a new message: this prunes expired
 //! envelopes, fires a cold-start or idle-reset envelope when appropriate, and
-//! draws packet loss. At any other moment they can query
-//! [`LinkState::bw_mult`] (the multiplier on nominal bandwidth) and
-//! [`LinkState::delivery_floor`] (an absolute time below which arrivals must
-//! not be reported).
+//! pushes a loss envelope if the caller's pre-drawn `loss_drawn` flag is set.
+//! At any other moment they can query [`LinkState::bw_mult`] (the multiplier
+//! on nominal bandwidth) and [`LinkState::delivery_floor`] (an absolute time
+//! below which arrivals must not be reported).
+//!
+//! Randomness is the consumer's responsibility: see
+//! [`LinkEnvelopeCfg::msg_loss_prob`] for the per-message probability to
+//! Bernoulli-sample from any deterministic oracle.
 
 use std::time::Duration;
 
-use rand::Rng;
-use rand::rngs::StdRng;
 use smallvec::SmallVec;
 
 use crate::config::LinkEnvelopeCfg;
@@ -22,16 +24,14 @@ const INTEGRATE_STEPS: u32 = 16;
 
 pub struct LinkState {
     cfg: LinkEnvelopeCfg,
-    rng: StdRng,
     last_traffic: Option<Duration>,
     active: SmallVec<[Envelope; 4]>,
 }
 
 impl LinkState {
-    pub fn new(cfg: LinkEnvelopeCfg, rng: StdRng) -> Self {
+    pub fn new(cfg: LinkEnvelopeCfg) -> Self {
         Self {
             cfg,
-            rng,
             last_traffic: None,
             active: SmallVec::new(),
         }
@@ -57,9 +57,14 @@ impl LinkState {
     }
 
     /// Called before a new message is queued for transmission. Drops expired
-    /// envelopes, fires a cold or idle envelope when applicable, and draws a
-    /// loss event whose probability scales with the message's segment count.
-    pub fn on_send(&mut self, t: Duration, bytes: u64) {
+    /// envelopes, fires a cold or idle envelope when applicable, and pushes
+    /// a loss envelope when the caller's pre-drawn `loss_drawn` is true.
+    /// Envelopes whose depth and durations make them immediately expired
+    /// (e.g. when the config is [`LinkEnvelopeCfg::disabled`]) are never
+    /// retained — callers can rely on [`Self::has_active_envelopes`] being
+    /// false in that case. `_bytes` is currently unused but kept for symmetry
+    /// with [`LinkEnvelopeCfg::msg_loss_prob`].
+    pub fn on_send(&mut self, t: Duration, _bytes: u64, loss_drawn: bool) {
         self.active.retain(|e| !e.is_expired_at(t));
 
         let trigger_cold = match self.last_traffic {
@@ -67,14 +72,59 @@ impl LinkState {
             Some(prev) => t.checked_sub(prev).is_some_and(|gap| gap > self.cfg.idle_reset_threshold),
         };
         if trigger_cold {
-            self.active.push(self.cold_envelope(t));
+            let env = self.cold_envelope(t);
+            if !env.is_expired_at(t) {
+                self.active.push(env);
+            }
         }
 
-        if self.draw_loss(bytes) {
-            self.active.push(self.loss_envelope(t));
+        if loss_drawn {
+            let env = self.loss_envelope(t);
+            if !env.is_expired_at(t) {
+                self.active.push(env);
+            }
         }
 
         self.last_traffic = Some(t);
+    }
+
+    /// True iff at least one envelope is currently in [`Self::on_send`]'s
+    /// active stack. Useful for consumers that want to take a faster path
+    /// when the link is unperturbed.
+    pub fn has_active_envelopes(&self) -> bool {
+        !self.active.is_empty()
+    }
+
+    /// Smallest `t ≥ t0` such that [`Self::bytes_deliverable`]`(bps, t0, t)`
+    /// reaches `target`. Returns `t0` when the target is zero; returns the
+    /// supplied `upper` if even `bytes_deliverable(t0, upper)` falls short.
+    /// Useful for projecting when a specific number of bytes will have been
+    /// delivered through an envelope-modulated pipe.
+    pub fn invert_bytes_deliverable(
+        &self,
+        bps: u64,
+        target: u64,
+        t0: Duration,
+        upper: Duration,
+    ) -> Duration {
+        if target == 0 || bps == 0 {
+            return t0;
+        }
+        if upper <= t0 || self.bytes_deliverable(bps, t0, upper) < target {
+            return upper;
+        }
+        let mut lo = t0;
+        let mut hi = upper;
+        let tolerance = Duration::from_micros(1);
+        while hi.saturating_sub(lo) > tolerance {
+            let mid = lo + (hi - lo) / 2;
+            if self.bytes_deliverable(bps, t0, mid) >= target {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+        hi
     }
 
     /// Integrates `bps · bw_mult(s)` over `[t0, t1]`. Sub-divides at every
@@ -139,35 +189,21 @@ impl LinkState {
             lat_stall: self.cfg.rto,
         }
     }
-
-    fn draw_loss(&mut self, bytes: u64) -> bool {
-        if self.cfg.loss_prob_per_segment <= 0.0 || bytes == 0 {
-            return false;
-        }
-        let segments = bytes.div_ceil(self.cfg.mss_bytes) as f64;
-        let p_msg = 1.0 - (1.0 - self.cfg.loss_prob_per_segment).powf(segments);
-        self.rng.gen::<f64>() < p_msg
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::SeedableRng;
 
     fn ms(n: u64) -> Duration {
         Duration::from_millis(n)
     }
 
-    fn rng() -> StdRng {
-        StdRng::seed_from_u64(0xC0FFEE)
-    }
-
     #[test]
     fn fresh_link_fires_cold_envelope_on_first_send() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(0), 1500);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(0), 1500, false);
         assert_eq!(s.active.len(), 1);
         // Step onset → mult at t=0 is `depth`, well below 1.0.
         assert!(s.bw_mult(ms(0)) < 0.2);
@@ -176,23 +212,23 @@ mod tests {
     #[test]
     fn second_send_within_idle_threshold_does_not_re_fire() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(0), 1500);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(0), 1500, false);
         let cold_release_end = ms(0) + s.cfg.cold_release;
         // Second send inside the cold envelope's recovery and well inside
         // the idle threshold: only the original envelope is active.
-        s.on_send(cold_release_end / 2, 1500);
+        s.on_send(cold_release_end / 2, 1500, false);
         assert_eq!(s.active.len(), 1);
     }
 
     #[test]
     fn long_idle_gap_re_fires_cold_envelope() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(0), 1500);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(0), 1500, false);
         let before = s.active.len();
         let later = s.cfg.idle_reset_threshold + ms(100);
-        s.on_send(later, 1500);
+        s.on_send(later, 1500, false);
         // A new cold envelope has been pushed; the old one may still be
         // mid-release if its recovery is longer than the idle threshold.
         assert!(s.active.len() > before);
@@ -200,33 +236,20 @@ mod tests {
     }
 
     #[test]
-    fn loss_disabled_by_default() {
+    fn loss_drawn_pushes_loss_envelope() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        let mut s = LinkState::new(cfg, rng());
-        for i in 0..1000 {
-            s.on_send(ms(i * 10), 1500);
-        }
-        // Without loss, only one envelope at a time is active (cold/idle).
-        assert!(s.active.len() <= 1);
-    }
-
-    #[test]
-    fn loss_certain_always_fires() {
-        let mut cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        cfg.loss_prob_per_segment = 1.0;
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(0), 1500);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(0), 1500, true);
         // Cold + loss envelopes both active.
         assert_eq!(s.active.len(), 2);
     }
 
     #[test]
     fn delivery_floor_unblocked_outside_stall() {
-        let mut cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        cfg.loss_prob_per_segment = 1.0;
+        let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
         let rto = cfg.rto;
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(100), 1500);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(100), 1500, true);
         // Inside the rto stall → floor at fired_at + rto.
         assert_eq!(s.delivery_floor(ms(500)), ms(100) + rto);
         // After stall → no floor.
@@ -235,8 +258,7 @@ mod tests {
 
     #[test]
     fn bytes_deliverable_zero_envelopes_is_linear() {
-        let cfg = LinkEnvelopeCfg::disabled();
-        let s = LinkState::new(cfg, rng());
+        let s = LinkState::new(LinkEnvelopeCfg::disabled());
         let bytes = s.bytes_deliverable(1_000_000, ms(0), ms(100));
         // 100ms at 1MB/s = 100_000 bytes.
         assert_eq!(bytes, 100_000);
@@ -245,8 +267,8 @@ mod tests {
     #[test]
     fn bytes_deliverable_under_cold_envelope_is_below_linear() {
         let cfg = LinkEnvelopeCfg::defaults_for(ms(150), 1_000_000);
-        let mut s = LinkState::new(cfg, rng());
-        s.on_send(ms(0), 1);
+        let mut s = LinkState::new(cfg);
+        s.on_send(ms(0), 1, false);
         let bytes = s.bytes_deliverable(1_000_000, ms(0), ms(200));
         // 200ms at 1MB/s, depth ≈ 0.05 ramping up → much less than 200_000.
         assert!(bytes < 100_000, "got {bytes}");
@@ -260,8 +282,8 @@ mod tests {
         // `bytes_deliverable` and assert the integrator lands in a sane band.
         let lat = ms(300);
         let bps: u64 = 1_024_000;
-        let mut s = LinkState::new(LinkEnvelopeCfg::defaults_for(lat, bps), rng());
-        s.on_send(Duration::ZERO, 1);
+        let mut s = LinkState::new(LinkEnvelopeCfg::defaults_for(lat, bps));
+        s.on_send(Duration::ZERO, 1, false);
 
         let target: u64 = 1_048_576;
         let (mut lo, mut hi) = (Duration::ZERO, Duration::from_secs(10));

--- a/sim-rs/Cargo.lock
+++ b/sim-rs/Cargo.lock
@@ -1425,6 +1425,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "shared-consensus",
+ "tcp-model",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1454,6 +1455,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1492,6 +1496,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tcp-model"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "smallvec",
 ]
 
 [[package]]

--- a/sim-rs/sim-cli/src/bin/gen-test-data/strategy/utils.rs
+++ b/sim-rs/sim-cli/src/bin/gen-test-data/strategy/utils.rs
@@ -185,6 +185,7 @@ impl GraphBuilder {
                 RawLinkInfo {
                     latency_ms: link.latency_ms as f64,
                     bandwidth_bytes_per_second: None,
+                    tcp_envelope: None,
                 },
             );
         }

--- a/sim-rs/sim-cli/src/main.rs
+++ b/sim-rs/sim-cli/src/main.rs
@@ -80,11 +80,7 @@ fn read_config(args: &Args) -> Result<SimConfiguration> {
         Some(path) => fs::read_to_string(path)?,
         None => get_default_topology()?,
     };
-    let topology: Topology = {
-        let raw_topology: RawTopology = serde_yaml::from_str(&topology_str)?;
-        raw_topology.into()
-    };
-    topology.validate()?;
+    let raw_topology: RawTopology = serde_yaml::from_str(&topology_str)?;
 
     let mut raw_params = Figment::new()
         .merge(Yaml::string(include_str!(
@@ -97,6 +93,8 @@ fn read_config(args: &Args) -> Result<SimConfiguration> {
     }
 
     let params: RawParameters = raw_params.extract()?;
+    let topology = Topology::from_raw(raw_topology, params.tcp_envelope.as_ref());
+    topology.validate()?;
     let mut config = SimConfiguration::build(params, topology)?;
     if let Some(slots) = args.slots {
         config.slots = Some(slots);

--- a/sim-rs/sim-core/Cargo.toml
+++ b/sim-rs/sim-core/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.9"
 rand_chacha = "0.9"
 rand_distr = "0.5"
 serde = { version = "1", features = ["derive"] }
+tcp-model = { path = "../../shared-rs/tcp-model" }
 tokio = { version = "1", features = ["macros"] }
 tokio-util = "0.7"
 tracing = "0.1"

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -529,14 +529,79 @@ pub struct RawLinkInfo {
     pub tcp_envelope: Option<RawTcpEnvelope>,
 }
 
-/// User-facing topology knobs for the analytic TCP envelope model. Only the
-/// loss probability is exposed; all other parameters are derived from the
-/// link's latency and bandwidth in [`tcp_model::LinkEnvelopeCfg::defaults_for`].
+/// User-facing topology knobs for the analytic TCP envelope model. Every
+/// field is an optional override on top of the
+/// [`tcp_model::LinkEnvelopeCfg::defaults_for`] derivation. Durations use
+/// the same `_ms` suffix convention as the surrounding topology schema.
+///
+/// Note: `mss_bytes` and `initial_cwnd_segments` do *not* re-derive
+/// dependent fields like `cold_bw_depth` or `cold_release_ms` on their own.
+/// Override those too if you change MSS or IW away from the defaults.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RawTcpEnvelope {
-    #[serde(default)]
-    pub loss_prob_per_segment: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loss_prob_per_segment: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mss_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_cwnd_segments: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_reset_threshold_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rto_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loss_bw_depth: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cold_bw_depth: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cold_release_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cold_release_shape: Option<tcp_model::Curve>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loss_release_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loss_release_shape: Option<tcp_model::Curve>,
+}
+
+impl RawTcpEnvelope {
+    /// Apply this YAML block over a baseline [`tcp_model::LinkEnvelopeCfg`].
+    /// Fields left as `None` keep the baseline value.
+    pub fn apply(&self, cfg: &mut tcp_model::LinkEnvelopeCfg) {
+        if let Some(v) = self.loss_prob_per_segment {
+            cfg.loss_prob_per_segment = v;
+        }
+        if let Some(v) = self.mss_bytes {
+            cfg.mss_bytes = v;
+        }
+        if let Some(v) = self.initial_cwnd_segments {
+            cfg.initial_cwnd_segments = v;
+        }
+        if let Some(v) = self.idle_reset_threshold_ms {
+            cfg.idle_reset_threshold = Duration::from_millis(v);
+        }
+        if let Some(v) = self.rto_ms {
+            cfg.rto = Duration::from_millis(v);
+        }
+        if let Some(v) = self.loss_bw_depth {
+            cfg.loss_bw_depth = v;
+        }
+        if let Some(v) = self.cold_bw_depth {
+            cfg.cold_bw_depth = v;
+        }
+        if let Some(v) = self.cold_release_ms {
+            cfg.cold_release = Duration::from_millis(v);
+        }
+        if let Some(v) = self.cold_release_shape {
+            cfg.cold_release_shape = v;
+        }
+        if let Some(v) = self.loss_release_ms {
+            cfg.loss_release = Duration::from_millis(v);
+        }
+        if let Some(v) = self.loss_release_shape {
+            cfg.loss_release_shape = v;
+        }
+    }
 }
 
 pub struct Topology {
@@ -659,7 +724,7 @@ impl From<RawTopology> for Topology {
                         return None;
                     }
                     let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(latency, bps);
-                    cfg.loss_prob_per_segment = raw.loss_prob_per_segment;
+                    raw.apply(&mut cfg);
                     Some(cfg)
                 });
                 links.insert(
@@ -1501,5 +1566,80 @@ mod consensus_behaviour_tests {
         for id in a.keys() {
             assert!(id.to_inner() % 2 == 0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tcp_envelope_tests {
+    use super::*;
+    use tcp_model::Curve;
+
+    fn parsed(yaml: &str) -> RawTcpEnvelope {
+        serde_yaml::from_str(yaml).expect("parse failure")
+    }
+
+    #[test]
+    fn empty_block_is_all_none() {
+        let env = parsed("{}");
+        assert!(env.loss_prob_per_segment.is_none());
+        assert!(env.cold_release_shape.is_none());
+    }
+
+    #[test]
+    fn kebab_case_fields_parse() {
+        let env = parsed(
+            "
+            loss-prob-per-segment: 0.001
+            mss-bytes: 1500
+            initial-cwnd-segments: 16
+            idle-reset-threshold-ms: 250
+            rto-ms: 200
+            loss-bw-depth: 0.75
+            cold-bw-depth: 0.1
+            cold-release-ms: 500
+            cold-release-shape: linear
+            loss-release-ms: 2000
+            loss-release-shape: geometric
+            ",
+        );
+        assert_eq!(env.loss_prob_per_segment, Some(0.001));
+        assert_eq!(env.mss_bytes, Some(1500));
+        assert_eq!(env.initial_cwnd_segments, Some(16));
+        assert_eq!(env.idle_reset_threshold_ms, Some(250));
+        assert_eq!(env.rto_ms, Some(200));
+        assert_eq!(env.loss_bw_depth, Some(0.75));
+        assert_eq!(env.cold_bw_depth, Some(0.1));
+        assert_eq!(env.cold_release_ms, Some(500));
+        assert_eq!(env.cold_release_shape, Some(Curve::Linear));
+        assert_eq!(env.loss_release_ms, Some(2000));
+        assert_eq!(env.loss_release_shape, Some(Curve::Geometric));
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let res: Result<RawTcpEnvelope, _> = serde_yaml::from_str("not-a-field: 1");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn apply_layers_overrides_on_top_of_defaults() {
+        let yaml = "
+            loss-prob-per-segment: 0.002
+            rto-ms: 500
+            cold-release-shape: linear
+        ";
+        let raw: RawTcpEnvelope = serde_yaml::from_str(yaml).unwrap();
+        let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(
+            Duration::from_millis(150),
+            1_000_000,
+        );
+        let baseline_cold_release = cfg.cold_release;
+        raw.apply(&mut cfg);
+        assert_eq!(cfg.loss_prob_per_segment, 0.002);
+        assert_eq!(cfg.rto, Duration::from_millis(500));
+        assert_eq!(cfg.cold_release_shape, Curve::Linear);
+        // Unmentioned fields keep their derived defaults.
+        assert_eq!(cfg.cold_release, baseline_cold_release);
+        assert_eq!(cfg.mss_bytes, 1460);
     }
 }

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -572,12 +572,20 @@ pub struct RawTcpEnvelope {
 
 impl RawTcpEnvelope {
     /// Apply this YAML block over a baseline [`tcp_model::LinkEnvelopeCfg`].
-    /// Fields left as `None` keep the baseline value.
-    pub fn apply(&self, cfg: &mut tcp_model::LinkEnvelopeCfg) {
+    /// Fields left as `None` keep the baseline value. Rejects values that
+    /// would crash or NaN-poison downstream computations
+    /// (`mss-bytes: 0`, `loss-prob-per-segment` outside `[0, 1]`).
+    pub fn apply(&self, cfg: &mut tcp_model::LinkEnvelopeCfg) -> Result<()> {
         if let Some(v) = self.loss_prob_per_segment {
+            if !(0.0..=1.0).contains(&v) {
+                bail!("tcp-envelope.loss-prob-per-segment must be in [0, 1], got {v}");
+            }
             cfg.loss_prob_per_segment = v;
         }
         if let Some(v) = self.mss_bytes {
+            if v == 0 {
+                bail!("tcp-envelope.mss-bytes must be > 0");
+            }
             cfg.mss_bytes = v;
         }
         if let Some(v) = self.initial_cwnd_segments {
@@ -607,6 +615,7 @@ impl RawTcpEnvelope {
         if let Some(v) = self.loss_release_shape {
             cfg.loss_release_shape = v;
         }
+        Ok(())
     }
 }
 
@@ -744,10 +753,12 @@ impl Topology {
                         }
                         let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(latency, bps);
                         if let Some(g) = global {
-                            g.apply(&mut cfg);
+                            g.apply(&mut cfg)
+                                .expect("invalid global tcp-envelope override");
                         }
                         if let Some(l) = per_link {
-                            l.apply(&mut cfg);
+                            l.apply(&mut cfg)
+                                .expect("invalid per-link tcp-envelope override");
                         }
                         Some(cfg)
                     }),
@@ -1740,12 +1751,36 @@ mod tcp_envelope_tests {
             1_000_000,
         );
         let baseline_cold_release = cfg.cold_release;
-        raw.apply(&mut cfg);
+        raw.apply(&mut cfg).unwrap();
         assert_eq!(cfg.loss_prob_per_segment, 0.002);
         assert_eq!(cfg.rto, Duration::from_millis(500));
         assert_eq!(cfg.cold_release_shape, Curve::Linear);
         // Unmentioned fields keep their derived defaults.
         assert_eq!(cfg.cold_release, baseline_cold_release);
         assert_eq!(cfg.mss_bytes, 1460);
+    }
+
+    #[test]
+    fn apply_rejects_invalid_mss_bytes() {
+        let raw: RawTcpEnvelope = serde_yaml::from_str("mss-bytes: 0").unwrap();
+        let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(
+            Duration::from_millis(150),
+            1_000_000,
+        );
+        assert!(raw.apply(&mut cfg).is_err());
+    }
+
+    #[test]
+    fn apply_rejects_loss_prob_outside_unit_interval() {
+        let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(
+            Duration::from_millis(150),
+            1_000_000,
+        );
+        let bad_low: RawTcpEnvelope =
+            serde_yaml::from_str("loss-prob-per-segment: -0.1").unwrap();
+        assert!(bad_low.apply(&mut cfg).is_err());
+        let bad_high: RawTcpEnvelope =
+            serde_yaml::from_str("loss-prob-per-segment: 1.5").unwrap();
+        assert!(bad_high.apply(&mut cfg).is_err());
     }
 }

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -376,6 +376,12 @@ pub struct RawParameters {
     /// [`BehaviourSpec::Honest`]: shared_consensus::behaviour::BehaviourSpec::Honest
     #[serde(default)]
     pub consensus_behaviours: Vec<ConsensusBehaviourEntry>,
+
+    /// Global tcp-envelope defaults applied to every directed link in the
+    /// topology that has a bandwidth_bps set. Per-link overrides in the
+    /// topology YAML's `tcp-envelope` block layer on top of this.
+    #[serde(default)]
+    pub tcp_envelope: Option<RawTcpEnvelope>,
 }
 
 /// One row of [`RawParameters::consensus_behaviours`].
@@ -678,6 +684,17 @@ impl Topology {
 
 impl From<RawTopology> for Topology {
     fn from(value: RawTopology) -> Self {
+        Self::from_raw(value, None)
+    }
+}
+
+impl Topology {
+    /// Convert a raw topology, layering an optional global tcp-envelope under
+    /// any per-link overrides. The final per-link envelope is computed as
+    /// `defaults_for(latency, bps)` → apply `global` → apply per-link. Links
+    /// without a bandwidth_bps or with zero latency get no envelope, even if
+    /// a global cfg is supplied.
+    pub fn from_raw(value: RawTopology, global: Option<&RawTcpEnvelope>) -> Self {
         let mut node_ids = BTreeMap::new();
         let mut nodes = BTreeMap::new();
         for (index, (name, node)) in value.nodes.iter().enumerate() {
@@ -718,15 +735,23 @@ impl From<RawTopology> for Topology {
                 let mut ids = [consumer_id, producer_id];
                 ids.sort();
                 let latency = duration_ms(producer_info.latency_ms);
-                let tcp_envelope = producer_info.tcp_envelope.as_ref().and_then(|raw| {
-                    let bps = producer_info.bandwidth_bytes_per_second?;
-                    if bps == 0 || latency.is_zero() {
-                        return None;
-                    }
-                    let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(latency, bps);
-                    raw.apply(&mut cfg);
-                    Some(cfg)
-                });
+                let per_link = producer_info.tcp_envelope.as_ref();
+                let tcp_envelope = match (global, per_link) {
+                    (None, None) => None,
+                    _ => producer_info.bandwidth_bytes_per_second.and_then(|bps| {
+                        if bps == 0 || latency.is_zero() {
+                            return None;
+                        }
+                        let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(latency, bps);
+                        if let Some(g) = global {
+                            g.apply(&mut cfg);
+                        }
+                        if let Some(l) = per_link {
+                            l.apply(&mut cfg);
+                        }
+                        Some(cfg)
+                    }),
+                };
                 links.insert(
                     ids,
                     LinkConfiguration {
@@ -1619,6 +1644,87 @@ mod tcp_envelope_tests {
     fn unknown_field_is_rejected() {
         let res: Result<RawTcpEnvelope, _> = serde_yaml::from_str("not-a-field: 1");
         assert!(res.is_err());
+    }
+
+    fn raw_topology_2node_with_bandwidth() -> RawTopology {
+        let mut nodes = std::collections::BTreeMap::new();
+        nodes.insert(
+            "a".to_string(),
+            RawNode {
+                location: RawNodeLocation::Coords((0.0, 0.0)),
+                cpu_core_count: None,
+                tx_conflict_fraction: None,
+                tx_generation_weight: None,
+                stake: None,
+                producers: std::collections::BTreeMap::new(),
+                adversarial: None,
+                behaviours: vec![],
+            },
+        );
+        let mut b_producers = std::collections::BTreeMap::new();
+        b_producers.insert(
+            "a".to_string(),
+            RawLinkInfo {
+                latency_ms: 50.0,
+                bandwidth_bytes_per_second: Some(1_000_000),
+                tcp_envelope: None,
+            },
+        );
+        nodes.insert(
+            "b".to_string(),
+            RawNode {
+                location: RawNodeLocation::Coords((1.0, 1.0)),
+                cpu_core_count: None,
+                tx_conflict_fraction: None,
+                tx_generation_weight: None,
+                stake: None,
+                producers: b_producers,
+                adversarial: None,
+                behaviours: vec![],
+            },
+        );
+        RawTopology { nodes }
+    }
+
+    #[test]
+    fn global_envelope_applies_to_every_link_without_per_link_override() {
+        let global = RawTcpEnvelope {
+            loss_prob_per_segment: Some(0.005),
+            ..Default::default()
+        };
+        let topo = Topology::from_raw(raw_topology_2node_with_bandwidth(), Some(&global));
+        assert_eq!(topo.links.len(), 1);
+        let cfg = topo.links[0].tcp_envelope.as_ref().expect("envelope was attached");
+        assert_eq!(cfg.loss_prob_per_segment, 0.005);
+        // Untouched fields keep their physics-derived defaults.
+        assert_eq!(cfg.mss_bytes, 1460);
+    }
+
+    #[test]
+    fn no_global_and_no_per_link_means_no_envelope() {
+        let topo = Topology::from_raw(raw_topology_2node_with_bandwidth(), None);
+        assert_eq!(topo.links.len(), 1);
+        assert!(topo.links[0].tcp_envelope.is_none());
+    }
+
+    #[test]
+    fn per_link_override_layers_on_top_of_global() {
+        let global = RawTcpEnvelope {
+            loss_prob_per_segment: Some(0.005),
+            rto_ms: Some(800),
+            ..Default::default()
+        };
+        let mut raw = raw_topology_2node_with_bandwidth();
+        raw.nodes.get_mut("b").unwrap().producers.get_mut("a").unwrap().tcp_envelope = Some(
+            RawTcpEnvelope {
+                rto_ms: Some(200), // per-link overrides global's 800
+                ..Default::default()
+            },
+        );
+        let topo = Topology::from_raw(raw, Some(&global));
+        let cfg = topo.links[0].tcp_envelope.as_ref().unwrap();
+        assert_eq!(cfg.loss_prob_per_segment, 0.005); // from global
+        assert_eq!(cfg.rto, Duration::from_millis(200)); // per-link wins
     }
 
     #[test]

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -525,6 +525,18 @@ pub struct RawLinkInfo {
     pub latency_ms: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bandwidth_bytes_per_second: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tcp_envelope: Option<RawTcpEnvelope>,
+}
+
+/// User-facing topology knobs for the analytic TCP envelope model. Only the
+/// loss probability is exposed; all other parameters are derived from the
+/// link's latency and bandwidth in [`tcp_model::LinkEnvelopeCfg::defaults_for`].
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RawTcpEnvelope {
+    #[serde(default)]
+    pub loss_prob_per_segment: f64,
 }
 
 pub struct Topology {
@@ -640,13 +652,24 @@ impl From<RawTopology> for Topology {
                     .push(consumer_id);
                 let mut ids = [consumer_id, producer_id];
                 ids.sort();
+                let latency = duration_ms(producer_info.latency_ms);
+                let tcp_envelope = producer_info.tcp_envelope.as_ref().and_then(|raw| {
+                    let bps = producer_info.bandwidth_bytes_per_second?;
+                    if bps == 0 || latency.is_zero() {
+                        return None;
+                    }
+                    let mut cfg = tcp_model::LinkEnvelopeCfg::defaults_for(latency, bps);
+                    cfg.loss_prob_per_segment = raw.loss_prob_per_segment;
+                    Some(cfg)
+                });
                 links.insert(
                     ids,
                     LinkConfiguration {
                         nodes: (ids[0], ids[1]),
-                        latency: duration_ms(producer_info.latency_ms),
+                        latency,
                         bandwidth_bps: producer_info.bandwidth_bytes_per_second,
                         use_tcp: false,
+                        tcp_envelope,
                     },
                 );
             }
@@ -1351,6 +1374,7 @@ pub struct LinkConfiguration {
     /// Use the TCP congestion-window model for this link instead of the
     /// simple bandwidth-sharing model.
     pub use_tcp: bool,
+    pub tcp_envelope: Option<tcp_model::LinkEnvelopeCfg>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/sim-rs/sim-core/src/network.rs
+++ b/sim-rs/sim-core/src/network.rs
@@ -2,11 +2,13 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc, time::Duratio
 
 use anyhow::{Result, bail};
 use coordinator::{CrossShardDelivery, EdgeConfig, Message, NetworkCoordinator};
+use tcp_model::LinkEnvelopeCfg;
 use tokio::sync::mpsc;
 
 use crate::{
     clock::{Clock, ClockBarrier},
     config::NodeId,
+    rng::Rng,
 };
 
 pub(crate) mod connection;
@@ -33,6 +35,13 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
         }
     }
 
+    /// Attach the deterministic loss-draw oracle. Required for any edge that
+    /// is later added with a non-`None` tcp-envelope configuration; ignored
+    /// when no edge uses an envelope.
+    pub fn set_rng_oracle(&mut self, oracle: Rng) {
+        self.coordinator.set_rng_oracle(oracle);
+    }
+
     pub fn set_edge_policy(
         &mut self,
         from: NodeId,
@@ -40,6 +49,7 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
         latency: Duration,
         bandwidth_bps: Option<u64>,
         use_tcp: bool,
+        tcp_envelope: Option<LinkEnvelopeCfg>,
     ) -> Result<()> {
         self.coordinator.add_edge(EdgeConfig {
             from,
@@ -47,6 +57,7 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
             latency,
             bandwidth_bps,
             use_tcp,
+            tcp_envelope: tcp_envelope.clone(),
         });
         self.coordinator.add_edge(EdgeConfig {
             from: to,
@@ -54,6 +65,7 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
             latency,
             bandwidth_bps,
             use_tcp,
+            tcp_envelope,
         });
         Ok(())
     }
@@ -66,9 +78,16 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> Network<TProtocol, TMe
         latency: Duration,
         bandwidth_bps: Option<u64>,
         use_tcp: bool,
+        tcp_envelope: Option<LinkEnvelopeCfg>,
     ) {
-        self.coordinator
-            .add_edge(EdgeConfig { from, to, latency, bandwidth_bps, use_tcp });
+        self.coordinator.add_edge(EdgeConfig {
+            from,
+            to,
+            latency,
+            bandwidth_bps,
+            use_tcp,
+            tcp_envelope,
+        });
     }
 
     /// Set up direct cross-shard routing: this NC sends directly to target NCs.

--- a/sim-rs/sim-core/src/network/connection.rs
+++ b/sim-rs/sim-core/src/network/connection.rs
@@ -3,7 +3,9 @@ use std::{
     time::Duration,
 };
 
-use crate::{clock::Timestamp, tcp::TcpConnProps};
+use tcp_model::{LinkEnvelopeCfg, LinkState};
+
+use crate::{clock::Timestamp, config::NodeId, rng::Rng, tcp::TcpConnProps};
 
 use super::tcp_connection::{DEFAULT_TCP_BANDWIDTH, TcpConnection};
 
@@ -63,6 +65,27 @@ pub struct Connection<TProtocol, TMessage> {
     latency_queue: VecDeque<(TMessage, Timestamp)>,
     last_event: Timestamp,
     next_id: u64,
+    envelope: Option<EnvelopeWiring>,
+}
+
+/// Per-link state for the analytic TCP envelope model plus the deterministic
+/// oracle and link identity used to seed loss draws.
+pub struct EnvelopeWiring {
+    pub state: LinkState,
+    pub rng: Rng,
+    pub from: NodeId,
+    pub to: NodeId,
+}
+
+impl EnvelopeWiring {
+    pub fn new(cfg: LinkEnvelopeCfg, rng: Rng, from: NodeId, to: NodeId) -> Self {
+        Self {
+            state: LinkState::new(cfg),
+            rng,
+            from,
+            to,
+        }
+    }
 }
 
 impl<TProtocol, TMessage> Connection<TProtocol, TMessage>
@@ -70,6 +93,25 @@ where
     TProtocol: Clone + Ord,
 {
     pub fn new(latency: Duration, bandwidth_bps: Option<u64>) -> Self {
+        Self::new_inner(latency, bandwidth_bps, None)
+    }
+
+    /// Constructor that attaches a [`tcp_model::LinkState`] driving slow-start,
+    /// idle-reset, and per-message loss for this directed link. Behaviour
+    /// matches [`Self::new`] exactly when the cfg is [`LinkEnvelopeCfg::disabled`].
+    pub fn with_envelope(
+        latency: Duration,
+        bandwidth_bps: Option<u64>,
+        envelope: EnvelopeWiring,
+    ) -> Self {
+        Self::new_inner(latency, bandwidth_bps, Some(envelope))
+    }
+
+    fn new_inner(
+        latency: Duration,
+        bandwidth_bps: Option<u64>,
+        envelope: Option<EnvelopeWiring>,
+    ) -> Self {
         Self {
             bandwidth_bps,
             latency,
@@ -77,7 +119,34 @@ where
             latency_queue: VecDeque::new(),
             last_event: Timestamp::zero(),
             next_id: 0,
+            envelope,
         }
+    }
+
+    /// Absolute time below which arrivals are not delivered, given the current
+    /// envelope state. `t` is returned unchanged when no stall is active or no
+    /// envelope is attached.
+    fn delivery_floor(&self, t: Timestamp) -> Timestamp {
+        let Some(env) = &self.envelope else { return t };
+        let floor_dur = env.state.delivery_floor(t - Timestamp::zero());
+        Timestamp::zero() + floor_dur
+    }
+
+    /// Fires the cold/idle envelope and the per-message loss draw for the
+    /// pending message. The loss outcome is deterministic in
+    /// `(global_seed, from, to, send_time_nanos, message_id)`.
+    fn run_on_send(&mut self, bytes: u64, now: Timestamp) {
+        let Some(env) = self.envelope.as_mut() else {
+            return;
+        };
+        let send_dur = now - Timestamp::zero();
+        let p = env.state.cfg().msg_loss_prob(bytes);
+        let loss = p > 0.0
+            && env.rng.draw_bool_with_context(
+                &("tcp_loss", env.from, env.to, send_dur, self.next_id),
+                p,
+            );
+        env.state.on_send(send_dur, bytes, loss);
     }
 
     /// Returns (message_count, total_bytes) across all bandwidth and latency queues.
@@ -95,9 +164,12 @@ where
 
     pub fn send(&mut self, message: TMessage, bytes: u64, miniprotocol: TProtocol, now: Timestamp) {
         if self.bandwidth_bps.is_none() {
-            self.latency_queue.push_back((message, now + self.latency));
+            self.run_on_send(bytes, now);
+            let arrival = self.delivery_floor(now + self.latency);
+            self.latency_queue.push_back((message, arrival));
         } else {
             self.update_bandwidth_queues(now);
+            self.run_on_send(bytes, now);
             self.bandwidth_queues
                 .entry(miniprotocol)
                 .or_default()
@@ -115,15 +187,14 @@ where
             .values()
             .filter_map(|q| q.bytes_in_next_message())
             .min()?;
-        Some(
-            self.last_event
-                + compute_bandwidth_delay(
-                    self.bandwidth_bps?,
-                    self.bandwidth_queues.len() as u64,
-                    bytes_left,
-                )
-                + self.latency,
-        )
+        let raw = self.last_event
+            + compute_bandwidth_delay(
+                self.bandwidth_bps?,
+                self.bandwidth_queues.len() as u64,
+                bytes_left,
+            )
+            + self.latency;
+        Some(self.delivery_floor(raw))
     }
 
     pub fn recv_many(&mut self, now: Timestamp) -> Vec<(TMessage, Timestamp)> {
@@ -144,14 +215,42 @@ where
             return;
         }
 
-        let mut bytes_to_consume =
-            (now - self.last_event).as_micros() as u64 * total_bps / 1_000_000;
+        // Total bytes the link could push over [last_event, now]. With no
+        // envelope this is `bps * elapsed`; with an envelope it integrates
+        // `bps * bw_mult(s)` so that slow-start, idle reset and loss-stall
+        // bandwidth dips are honoured.
+        let mut bytes_to_consume = match &self.envelope {
+            Some(env) => env.state.bytes_deliverable(
+                total_bps,
+                self.last_event - Timestamp::zero(),
+                now - Timestamp::zero(),
+            ),
+            None => (now - self.last_event).as_micros() as u64 * total_bps / 1_000_000,
+        };
 
         let mut messages_received = vec![];
         while bytes_to_consume > 0 && !self.bandwidth_queues.is_empty() {
             let queues = self.bandwidth_queues.len() as u64;
             let bytes_per_queue = self.split_bytes_amongst_queues(bytes_to_consume);
-            let total_bytes_consumed = bytes_per_queue.values().copied().sum();
+            let total_bytes_consumed: u64 = bytes_per_queue.values().copied().sum();
+
+            let envelope = self.envelope.as_ref();
+            let latency = self.latency;
+            let round_t0 = self.last_event;
+            let envelope_active = envelope.is_some_and(|e| e.state.has_active_envelopes());
+            let arrival_after = |link_bytes: u64| -> Timestamp {
+                if !envelope_active {
+                    return round_t0 + compute_bandwidth_delay(total_bps, 1, link_bytes) + latency;
+                }
+                let env = envelope.unwrap();
+                let t = env.state.invert_bytes_deliverable(
+                    total_bps,
+                    link_bytes,
+                    round_t0 - Timestamp::zero(),
+                    now - Timestamp::zero(),
+                );
+                Timestamp::zero() + t + latency
+            };
 
             self.bandwidth_queues.retain(|key, queue| {
                 let mut bytes_consumed = 0;
@@ -160,25 +259,24 @@ where
                 };
                 for (message, size) in queue.consume(bytes_to_consume_next) {
                     bytes_consumed += size;
-                    messages_received.push((
-                        message,
-                        self.last_event
-                            + compute_bandwidth_delay(total_bps, queues, bytes_consumed)
-                            + self.latency,
-                    ));
+                    messages_received.push((message, arrival_after(bytes_consumed * queues)));
                 }
                 bytes_to_consume -= bytes_to_consume_next;
                 !queue.is_empty()
             });
-            self.last_event += compute_bandwidth_delay(total_bps, 1, total_bytes_consumed);
+            // Advance last_event by the time taken to consume the whole pool
+            // (so the next iteration of this loop sees the correct t0).
+            self.last_event = arrival_after(total_bytes_consumed) - self.latency;
         }
         messages_received.sort_by_key(|((id, _), ts)| (*ts, *id));
         for ((_, message), arrival) in messages_received {
-            self.latency_queue.push_back((message, arrival));
+            let clamped = self.delivery_floor(arrival);
+            self.latency_queue.push_back((message, clamped));
         }
 
         self.last_event = now;
     }
+
 
     fn split_bytes_amongst_queues(&self, bytes: u64) -> BTreeMap<TProtocol, u64> {
         let mut queue_bytes: Vec<(&TProtocol, u64)> = self
@@ -546,6 +644,80 @@ mod tests {
         );
         assert_eq!(conn.next_arrival_time(), None);
     }
+
+    fn envelope_for(latency: Duration, bps: u64, loss_p: f64) -> super::EnvelopeWiring {
+        use crate::config::NodeId;
+        use tcp_model::LinkEnvelopeCfg;
+        let mut cfg = LinkEnvelopeCfg::defaults_for(latency, bps);
+        cfg.loss_prob_per_segment = loss_p;
+        super::EnvelopeWiring::new(cfg, crate::rng::Rng::new(0xC0FFEE), NodeId::new(1), NodeId::new(2))
+    }
+
+    #[test]
+    fn envelope_slow_start_delays_cold_message_vs_no_envelope() {
+        let latency = Duration::from_millis(150);
+        let bps = 1_000_000u64;
+        let far_future = Timestamp::zero() + Duration::from_secs(20);
+
+        let mut warm = Connection::<MiniProtocol, &'static str>::new(latency, Some(bps));
+        warm.send("m", 1_000_000, MiniProtocol::One, Timestamp::zero());
+        let warm_arrival = warm.recv_many(far_future)[0].1;
+
+        let mut cold = Connection::with_envelope(latency, Some(bps), envelope_for(latency, bps, 0.0));
+        cold.send("m", 1_000_000, MiniProtocol::One, Timestamp::zero());
+        let cold_arrival = cold.recv_many(far_future)[0].1;
+
+        // Warm pipe: 1MB / 1MB/s + 150ms ≈ 1.15s. Cold pipe: slow-start ramp
+        // pushes it noticeably later.
+        assert!(
+            cold_arrival > warm_arrival + Duration::from_millis(500),
+            "cold {cold_arrival:?} vs warm {warm_arrival:?} delta too small"
+        );
+    }
+
+    #[test]
+    fn envelope_loss_pushes_arrival_to_delivery_floor() {
+        let latency = Duration::from_millis(150);
+        let bps = 1_000_000u64;
+        let mut conn = Connection::with_envelope(latency, Some(bps), envelope_for(latency, bps, 1.0));
+        let send_at = Timestamp::zero() + Duration::from_millis(100);
+        conn.send("m", 1500, MiniProtocol::One, send_at);
+        let arrival = conn.recv_many(send_at + Duration::from_secs(5))[0].1;
+        // Loss certain → stall window = RTO = max(1s, 2*latency) = 1s.
+        let floor = send_at + Duration::from_secs(1);
+        assert!(arrival >= floor, "arrival {arrival:?} below floor {floor:?}");
+    }
+
+    #[test]
+    fn envelope_disabled_matches_no_envelope_byte_for_byte() {
+        use tcp_model::LinkEnvelopeCfg;
+        let latency = Duration::from_millis(10);
+        let bps = 1_000u64;
+
+        let mut plain = Connection::<MiniProtocol, &'static str>::new(latency, Some(bps));
+        let wiring = super::EnvelopeWiring::new(
+            LinkEnvelopeCfg::disabled(),
+            crate::rng::Rng::new(0),
+            crate::config::NodeId::new(1),
+            crate::config::NodeId::new(2),
+        );
+        let mut env = Connection::with_envelope(latency, Some(bps), wiring);
+
+        let start = Timestamp::zero() + Duration::from_secs(1);
+        for (i, p) in [MiniProtocol::One, MiniProtocol::Two, MiniProtocol::Three].into_iter().enumerate() {
+            let when = start + Duration::from_millis(50 * i as u64);
+            plain.send("m", 100, p.clone(), when);
+            env.send("m", 100, p, when);
+        }
+        let later = start + Duration::from_secs(5);
+        let plain_msgs = plain.recv_many(later);
+        let env_msgs = env.recv_many(later);
+        assert_eq!(plain_msgs.len(), env_msgs.len());
+        for ((pm, pt), (em, et)) in plain_msgs.iter().zip(env_msgs.iter()) {
+            assert_eq!(pm, em);
+            assert_eq!(pt, et, "envelope-disabled arrival diverged from baseline");
+        }
+    }
 }
 
 // ── Connection kind ───────────────────────────────────────────────────────────
@@ -573,11 +745,27 @@ impl<TProtocol: Clone + Ord, TMessage> ConnectionKind<TProtocol, TMessage> {
         Self::Tcp(TcpConnection::new(TcpConnProps::new(latency, bandwidth)))
     }
 
-    pub fn from_config(latency: Duration, bandwidth_bps: Option<u64>, use_tcp: bool) -> Self {
+    pub fn from_config(
+        latency: Duration,
+        bandwidth_bps: Option<u64>,
+        use_tcp: bool,
+        envelope: Option<EnvelopeWiring>,
+    ) -> Self {
         if use_tcp {
+            debug_assert!(
+                envelope.is_none(),
+                "use-tcp and tcp-envelope are mutually exclusive; tcp-envelope ignored",
+            );
             Self::tcp(latency, bandwidth_bps)
         } else {
-            Self::simple(latency, bandwidth_bps)
+            match envelope {
+                Some(wiring) => Self::Simple(Connection::with_envelope(
+                    latency,
+                    bandwidth_bps,
+                    wiring,
+                )),
+                None => Self::simple(latency, bandwidth_bps),
+            }
         }
     }
 

--- a/sim-rs/sim-core/src/network/coordinator.rs
+++ b/sim-rs/sim-core/src/network/coordinator.rs
@@ -9,14 +9,16 @@ use std::{
 
 use anyhow::Result;
 use priority_queue::PriorityQueue;
+use tcp_model::LinkEnvelopeCfg;
 use tokio::{select, sync::mpsc};
 
 use crate::{
     clock::{ClockBarrier, Timestamp},
     config::NodeId,
+    rng::Rng,
 };
 
-use super::connection::ConnectionKind;
+use super::connection::{ConnectionKind, EnvelopeWiring};
 
 /// Tuple sent directly from source NC to target NC for cross-shard messages.
 pub type CrossShardDelivery<TProtocol, TMessage> = (NodeId, NodeId, TProtocol, TMessage, u64, Timestamp);
@@ -32,6 +34,9 @@ pub struct NetworkCoordinator<TProtocol, TMessage> {
     shard_lookup: Option<Arc<HashMap<NodeId, usize>>>,
     /// Receives cross-shard messages from other NCs for local timing/delivery.
     cross_shard_delivery: Option<mpsc::UnboundedReceiver<CrossShardDelivery<TProtocol, TMessage>>>,
+    /// Deterministic oracle used to seed per-message loss draws when an edge
+    /// has a tcp-envelope configured.
+    rng_oracle: Option<Rng>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -46,6 +51,7 @@ pub struct EdgeConfig {
     pub latency: Duration,
     pub bandwidth_bps: Option<u64>,
     pub use_tcp: bool,
+    pub tcp_envelope: Option<LinkEnvelopeCfg>,
 }
 
 impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> NetworkCoordinator<TProtocol, TMessage> {
@@ -59,7 +65,12 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> NetworkCoordinator<TPr
             cross_shard_targets: Vec::new(),
             shard_lookup: None,
             cross_shard_delivery: None,
+            rng_oracle: None,
         }
+    }
+
+    pub fn set_rng_oracle(&mut self, oracle: Rng) {
+        self.rng_oracle = Some(oracle);
     }
 
     /// Set up direct cross-shard routing: this NC sends directly to target NCs.
@@ -91,10 +102,25 @@ impl<TProtocol: Clone + Eq + Hash + Ord, TMessage: Debug> NetworkCoordinator<TPr
             from: config.from,
             to: config.to,
         };
+        let envelope = match (config.tcp_envelope, self.rng_oracle) {
+            (Some(cfg), Some(rng)) => {
+                Some(EnvelopeWiring::new(cfg, rng, config.from, config.to))
+            }
+            (Some(_), None) => {
+                debug_assert!(
+                    false,
+                    "tcp_envelope configured for link {}→{} but rng_oracle is unset; call Network::set_rng_oracle before adding edges",
+                    config.from, config.to,
+                );
+                None
+            }
+            (None, _) => None,
+        };
         let connection = ConnectionKind::from_config(
             config.latency,
             config.bandwidth_bps,
             config.use_tcp,
+            envelope,
         );
         self.connections.insert(link, connection);
     }

--- a/sim-rs/sim-core/src/rng.rs
+++ b/sim-rs/sim-core/src/rng.rs
@@ -117,6 +117,22 @@ impl Rng {
         self.draw_f64_01(node, slot, site) < p
     }
 
+    /// Uniform in `[0.0, 1.0)` keyed by an arbitrary hashable context. Mirror
+    /// of [`Self::draw_f64_01`] for draws that don't fit the
+    /// `(NodeId, slot, DrawSite)` shape — e.g. per-link transport events.
+    pub fn draw_f64_01_with_context<K: Hash>(&self, ctx: &K) -> f64 {
+        let bits = self.draw_u64_with_context(ctx) >> 11;
+        (bits as f64) / (1u64 << 53) as f64
+    }
+
+    /// Bernoulli trial keyed by an arbitrary hashable context. Mirror of
+    /// [`Self::draw_bool`] for contexts that don't fit the
+    /// `(NodeId, slot, DrawSite)` shape.
+    pub fn draw_bool_with_context<K: Hash>(&self, ctx: &K, p: f64) -> bool {
+        let p = p.clamp(0.0, 1.0);
+        self.draw_f64_01_with_context(ctx) < p
+    }
+
     /// Seed a one-shot `ChaChaRng` from the given context. Useful when
     /// driving code that requires a `rand::Rng` interface (e.g., a
     /// `rand_distr::Distribution::sample` call, or any function taking

--- a/sim-rs/sim-core/src/sharding/shard.rs
+++ b/sim-rs/sim-core/src/sharding/shard.rs
@@ -69,6 +69,7 @@ where
 {
     let shard_count = clocks.len();
     let mut rng = ChaChaRng::seed_from_u64(config.seed.wrapping_add(1));
+    let net_oracle = crate::rng::Rng::new(config.seed);
 
     // Set up direct NC-to-NC cross-shard routing
     if shard_count > 1 {
@@ -81,6 +82,10 @@ where
         for network in &mut networks {
             network.set_cross_shard_routing(delivery_sinks.clone(), shard_lookup.clone());
         }
+    }
+
+    for network in &mut networks {
+        network.set_rng_oracle(net_oracle);
     }
 
     // Add edges to per-shard networks
@@ -99,6 +104,7 @@ where
                     link_config.latency,
                     link_config.bandwidth_bps,
                     link_config.use_tcp,
+                    link_config.tcp_envelope.clone(),
                 )
                 .expect("failed to set edge policy");
         } else {
@@ -109,6 +115,7 @@ where
                 link_config.latency,
                 link_config.bandwidth_bps,
                 link_config.use_tcp,
+                link_config.tcp_envelope.clone(),
             );
             networks[from_shard].add_incoming_edge(
                 to,
@@ -116,6 +123,7 @@ where
                 link_config.latency,
                 link_config.bandwidth_bps,
                 link_config.use_tcp,
+                link_config.tcp_envelope.clone(),
             );
         }
     }

--- a/sim-rs/sim-core/src/sim/sequential.rs
+++ b/sim-rs/sim-core/src/sim/sequential.rs
@@ -974,30 +974,29 @@ where
 
         // Build connections
         let mut connections: HashMap<Link, ConnectionKind<MiniProtocol, N::Message>> = HashMap::new();
+        let net_oracle = crate::rng::Rng::new(config.seed);
+        let make_conn = |from, to, lc: &crate::config::LinkConfiguration| {
+            let envelope = lc.tcp_envelope.as_ref().map(|cfg| {
+                crate::network::connection::EnvelopeWiring::new(
+                    cfg.clone(),
+                    net_oracle,
+                    from,
+                    to,
+                )
+            });
+            ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, envelope)
+        };
         for lc in &config.links {
             let (from, to) = lc.nodes;
             let fs = shard_lookup[&from];
             let ts = shard_lookup[&to];
             if shard_count == 1 || (fs == shard_idx && ts == shard_idx) {
-                // Intra-shard (or single-shard): both directions
-                connections.insert(
-                    Link { from, to },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
-                );
-                connections.insert(
-                    Link { from: to, to: from },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
-                );
+                connections.insert(Link { from, to }, make_conn(from, to, lc));
+                connections.insert(Link { from: to, to: from }, make_conn(to, from, lc));
             } else if ts == shard_idx {
-                connections.insert(
-                    Link { from, to },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
-                );
+                connections.insert(Link { from, to }, make_conn(from, to, lc));
             } else if fs == shard_idx {
-                connections.insert(
-                    Link { from: to, to: from },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
-                );
+                connections.insert(Link { from: to, to: from }, make_conn(to, from, lc));
             }
         }
 

--- a/sim-rs/sim-core/src/sim/sequential.rs
+++ b/sim-rs/sim-core/src/sim/sequential.rs
@@ -982,21 +982,21 @@ where
                 // Intra-shard (or single-shard): both directions
                 connections.insert(
                     Link { from, to },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
                 );
                 connections.insert(
                     Link { from: to, to: from },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
                 );
             } else if ts == shard_idx {
                 connections.insert(
                     Link { from, to },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
                 );
             } else if fs == shard_idx {
                 connections.insert(
                     Link { from: to, to: from },
-                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp),
+                    ConnectionKind::from_config(lc.latency, lc.bandwidth_bps, lc.use_tcp, None),
                 );
             }
         }

--- a/sim-rs/sim-core/src/sim/tests/engine.rs
+++ b/sim-rs/sim-core/src/sim/tests/engine.rs
@@ -247,6 +247,7 @@ fn new_node_with_bandwidth(
                     RawLinkInfo {
                         latency_ms: 5.0,
                         bandwidth_bytes_per_second,
+                        tcp_envelope: None,
                     },
                 )
             })

--- a/sim-rs/sim-core/src/sim/tests/linear_leios.rs
+++ b/sim-rs/sim-core/src/sim/tests/linear_leios.rs
@@ -110,6 +110,7 @@ fn new_node(stake: Option<u64>, producers: Vec<&'static str>) -> RawNode {
                     RawLinkInfo {
                         latency_ms: 0.0,
                         bandwidth_bytes_per_second: None,
+                        tcp_envelope: None,
                     },
                 )
             })


### PR DESCRIPTION
## Summary

Adds a new `shared-rs/tcp-model` crate plus an opt-in integration in
`sim-rs/sim-core` that overlays TCP transport effects — slow-start /
idle-reset / packet loss — on top of the existing fair-share bandwidth
model. Designed to be consumed identically by `sim-rs` and (in a later
phase) `net-rs`, hence the shared crate.

Per directed link, at most one envelope is active at a time (one cwnd
per connection). A new event re-triggers the envelope from whatever
multiplier the link is currently sitting at, dips to depth through the
onset, recovers to 1.0 through the release. Three events:

- **Cold start** — fresh link or post-idle reset: depth = IW / (2·BDP),
  geometric recovery over log2(2·BDP/IW)·2L.
- **Loss** — per-message Bernoulli `p = 1 − (1 − p_seg)^segments` against
  the consumer's deterministic oracle; halves bw from current mult,
  linear AIMD-shape recovery over (BDP/2)/MSS RTTs, plus a one-RTO
  delivery-floor stall that models cross-protocol HoL on the
  multiplexed-TCP link.
- **Idle reset** — same shape as cold, triggered after `max(1s, 2L)`
  of silence per the Linux/RFC-6298 idle-reset rule.

Behaviour with no `tcp-envelope` block configured is byte-identical to
the current sim-rs network model (verified by the existing connection
test suite plus a new `envelope_disabled_matches_no_envelope_byte_for_byte`
regression).

## Configuration

Optional global block at the top of the scenario config applies to every
directed link with a bandwidth set:

```yaml
tcp-envelope:
  loss-prob-per-segment: 0.001
```

Every `LinkEnvelopeCfg` knob (mss-bytes, initial-cwnd-segments,
idle-reset-threshold-ms, rto-ms, loss-bw-depth, cold-bw-depth,
cold-release-ms, cold-release-shape, loss-release-ms, loss-release-shape)
can also be overridden in the same block; physics-derived defaults
otherwise. Per-link `tcp-envelope` blocks in the topology YAML layer
on top of the global cfg.

## Verification

- **shared-rs/tcp-model**: 27 unit tests including an analytic slow-start
  cross-check against the Haskell sim's `ExamplesTCP.example2` (300 ms /
  1 MiB/s / 1 MB cold message → ~3.4 s transfer time).
- **sim-rs/sim-core**: 65 unit tests pass, including 3 new envelope-on
  tests (`envelope_slow_start_delays_cold_message_vs_no_envelope`,
  `envelope_loss_pushes_arrival_to_delivery_floor`, and the disabled
  regression).
- **End-to-end sanity** on a standard 2026w18 cell (NA,0.200 /
  top-stake-fraction / 750n / seed 0, turbo engine, 1500 slots): with
  `loss-prob-per-segment: 0.01` (intentionally aggressive) the sim
  shows the expected qualitative collapse — vote failures dominated by
  a new `LateEB` mode (0 → 11 025), votes per EB −69%, EBs missing
  threshold +57pp, tx→EB latency 13s → 640s, network-level receipt rate
  unchanged at 100% (we model delivery delay, not drops). Disabled-path
  is bit-identical to pre-envelope behaviour.

## Test plan

- [x] Build + tests pass: `cd shared-rs && cargo test && cd ../sim-rs && cargo test -p sim-core --lib`
- [x] Existing sim-rs sweeps continue to produce identical results when
      no `tcp-envelope` block is configured.
- [x] Spot-check a small sim with a non-zero `loss-prob-per-segment` to
      confirm the envelope fires and the expected metrics shift.

## Out of scope (followups)

- `net-rs` consumer (Phase 3 in the design plan) — bearer-level
  chaos/throttling that reuses the same `LinkState`. Pure-library
  design means no further changes to the crate are expected for that.
- Closed-form integrators replacing the current trapezoid sub-stepping
  if perf becomes an issue at high loss densities.
- Per-flow shared-bottleneck queueing and RTO backoff under repeated
  losses — both currently approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)