### PR TITLE
net-node: stable CPU + memory under cluster load

### DIFF
--- a/net-rs/net-core/src/peer/server_handlers.rs
+++ b/net-rs/net-core/src/peer/server_handlers.rs
@@ -529,7 +529,7 @@ pub async fn serve_leios_notify(ln_send: CodecSend, ln_recv: CodecRecv, store: A
 
         match msg {
             LnMsg::MsgLeiosNotificationRequestNext => {
-                let pending = store.notifications_after(read_index);
+                let pending = store.notifications_after(&mut read_index);
                 if let Some(notification) = pending.first() {
                     read_index += 1;
                     let response = match notification {
@@ -554,7 +554,7 @@ pub async fn serve_leios_notify(ln_send: CodecSend, ln_recv: CodecRecv, store: A
                         if subscription.changed().await.is_err() {
                             return;
                         }
-                        let pending = store.notifications_after(read_index);
+                        let pending = store.notifications_after(&mut read_index);
                         if let Some(notification) = pending.first() {
                             read_index += 1;
                             let response = match notification {

--- a/net-rs/net-core/src/protocols/blockfetch/mod.rs
+++ b/net-rs/net-core/src/protocols/blockfetch/mod.rs
@@ -101,8 +101,24 @@ impl Protocol for BlockFetch {
 
     fn size_limit(state: &State) -> usize {
         match state {
-            State::StIdle | State::StBusy => SIZE_LIMIT_SMALL,
-            State::StStreaming => SIZE_LIMIT_STREAMING,
+            // `StIdle` is client-agency: the server never sends here,
+            // so the small cap is enough.
+            State::StIdle => SIZE_LIMIT_SMALL,
+            // In `StBusy` and `StStreaming` the client receives from
+            // the server.  The demuxer enforces this value as a
+            // *buffer* cap, not a per-message cap — and the server
+            // can pipeline a `MsgStartBatch` plus one or more
+            // `MsgBlock`s in a single TCP read.  `SIZE_LIMIT_STREAMING`
+            // (2.5 MB) is the per-message spec cap but it's too tight
+            // for the buffer: a single legitimate Praos block body
+            // (post-EB-overflow fallback) can land right around 2.5
+            // MB and trip the demuxer.  Use the per-spec ingress
+            // buffer cap (`INGRESS_LIMIT`, 230 MB) instead.
+            //
+            // Per-spec per-message rejection at `SIZE_LIMIT_*` values
+            // belongs in the codec at decode time (not yet wired);
+            // this constant is buffer sizing, not message validation.
+            State::StBusy | State::StStreaming => INGRESS_LIMIT,
             State::StDone => 0,
         }
     }
@@ -238,8 +254,12 @@ mod tests {
     #[test]
     fn size_limits() {
         assert_eq!(BlockFetch::size_limit(&State::StIdle), 65_535);
-        assert_eq!(BlockFetch::size_limit(&State::StBusy), 65_535);
-        assert_eq!(BlockFetch::size_limit(&State::StStreaming), 2_500_000);
+        // StBusy and StStreaming use the per-protocol ingress buffer
+        // cap so the demuxer can hold pipelined `MsgStartBatch` +
+        // `MsgBlock` plus block-body messages that exceed the
+        // per-message spec cap of 2.5 MB.
+        assert_eq!(BlockFetch::size_limit(&State::StBusy), INGRESS_LIMIT);
+        assert_eq!(BlockFetch::size_limit(&State::StStreaming), INGRESS_LIMIT);
     }
 
     #[test]

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -8,7 +8,7 @@
 //! Server-side protocol handlers read (block lookups, vote lookups,
 //! notification subscriptions).
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::watch;
@@ -58,8 +58,17 @@ struct LeiosStoreInner {
     eb_tx_hashes: HashMap<BlockKey, Vec<[u8; 32]>>,
     /// Votes keyed by (slot, voter_id).
     votes: HashMap<(u64, Vec<u8>), Vec<u8>>,
-    /// Notification queue for the LeiosNotify server.
-    notifications: Vec<LeiosNotification>,
+    /// Notification queue for the LeiosNotify server.  Front-pruned
+    /// alongside the slot-window eviction of the other maps so
+    /// long-running connections don't accumulate notifications for
+    /// data that no longer lives in the store.
+    notifications: VecDeque<LeiosNotification>,
+    /// Total notifications popped off `notifications`' front so far —
+    /// used to translate `notifications_after`'s logical cursor into
+    /// the deque's local index.  Subscribers track a monotonically
+    /// increasing logical position; when their cursor falls behind
+    /// this count, `notifications_after` advances it to the front.
+    notifications_pruned_count: usize,
     /// Max number of blocks to retain.
     capacity: usize,
     /// Monotonically increasing counter for change notifications.
@@ -138,7 +147,8 @@ impl LeiosStore {
                 block_txs: HashMap::new(),
                 eb_tx_hashes: HashMap::new(),
                 votes: HashMap::new(),
-                notifications: Vec::new(),
+                notifications: VecDeque::new(),
+                notifications_pruned_count: 0,
                 capacity,
                 version: 0,
                 max_slot: 0,
@@ -165,7 +175,7 @@ impl LeiosStore {
         inner.blocks.insert(key, block);
         inner
             .notifications
-            .push(LeiosNotification::BlockOffer { point });
+            .push_back(LeiosNotification::BlockOffer { point });
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
     }
@@ -198,7 +208,7 @@ impl LeiosStore {
         if first_injection {
             inner
                 .notifications
-                .push(LeiosNotification::BlockTxsOffer { point });
+                .push_back(LeiosNotification::BlockTxsOffer { point });
         }
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
@@ -228,7 +238,7 @@ impl LeiosStore {
         }
         inner
             .notifications
-            .push(LeiosNotification::VotesOffer { votes: ids });
+            .push_back(LeiosNotification::VotesOffer { votes: ids });
         inner.max_slot = inner.max_slot.max(max_in_batch);
         self.bump_version(&mut inner);
     }
@@ -257,7 +267,7 @@ impl LeiosStore {
             .insert(BlockKey { slot, hash }, tx_hashes);
         inner
             .notifications
-            .push(LeiosNotification::BlockTxsOffer { point });
+            .push_back(LeiosNotification::BlockTxsOffer { point });
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
     }
@@ -332,19 +342,31 @@ impl LeiosStore {
         }
     }
 
-    /// Get notifications after the given index (exclusive).
-    /// Index 0 means "from the beginning".
-    pub fn notifications_after(&self, after: usize) -> Vec<LeiosNotification> {
+    /// Get notifications after the given logical index (exclusive).
+    ///
+    /// The cursor `after` is monotonically increasing across the
+    /// connection's lifetime — never reset, never shifted by pruning.
+    /// If the caller's cursor has fallen behind the prune frontier,
+    /// it's bumped up to the frontier so subsequent `*after += 1`
+    /// increments stay aligned with the logical position of items the
+    /// caller actually consumes.  Index `0` still means "from the
+    /// earliest still-retained notification".
+    pub fn notifications_after(&self, after: &mut usize) -> Vec<LeiosNotification> {
         let inner = self.inner.lock().unwrap();
-        if after >= inner.notifications.len() {
+        if *after < inner.notifications_pruned_count {
+            *after = inner.notifications_pruned_count;
+        }
+        let local = *after - inner.notifications_pruned_count;
+        if local >= inner.notifications.len() {
             return Vec::new();
         }
-        inner.notifications[after..].to_vec()
+        inner.notifications.range(local..).cloned().collect()
     }
 
-    /// Get the total number of notifications so far.
+    /// Total notifications ever pushed (including those since pruned).
     pub fn notification_count(&self) -> usize {
-        self.inner.lock().unwrap().notifications.len()
+        let inner = self.inner.lock().unwrap();
+        inner.notifications_pruned_count + inner.notifications.len()
     }
 
     /// Subscribe to change notifications.
@@ -369,6 +391,22 @@ impl LeiosStore {
             inner.block_txs.retain(|key, _| key.slot >= cutoff);
             inner.eb_tx_hashes.retain(|key, _| key.slot >= cutoff);
             inner.votes.retain(|(slot, _), _| *slot >= cutoff);
+            // Front-prune `notifications` for entries that reference
+            // only data older than the cutoff.  Notifications are
+            // pushed in arrival order, which roughly tracks slot
+            // order under normal operation — a non-evictable item at
+            // the front means later items are at least as recent, so
+            // stopping there is safe.  Worst case (out-of-order
+            // arrivals) leaks a small tail past the cutoff; the next
+            // bump catches it up.
+            while let Some(front) = inner.notifications.front() {
+                if notification_evictable(front, cutoff) {
+                    inner.notifications.pop_front();
+                    inner.notifications_pruned_count += 1;
+                } else {
+                    break;
+                }
+            }
         }
 
         // Capacity backstop on `blocks` (independent of slot window).
@@ -403,6 +441,22 @@ impl LeiosStore {
 
         let version = inner.version;
         let _ = self.notify.send(version);
+    }
+}
+
+/// True iff every slot the notification references is below `cutoff`
+/// — i.e. the notification only points at data that's already been
+/// evicted from the slot-window-pruned maps and can never be served.
+fn notification_evictable(n: &LeiosNotification, cutoff: u64) -> bool {
+    match n {
+        LeiosNotification::BlockOffer { point }
+        | LeiosNotification::BlockTxsOffer { point } => match point {
+            Point::Specific { slot, .. } => *slot < cutoff,
+            Point::Origin => true,
+        },
+        LeiosNotification::VotesOffer { votes } => {
+            !votes.is_empty() && votes.iter().all(|(s, _)| *s < cutoff)
+        }
     }
 }
 
@@ -601,7 +655,7 @@ mod tests {
 
         // One BlockTxsOffer notification, not two.
         let txs_offers = store
-            .notifications_after(0)
+            .notifications_after(&mut 0)
             .into_iter()
             .filter(|n| matches!(n, LeiosNotification::BlockTxsOffer { .. }))
             .count();
@@ -698,7 +752,7 @@ mod tests {
         store.inject_block(point, vec![0x01]);
         store.inject_votes(vec![(10, vec![0x02])], vec![vec![0x03]]);
 
-        let all = store.notifications_after(0);
+        let all = store.notifications_after(&mut 0);
         assert_eq!(all.len(), 2);
         assert!(matches!(
             all[0],
@@ -708,10 +762,10 @@ mod tests {
         ));
         assert!(matches!(all[1], LeiosNotification::VotesOffer { .. }));
 
-        let after_first = store.notifications_after(1);
+        let after_first = store.notifications_after(&mut 1);
         assert_eq!(after_first.len(), 1);
 
-        let after_all = store.notifications_after(2);
+        let after_all = store.notifications_after(&mut 2);
         assert!(after_all.is_empty());
     }
 
@@ -769,6 +823,56 @@ mod tests {
 
         // Recent entry stays.
         assert!(store.get_block(100, &[0x33; 32]).is_some());
+    }
+
+    #[test]
+    fn slot_retention_prunes_notifications() {
+        // Tight retention window so a few slot advances trigger eviction.
+        let (store, _rx) = LeiosStore::new_with_retention(1000, None, 5, 0);
+
+        // Three notifications at slot 1.
+        store.inject_block(
+            Point::Specific {
+                slot: 1,
+                hash: [0x11; 32],
+            },
+            vec![0xB0],
+        );
+        store.inject_block(
+            Point::Specific {
+                slot: 1,
+                hash: [0x12; 32],
+            },
+            vec![0xB1],
+        );
+        store.inject_votes(vec![(1, vec![0xAA])], vec![vec![0x01]]);
+        assert_eq!(store.notification_count(), 3);
+
+        // Inject a recent block to push max_slot past the retention
+        // window — cutoff = 100 - 5 = 95, all slot-1 notifications
+        // are now stale.
+        store.inject_block(
+            Point::Specific {
+                slot: 100,
+                hash: [0x33; 32],
+            },
+            vec![0xD0],
+        );
+
+        // The slot-1 notifications were front-pruned; only the
+        // slot-100 one remains.  The logical count still reflects
+        // every notification ever pushed.
+        assert_eq!(store.notification_count(), 4);
+        let mut cursor = 0;
+        let pending = store.notifications_after(&mut cursor);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(cursor, 3, "cursor advanced past the prune frontier");
+        assert!(matches!(
+            pending[0],
+            LeiosNotification::BlockOffer {
+                point: Point::Specific { slot: 100, .. }
+            }
+        ));
     }
 
     #[tokio::test]

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -652,14 +652,14 @@ fn log_event(node_id: &str, event: &NetworkEvent) {
         NetworkEvent::TransactionReceived { peer_id, body } => {
             // Accumulate received tx into local mempool for block inclusion.
             // (The tx was already received via TxSubmission from a peer.)
-            info!(node_id, %peer_id, bytes = body.len(), "transaction received");
+            tracing::debug!(node_id, %peer_id, bytes = body.len(), "transaction received");
         }
         NetworkEvent::PeersDiscovered { peers, .. } => {
             info!(node_id, count = peers.len(), "peers discovered");
         }
         NetworkEvent::PeerSnapshot { .. } => {} // handled by telemetry
         _ => {
-            info!(node_id, event = ?event, "network event");
+            tracing::debug!(node_id, event = ?event, "network event");
         }
     }
 }

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -131,6 +131,14 @@ pub struct MempoolState {
     /// TxSubmission server never re-announces the same tx to the same
     /// peer.
     pub peer_advertised: BTreeMap<PeerId, BTreeSet<TxId>>,
+    /// Per-peer "still owed to this peer" set — the inverse partition of
+    /// `peer_advertised` over the current mempool.  Lazily seeded on
+    /// the first peer-facing call (peek or mark), then maintained by
+    /// admit fan-out and pruned alongside `peer_advertised`.  Lets the
+    /// TxSubmission server return in `O(log P)` when the peer is
+    /// caught up, instead of scanning the entire mempool to find that
+    /// out.
+    pub peer_unannounced: BTreeMap<PeerId, BTreeSet<TxId>>,
     /// Bodies currently with the validator.  Cleared on
     /// `on_tx_validated` (body moves to `txs`) or
     /// `on_tx_validation_failed` (body dropped).
@@ -170,6 +178,7 @@ impl MempoolState {
             total_bytes: 0,
             capacity,
             peer_advertised: BTreeMap::new(),
+            peer_unannounced: BTreeMap::new(),
             pending_validation: BTreeMap::new(),
             eb_manifests: BTreeMap::new(),
             eb_pinned: BTreeMap::new(),
@@ -316,6 +325,7 @@ impl MempoolState {
     /// Drop per-peer advertised state on disconnect.
     pub fn forget_peer(&mut self, peer_id: PeerId) {
         self.peer_advertised.remove(&peer_id);
+        self.peer_unannounced.remove(&peer_id);
     }
 
     // -- Pure queries ------------------------------------------------------
@@ -350,24 +360,53 @@ impl MempoolState {
     }
 
     /// Return up to `max_count` txs not yet advertised to `peer_id`,
-    /// recording them so subsequent calls skip them.  The per-peer
-    /// advertised set is pruned automatically when txs leave the
-    /// mempool.  Hot path under TxSubmission pull traffic; the
-    /// `contains` check before the clone-and-insert avoids the heap
-    /// allocation for tx ids the peer already has.
+    /// moving each one from the per-peer "owed" set into the per-peer
+    /// "advertised" set so subsequent calls skip them.  Hot path under
+    /// TxSubmission pull traffic — when the peer is caught up the
+    /// per-peer owed set is empty and the call returns in `O(log P)`
+    /// (the BTreeMap lookup) without touching `self.txs`.
     pub fn peek_unannounced_for_peer(
         &mut self,
         peer_id: PeerId,
         max_count: usize,
     ) -> Vec<PendingTx> {
-        let mut result = Vec::with_capacity(max_count);
+        self.ensure_peer_registered(peer_id);
+        let unann = self
+            .peer_unannounced
+            .get_mut(&peer_id)
+            .expect("ensure_peer_registered");
+        if unann.is_empty() || max_count == 0 {
+            return Vec::new();
+        }
+        let to_send: Vec<TxId> = unann.iter().take(max_count).cloned().collect();
+        for id in &to_send {
+            unann.remove(id);
+        }
         let advertised = self.peer_advertised.entry(peer_id).or_default();
+        for id in &to_send {
+            advertised.insert(id.clone());
+        }
+        // Resolve bodies.  One scan over the free pool collects every
+        // id present there; eb-pinned bodies fill in for ids that have
+        // already drained out of `txs` into an EB closure.  The scan
+        // only runs when the owed set was non-empty — under steady
+        // TxSubmission traffic with a caught-up peer this branch
+        // doesn't execute at all.
+        let wanted: BTreeSet<&TxId> = to_send.iter().collect();
+        let mut result = Vec::with_capacity(to_send.len());
         for tx in &self.txs {
-            if result.len() >= max_count {
-                break;
+            if wanted.contains(&tx.tx_id) {
+                result.push(tx.clone());
+                if result.len() == to_send.len() {
+                    return result;
+                }
             }
-            if !advertised.contains(&tx.tx_id) {
-                advertised.insert(tx.tx_id.clone());
+        }
+        for id in &to_send {
+            if result.iter().any(|tx| &tx.tx_id == id) {
+                continue;
+            }
+            if let Some(tx) = self.eb_pinned.get(id) {
                 result.push(tx.clone());
             }
         }
@@ -375,15 +414,24 @@ impl MempoolState {
     }
 
     /// Mark `tx_id` as advertised to `peer_id`.  Returns `true` iff the
-    /// entry was newly inserted (the caller still needs to send the tx
-    /// body to that peer).  Used by the admit-fanout path to announce
-    /// a single just-admitted tx to every connected peer in O(log N)
-    /// per peer.
+    /// peer hadn't previously been told about `tx_id` (the caller still
+    /// needs to send the tx body to that peer).  Used by the
+    /// admit-fan-out path to announce a single just-admitted tx to
+    /// every connected peer in `O(log N)` per peer.
     pub fn mark_announced_to_peer(&mut self, peer_id: PeerId, tx_id: &TxId) -> bool {
-        self.peer_advertised
-            .entry(peer_id)
-            .or_default()
-            .insert(tx_id.clone())
+        self.ensure_peer_registered(peer_id);
+        let was_owed = self
+            .peer_unannounced
+            .get_mut(&peer_id)
+            .expect("ensure_peer_registered")
+            .remove(tx_id);
+        if was_owed {
+            self.peer_advertised
+                .entry(peer_id)
+                .or_default()
+                .insert(tx_id.clone());
+        }
+        was_owed
     }
 
     /// Drain txs from the front of the queue up to `max_bytes`.  At
@@ -449,6 +497,14 @@ impl MempoolState {
             .map(|s| s.len())
             .max()
             .unwrap_or(0);
+        let peer_unannounced_total: usize =
+            self.peer_unannounced.values().map(|s| s.len()).sum();
+        let peer_unannounced_max: usize = self
+            .peer_unannounced
+            .values()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
         let eb_manifest_entries_total: usize =
             self.eb_manifests.values().map(|v| v.len()).sum();
         info!(
@@ -459,6 +515,9 @@ impl MempoolState {
             peer_advertised = self.peer_advertised.len(),
             peer_advertised_total,
             peer_advertised_max,
+            peer_unannounced = self.peer_unannounced.len(),
+            peer_unannounced_total,
+            peer_unannounced_max,
             pending_validation = self.pending_validation.len(),
             eb_manifests = self.eb_manifests.len(),
             eb_manifest_entries_total,
@@ -653,6 +712,11 @@ impl MempoolState {
         }
         self.total_bytes += size as usize;
         self.tx_index.insert(tx_id.clone());
+        // Fan the new id out into every known peer's "owed" set so the
+        // next TxSubmission peek returns it without rescanning `txs`.
+        for set in self.peer_unannounced.values_mut() {
+            set.insert(tx_id.clone());
+        }
         self.txs.push_back(PendingTx {
             tx_id,
             body,
@@ -664,6 +728,20 @@ impl MempoolState {
     fn prune_from_peer_sets(&mut self, tx_id: &TxId) {
         for set in self.peer_advertised.values_mut() {
             set.remove(tx_id);
+        }
+        for set in self.peer_unannounced.values_mut() {
+            set.remove(tx_id);
+        }
+    }
+
+    /// Seed the "owed" set for `peer_id` from the current mempool the
+    /// first time the peer surfaces — the catch-up backlog any new
+    /// connection inherits.  Cheap re-call: skips the clone once an
+    /// entry exists.
+    fn ensure_peer_registered(&mut self, peer_id: PeerId) {
+        if !self.peer_unannounced.contains_key(&peer_id) {
+            self.peer_unannounced
+                .insert(peer_id, self.tx_index.clone());
         }
     }
 }

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -699,7 +699,7 @@ impl MempoolState {
                 self.total_bytes -= old.size as usize;
                 let evicted_id = old.tx_id.clone();
                 self.prune_from_peer_sets(&evicted_id);
-                info!(
+                tracing::debug!(
                     evicted = ?hex_short(&evicted_id),
                     capacity = self.capacity,
                     "mempool: evicting oldest tx to make room"


### PR DESCRIPTION
## Summary

Four focused fixes for the test-cluster's CPU runaway and overnight stability, identified during a 25-node smoke session. Each lives on its own commit so reviewers can take them piecemeal.

| Commit | What | Why |
|---|---|---|
| `acfb807bf` | shared-consensus: O(log P) idle peek via per-peer "unannounced" set | `peek_unannounced_for_peer` was scanning the entire mempool on every TxSubmission poll — `O(N · log A · 32)` per call. Added an inverse-partition `peer_unannounced: BTreeMap<PeerId, BTreeSet<TxId>>` populated by admit-fanout and drained by peek. Empty polls now return in `O(log P)` without touching `txs`. |
| `e27fdf991` | net-core: BlockFetch demuxer cap uses `INGRESS_LIMIT` | `set_ingress_limit` enforces a *buffer* cap on the per-protocol ingress queue, not a per-message cap. The server can pipeline `MsgStartBatch` + `MsgBlock` in a single TCP read; per-state caps of 65 KB (`StBusy`) or even 2.5 MB (`StStreaming`) race against the codec's state transition and reject legitimate pipelined block bodies. Overnight a post-EB-overflow RB body hit 2,506,268 bytes and froze the cluster. Switched to `INGRESS_LIMIT = 230 MB` (the spec's buffer cap) for both receive states. Per-message rejection at `SIZE_LIMIT_*` belongs in the codec at decode time (not yet wired). |
| `fb1fbd3e0` | net-core: front-prune LeiosStore notifications alongside slot eviction | `LeiosStore::notifications: Vec` grew monotonically forever even though the blocks/votes those entries referenced were slot-window-evicted. Switched to `VecDeque` + `notifications_pruned_count` so caller cursors stay monotonic across pruning; front-prune entries whose every referenced slot is below the cutoff. `notifications_after` now takes `&mut usize`. |
| `dca80e7a4` | net-node, shared-consensus: demote per-tx / per-event spam to debug | Three `info!` lines (`transaction received`, `network event`, `mempool: evicting oldest tx`) fire once per item under steady load and together account for ~90% of log volume at `RUST_LOG=info`. At 25 nodes × 1 tx/s/node × 12h that's enough to fill a disk. Demoted to `debug!`; periodic state-size summaries stay at `info!`. |

## Test plan

- [x] All 75 affected unit tests pass (`shared-consensus mempool`, `net-core blockfetch`, `net-core leios_store`)
- [x] 25-node release-build smoke test (~7 min): 0 errors / 0 warns, 9 RBs produced + diffused + validated across the cluster, 100% Leios certification rate, log volume ~7 MB vs ~50 MB on the old verbose build at the same elapsed time
- [ ] Longer-soak run to confirm the BlockFetch fix + notifications prune hold through overnight (test-combo branch has been the reproducer; CI doesn't currently cover this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)