### PR TITLE
net-node memory + per-message size enforcement

### DIFF
--- a/net-rs/net-core/src/mux/channel.rs
+++ b/net-rs/net-core/src/mux/channel.rs
@@ -65,9 +65,10 @@ impl IngressCounter {
     }
 }
 
-/// Shared ingress limit that the protocol runner can update and the demuxer
-/// reads on each segment dispatch. Allows per-state size limits to be
-/// enforced at the demuxer level (closest to the TCP socket).
+/// Shared per-channel buffer cap that the demuxer reads on each
+/// segment dispatch.  Fixed at protocol registration in production;
+/// the atomic exists so tests can dial it down to exercise overflow
+/// handling.
 #[derive(Debug, Clone)]
 pub struct IngressLimit(pub Arc<AtomicUsize>);
 
@@ -107,9 +108,9 @@ impl ChannelRecv {
         }
     }
 
-    /// Update the demuxer's ingress limit for this protocol. Called by the
-    /// protocol runner when the state changes, so the demuxer enforces
-    /// per-state size limits at the segment level (before data is buffered).
+    /// Update the demuxer's per-channel buffer cap.  In production the
+    /// buffer cap is fixed at protocol registration; this hook exists
+    /// for tests that exercise the demuxer's overflow handling.
     pub fn set_ingress_limit(&self, limit: usize) {
         self.ingress_limit.store(limit);
     }

--- a/net-rs/net-core/src/mux/codec.rs
+++ b/net-rs/net-core/src/mux/codec.rs
@@ -36,9 +36,19 @@ impl CodecSend {
 /// messages. Handles the case where a message spans multiple segments or
 /// multiple messages arrive in a single segment.
 ///
-/// Size limits are enforced at the demuxer level (via shared `IngressLimit`),
-/// not here. The demuxer rejects oversized data at the segment level before
-/// it reaches this buffer, allowing TCP backpressure to constrain the sender.
+/// Two distinct size guards apply on the receive path:
+///
+/// 1. **Per-channel buffer cap** (DoS protection): enforced at the demuxer
+///    via `ChannelRecv`'s shared `IngressLimit`.  Sized once at protocol
+///    registration to a value much larger than any single legal message,
+///    so a slow consumer can briefly queue multiple messages without
+///    tripping it.
+///
+/// 2. **Per-message spec cap** (protocol conformance): enforced here in
+///    `recv()` by the caller passing `max_msg_size = P::size_limit(state)`.
+///    After a CBOR value decodes successfully, the consumed-bytes count
+///    is checked against the per-state spec limit; an oversized message
+///    returns `MuxError::MessageTooLarge` and the connection is torn down.
 pub struct CodecRecv {
     channel: ChannelRecv,
     buffer: BytesMut,
@@ -52,26 +62,39 @@ impl CodecRecv {
         }
     }
 
-    /// Update the demuxer's ingress limit for this protocol channel.
-    /// Called by the protocol runner when state changes, so the demuxer
-    /// enforces per-state size limits at the segment level.
+    /// Update the demuxer's per-channel buffer cap. In production the
+    /// cap is fixed at protocol registration; this hook exists for
+    /// tests that exercise the demuxer's overflow handling.
     pub fn set_ingress_limit(&self, limit: usize) {
         self.channel.set_ingress_limit(limit);
     }
 
-    /// Receive and decode one CBOR message. Blocks until a complete message
-    /// is available. Returns an error if the channel closes before a complete
-    /// message is received.
+    /// Receive and decode one CBOR message. Blocks until a complete
+    /// message is available. Returns an error if the channel closes
+    /// before a complete message is received, or if the decoded
+    /// message's wire size exceeds `max_msg_size`.
+    ///
+    /// `max_msg_size` is the per-state per-message spec limit (callers
+    /// pass `P::size_limit(state)`). A decoded message larger than this
+    /// is a protocol-conformance violation by the peer.
     ///
     /// The decoded type must be owned (no borrows from the input buffer).
     /// This is necessary because the buffer is mutated between decode attempts.
-    pub async fn recv<T: for<'a> minicbor::Decode<'a, ()>>(&mut self) -> Result<T, MuxError> {
+    pub async fn recv<T: for<'a> minicbor::Decode<'a, ()>>(
+        &mut self,
+        max_msg_size: usize,
+    ) -> Result<T, MuxError> {
         loop {
             // Try to decode a message from the buffer.
             if !self.buffer.is_empty() {
                 match try_decode::<T>(&self.buffer) {
                     DecodeResult::Ok(value, consumed) => {
-                        // Advance past the consumed bytes.
+                        if consumed > max_msg_size {
+                            return Err(MuxError::MessageTooLarge {
+                                size: consumed,
+                                limit: max_msg_size,
+                            });
+                        }
                         let _ = self.buffer.split_to(consumed);
                         return Ok(value);
                     }
@@ -211,7 +234,7 @@ mod tests {
         };
         codec_send.send(&msg).await.unwrap();
 
-        let received: TestMsg = codec_recv.recv().await.unwrap();
+        let received: TestMsg = codec_recv.recv(65535).await.unwrap();
         assert_eq!(received, msg);
 
         ra.abort();
@@ -237,7 +260,7 @@ mod tests {
         }
 
         for i in 0..3u32 {
-            let received: TestMsg = codec_recv.recv().await.unwrap();
+            let received: TestMsg = codec_recv.recv(65535).await.unwrap();
             assert_eq!(received.tag, i);
             assert_eq!(received.payload, vec![i as u8; 10]);
         }
@@ -264,7 +287,7 @@ mod tests {
         };
         codec_send.send(&msg).await.unwrap();
 
-        let received: TestMsg = codec_recv.recv().await.unwrap();
+        let received: TestMsg = codec_recv.recv(100_000).await.unwrap();
         assert_eq!(received.tag, 1);
         assert_eq!(received.payload.len(), 30_000);
         assert!(received.payload.iter().all(|&b| b == 0xAB));
@@ -304,11 +327,43 @@ mod tests {
         codec_send.send(&msg).await.unwrap();
 
         // The recv should fail because the demuxer rejects the oversized data.
-        let result: Result<TestMsg, _> = codec_recv.recv().await;
+        let result: Result<TestMsg, _> = codec_recv.recv(usize::MAX).await;
         assert!(
             result.is_err(),
             "should reject message exceeding ingress limit"
         );
+
+        ra.abort();
+        rb.abort();
+    }
+
+    #[tokio::test]
+    async fn codec_recv_rejects_message_exceeding_per_message_cap() {
+        // Demuxer buffer cap is generous, but the codec's per-message
+        // cap (passed by Runner from P::size_limit(state)) must reject
+        // a message whose decoded wire size exceeds it.
+        let proto = ProtocolConfig {
+            id: 0,
+            traffic_class: TrafficClass::Priority,
+            ingress_limit: 100_000,
+            egress_queue_size: 10,
+        };
+        let (codec_send, mut codec_recv, ra, rb) = make_mux_pair(&proto);
+
+        let msg = TestMsg {
+            tag: 1,
+            payload: vec![0xAB; 10_000],
+        };
+        codec_send.send(&msg).await.unwrap();
+
+        let result: Result<TestMsg, _> = codec_recv.recv(1_000).await;
+        match result {
+            Err(MuxError::MessageTooLarge { size, limit }) => {
+                assert!(size > 10_000);
+                assert_eq!(limit, 1_000);
+            }
+            other => panic!("expected MessageTooLarge, got {other:?}"),
+        }
 
         ra.abort();
         rb.abort();
@@ -332,7 +387,7 @@ mod tests {
         // Give tasks a moment to shut down.
         tokio::task::yield_now().await;
 
-        let result: Result<TestMsg, _> = codec_recv.recv().await;
+        let result: Result<TestMsg, _> = codec_recv.recv(65535).await;
         assert!(result.is_err());
     }
 }

--- a/net-rs/net-core/src/mux/ingress.rs
+++ b/net-rs/net-core/src/mux/ingress.rs
@@ -20,9 +20,9 @@ pub(crate) struct ProtocolIngress {
     pub tx: mpsc::Sender<Bytes>,
     /// Shared byte counter — incremented here, decremented by ChannelRecv.
     pub counter: IngressCounter,
-    /// Shared limit — updated by protocol runner as state changes, read by
-    /// demuxer on each segment dispatch. Enforces per-state size limits at
-    /// the nearest point to the TCP socket.
+    /// Per-channel buffer cap. Fixed at registration; the demuxer
+    /// reads it on each segment dispatch to bound runaway accumulation
+    /// when the protocol consumer falls behind.
     pub limit: IngressLimit,
 }
 

--- a/net-rs/net-core/src/mux/mod.rs
+++ b/net-rs/net-core/src/mux/mod.rs
@@ -117,6 +117,9 @@ pub enum MuxError {
         capacity: usize,
     },
 
+    #[error("message too large: {size} bytes exceeds per-state spec limit {limit}")]
+    MessageTooLarge { size: usize, limit: usize },
+
     #[error("unknown protocol {0}")]
     UnknownProtocol(ProtocolId),
 

--- a/net-rs/net-core/src/peer/server_handlers.rs
+++ b/net-rs/net-core/src/peer/server_handlers.rs
@@ -529,7 +529,7 @@ pub async fn serve_leios_notify(ln_send: CodecSend, ln_recv: CodecRecv, store: A
 
         match msg {
             LnMsg::MsgLeiosNotificationRequestNext => {
-                let pending = store.notifications_after(read_index);
+                let pending = store.notifications_after(&mut read_index);
                 if let Some(notification) = pending.first() {
                     read_index += 1;
                     let response = match notification {
@@ -554,7 +554,7 @@ pub async fn serve_leios_notify(ln_send: CodecSend, ln_recv: CodecRecv, store: A
                         if subscription.changed().await.is_err() {
                             return;
                         }
-                        let pending = store.notifications_after(read_index);
+                        let pending = store.notifications_after(&mut read_index);
                         if let Some(notification) = pending.first() {
                             read_index += 1;
                             let response = match notification {

--- a/net-rs/net-core/src/protocols/blockfetch/mod.rs
+++ b/net-rs/net-core/src/protocols/blockfetch/mod.rs
@@ -101,24 +101,8 @@ impl Protocol for BlockFetch {
 
     fn size_limit(state: &State) -> usize {
         match state {
-            // `StIdle` is client-agency: the server never sends here,
-            // so the small cap is enough.
-            State::StIdle => SIZE_LIMIT_SMALL,
-            // In `StBusy` and `StStreaming` the client receives from
-            // the server.  The demuxer enforces this value as a
-            // *buffer* cap, not a per-message cap — and the server
-            // can pipeline a `MsgStartBatch` plus one or more
-            // `MsgBlock`s in a single TCP read.  `SIZE_LIMIT_STREAMING`
-            // (2.5 MB) is the per-message spec cap but it's too tight
-            // for the buffer: a single legitimate Praos block body
-            // (post-EB-overflow fallback) can land right around 2.5
-            // MB and trip the demuxer.  Use the per-spec ingress
-            // buffer cap (`INGRESS_LIMIT`, 230 MB) instead.
-            //
-            // Per-spec per-message rejection at `SIZE_LIMIT_*` values
-            // belongs in the codec at decode time (not yet wired);
-            // this constant is buffer sizing, not message validation.
-            State::StBusy | State::StStreaming => INGRESS_LIMIT,
+            State::StIdle | State::StBusy => SIZE_LIMIT_SMALL,
+            State::StStreaming => SIZE_LIMIT_STREAMING,
             State::StDone => 0,
         }
     }
@@ -253,13 +237,12 @@ mod tests {
 
     #[test]
     fn size_limits() {
-        assert_eq!(BlockFetch::size_limit(&State::StIdle), 65_535);
-        // StBusy and StStreaming use the per-protocol ingress buffer
-        // cap so the demuxer can hold pipelined `MsgStartBatch` +
-        // `MsgBlock` plus block-body messages that exceed the
-        // per-message spec cap of 2.5 MB.
-        assert_eq!(BlockFetch::size_limit(&State::StBusy), INGRESS_LIMIT);
-        assert_eq!(BlockFetch::size_limit(&State::StStreaming), INGRESS_LIMIT);
+        assert_eq!(BlockFetch::size_limit(&State::StIdle), SIZE_LIMIT_SMALL);
+        assert_eq!(BlockFetch::size_limit(&State::StBusy), SIZE_LIMIT_SMALL);
+        assert_eq!(
+            BlockFetch::size_limit(&State::StStreaming),
+            SIZE_LIMIT_STREAMING
+        );
     }
 
     #[test]

--- a/net-rs/net-core/src/protocols/blockfetch/mod.rs
+++ b/net-rs/net-core/src/protocols/blockfetch/mod.rs
@@ -101,8 +101,24 @@ impl Protocol for BlockFetch {
 
     fn size_limit(state: &State) -> usize {
         match state {
-            State::StIdle | State::StBusy => SIZE_LIMIT_SMALL,
-            State::StStreaming => SIZE_LIMIT_STREAMING,
+            // `StIdle` is client-agency: the server never sends here,
+            // so the small cap is enough.
+            State::StIdle => SIZE_LIMIT_SMALL,
+            // In `StBusy` and `StStreaming` the client receives from
+            // the server.  The demuxer enforces this value as a
+            // *buffer* cap, not a per-message cap — and the server
+            // can pipeline a `MsgStartBatch` plus one or more
+            // `MsgBlock`s in a single TCP read.  `SIZE_LIMIT_STREAMING`
+            // (2.5 MB) is the per-message spec cap but it's too tight
+            // for the buffer: a single legitimate Praos block body
+            // (post-EB-overflow fallback) can land right around 2.5
+            // MB and trip the demuxer.  Use the per-spec ingress
+            // buffer cap (`INGRESS_LIMIT`, 230 MB) instead.
+            //
+            // Per-spec per-message rejection at `SIZE_LIMIT_*` values
+            // belongs in the codec at decode time (not yet wired);
+            // this constant is buffer sizing, not message validation.
+            State::StBusy | State::StStreaming => INGRESS_LIMIT,
             State::StDone => 0,
         }
     }
@@ -238,8 +254,12 @@ mod tests {
     #[test]
     fn size_limits() {
         assert_eq!(BlockFetch::size_limit(&State::StIdle), 65_535);
-        assert_eq!(BlockFetch::size_limit(&State::StBusy), 65_535);
-        assert_eq!(BlockFetch::size_limit(&State::StStreaming), 2_500_000);
+        // StBusy and StStreaming use the per-protocol ingress buffer
+        // cap so the demuxer can hold pipelined `MsgStartBatch` +
+        // `MsgBlock` plus block-body messages that exceed the
+        // per-message spec cap of 2.5 MB.
+        assert_eq!(BlockFetch::size_limit(&State::StBusy), INGRESS_LIMIT);
+        assert_eq!(BlockFetch::size_limit(&State::StStreaming), INGRESS_LIMIT);
     }
 
     #[test]

--- a/net-rs/net-core/src/protocols/protocol.rs
+++ b/net-rs/net-core/src/protocols/protocol.rs
@@ -56,9 +56,13 @@ pub trait Protocol: Send + 'static {
     /// message is invalid for the current state.
     fn transition(state: &Self::State, msg: &Self::Message) -> Result<Self::State, ProtocolError>;
 
-    /// Maximum message size (bytes) allowed in the given state.
-    /// Must be nonzero — Runner will panic if this returns 0, and
-    /// the demuxer will reject all data for a protocol with limit 0.
+    /// Per-spec maximum size (bytes) of a single message in the given
+    /// state.  Enforced at codec decode time by `Runner::recv`: a
+    /// decoded message whose wire size exceeds this is a spec-violating
+    /// peer and the connection is torn down with `MuxError::Message
+    /// TooLarge`.  The demuxer's buffer cap is a separate, static value
+    /// declared at registration in `ProtocolConfig::ingress_limit`.
+    /// Must be nonzero — Runner will panic if this returns 0.
     fn size_limit(state: &Self::State) -> usize;
 
     /// Timeout for receiving a message in the given state.
@@ -108,18 +112,25 @@ pub struct Runner<P: Protocol> {
 impl<P: Protocol> Runner<P> {
     /// Create a new runner starting in the protocol's initial state.
     ///
+    /// The per-state `P::size_limit()` declares the spec's per-message
+    /// cap and is enforced at codec decode time in `recv()`.  The
+    /// demuxer's *buffer* cap is a separate, static value sized once
+    /// at protocol registration (`ProtocolConfig::ingress_limit`) to
+    /// bound runaway accumulation when a protocol consumer falls
+    /// behind; conflating it with the per-message cap races against
+    /// pipelined responses that legitimately arrive ahead of the
+    /// local state transition.
+    ///
     /// # Panics
     ///
     /// Panics if `P::size_limit()` returns 0 for the initial state. Every
     /// protocol must define a nonzero size limit for all states.
     pub fn new(role: Role, codec_send: CodecSend, codec_recv: CodecRecv) -> Self {
         let initial_state = P::initial_state();
-        let limit = P::size_limit(&initial_state);
         assert!(
-            limit > 0,
+            P::size_limit(&initial_state) > 0,
             "protocol size_limit must be nonzero for all states"
         );
-        codec_recv.set_ingress_limit(limit);
 
         Self {
             role,
@@ -170,16 +181,8 @@ impl<P: Protocol> Runner<P> {
         // Validate the transition.
         let next_state = P::transition(&self.state, msg)?;
 
-        // Send.
         self.codec_send.send(msg).await?;
-
         self.state = next_state;
-
-        // Update the demuxer's ingress limit for the new state. After
-        // sending, the remote side typically has agency and will respond,
-        // so set the limit before data arrives.
-        self.codec_recv
-            .set_ingress_limit(P::size_limit(&self.state));
 
         Ok(())
     }
@@ -205,18 +208,18 @@ impl<P: Protocol> Runner<P> {
             });
         }
 
-        // Set the demuxer's ingress limit for the current state, so
-        // oversized data is rejected at the segment level (closest to TCP).
-        self.codec_recv
-            .set_ingress_limit(P::size_limit(&self.state));
-
-        // Receive with optional timeout.
+        // Receive with optional timeout.  Codec checks the decoded
+        // message's wire size against `P::size_limit(state)` and returns
+        // `MuxError::MessageTooLarge` for spec-violating peers.
+        let max_msg_size = P::size_limit(&self.state);
         let msg: P::Message = match P::timeout(&self.state) {
-            Some(duration) => match tokio::time::timeout(duration, self.codec_recv.recv()).await {
-                Ok(result) => result?,
-                Err(_) => return Err(ProtocolError::Timeout(duration)),
-            },
-            None => self.codec_recv.recv().await?,
+            Some(duration) => {
+                match tokio::time::timeout(duration, self.codec_recv.recv(max_msg_size)).await {
+                    Ok(result) => result?,
+                    Err(_) => return Err(ProtocolError::Timeout(duration)),
+                }
+            }
+            None => self.codec_recv.recv(max_msg_size).await?,
         };
 
         // Validate the transition.

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -8,7 +8,7 @@
 //! Server-side protocol handlers read (block lookups, vote lookups,
 //! notification subscriptions).
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::watch;
@@ -58,8 +58,17 @@ struct LeiosStoreInner {
     eb_tx_hashes: HashMap<BlockKey, Vec<[u8; 32]>>,
     /// Votes keyed by (slot, voter_id).
     votes: HashMap<(u64, Vec<u8>), Vec<u8>>,
-    /// Notification queue for the LeiosNotify server.
-    notifications: Vec<LeiosNotification>,
+    /// Notification queue for the LeiosNotify server.  Front-pruned
+    /// alongside the slot-window eviction of the other maps so
+    /// long-running connections don't accumulate notifications for
+    /// data that no longer lives in the store.
+    notifications: VecDeque<LeiosNotification>,
+    /// Total notifications popped off `notifications`' front so far —
+    /// used to translate `notifications_after`'s logical cursor into
+    /// the deque's local index.  Subscribers track a monotonically
+    /// increasing logical position; when their cursor falls behind
+    /// this count, `notifications_after` advances it to the front.
+    notifications_pruned_count: usize,
     /// Max number of blocks to retain.
     capacity: usize,
     /// Monotonically increasing counter for change notifications.
@@ -138,7 +147,8 @@ impl LeiosStore {
                 block_txs: HashMap::new(),
                 eb_tx_hashes: HashMap::new(),
                 votes: HashMap::new(),
-                notifications: Vec::new(),
+                notifications: VecDeque::new(),
+                notifications_pruned_count: 0,
                 capacity,
                 version: 0,
                 max_slot: 0,
@@ -165,7 +175,7 @@ impl LeiosStore {
         inner.blocks.insert(key, block);
         inner
             .notifications
-            .push(LeiosNotification::BlockOffer { point });
+            .push_back(LeiosNotification::BlockOffer { point });
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
     }
@@ -198,7 +208,7 @@ impl LeiosStore {
         if first_injection {
             inner
                 .notifications
-                .push(LeiosNotification::BlockTxsOffer { point });
+                .push_back(LeiosNotification::BlockTxsOffer { point });
         }
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
@@ -228,7 +238,7 @@ impl LeiosStore {
         }
         inner
             .notifications
-            .push(LeiosNotification::VotesOffer { votes: ids });
+            .push_back(LeiosNotification::VotesOffer { votes: ids });
         inner.max_slot = inner.max_slot.max(max_in_batch);
         self.bump_version(&mut inner);
     }
@@ -257,7 +267,7 @@ impl LeiosStore {
             .insert(BlockKey { slot, hash }, tx_hashes);
         inner
             .notifications
-            .push(LeiosNotification::BlockTxsOffer { point });
+            .push_back(LeiosNotification::BlockTxsOffer { point });
         inner.max_slot = inner.max_slot.max(slot);
         self.bump_version(&mut inner);
     }
@@ -332,19 +342,31 @@ impl LeiosStore {
         }
     }
 
-    /// Get notifications after the given index (exclusive).
-    /// Index 0 means "from the beginning".
-    pub fn notifications_after(&self, after: usize) -> Vec<LeiosNotification> {
+    /// Get notifications after the given logical index (exclusive).
+    ///
+    /// The cursor `after` is monotonically increasing across the
+    /// connection's lifetime — never reset, never shifted by pruning.
+    /// If the caller's cursor has fallen behind the prune frontier,
+    /// it's bumped up to the frontier so subsequent `*after += 1`
+    /// increments stay aligned with the logical position of items the
+    /// caller actually consumes.  Index `0` still means "from the
+    /// earliest still-retained notification".
+    pub fn notifications_after(&self, after: &mut usize) -> Vec<LeiosNotification> {
         let inner = self.inner.lock().unwrap();
-        if after >= inner.notifications.len() {
+        if *after < inner.notifications_pruned_count {
+            *after = inner.notifications_pruned_count;
+        }
+        let local = *after - inner.notifications_pruned_count;
+        if local >= inner.notifications.len() {
             return Vec::new();
         }
-        inner.notifications[after..].to_vec()
+        inner.notifications.range(local..).cloned().collect()
     }
 
-    /// Get the total number of notifications so far.
+    /// Total notifications ever pushed (including those since pruned).
     pub fn notification_count(&self) -> usize {
-        self.inner.lock().unwrap().notifications.len()
+        let inner = self.inner.lock().unwrap();
+        inner.notifications_pruned_count + inner.notifications.len()
     }
 
     /// Subscribe to change notifications.
@@ -369,6 +391,22 @@ impl LeiosStore {
             inner.block_txs.retain(|key, _| key.slot >= cutoff);
             inner.eb_tx_hashes.retain(|key, _| key.slot >= cutoff);
             inner.votes.retain(|(slot, _), _| *slot >= cutoff);
+            // Front-prune `notifications` for entries that reference
+            // only data older than the cutoff.  Notifications are
+            // pushed in arrival order, which roughly tracks slot
+            // order under normal operation — a non-evictable item at
+            // the front means later items are at least as recent, so
+            // stopping there is safe.  Worst case (out-of-order
+            // arrivals) leaks a small tail past the cutoff; the next
+            // bump catches it up.
+            while let Some(front) = inner.notifications.front() {
+                if notification_evictable(front, cutoff) {
+                    inner.notifications.pop_front();
+                    inner.notifications_pruned_count += 1;
+                } else {
+                    break;
+                }
+            }
         }
 
         // Capacity backstop on `blocks` (independent of slot window).
@@ -403,6 +441,22 @@ impl LeiosStore {
 
         let version = inner.version;
         let _ = self.notify.send(version);
+    }
+}
+
+/// True iff every slot the notification references is below `cutoff`
+/// — i.e. the notification only points at data that's already been
+/// evicted from the slot-window-pruned maps and can never be served.
+fn notification_evictable(n: &LeiosNotification, cutoff: u64) -> bool {
+    match n {
+        LeiosNotification::BlockOffer { point }
+        | LeiosNotification::BlockTxsOffer { point } => match point {
+            Point::Specific { slot, .. } => *slot < cutoff,
+            Point::Origin => true,
+        },
+        LeiosNotification::VotesOffer { votes } => {
+            !votes.is_empty() && votes.iter().all(|(s, _)| *s < cutoff)
+        }
     }
 }
 
@@ -601,7 +655,7 @@ mod tests {
 
         // One BlockTxsOffer notification, not two.
         let txs_offers = store
-            .notifications_after(0)
+            .notifications_after(&mut 0)
             .into_iter()
             .filter(|n| matches!(n, LeiosNotification::BlockTxsOffer { .. }))
             .count();
@@ -698,7 +752,7 @@ mod tests {
         store.inject_block(point, vec![0x01]);
         store.inject_votes(vec![(10, vec![0x02])], vec![vec![0x03]]);
 
-        let all = store.notifications_after(0);
+        let all = store.notifications_after(&mut 0);
         assert_eq!(all.len(), 2);
         assert!(matches!(
             all[0],
@@ -708,10 +762,10 @@ mod tests {
         ));
         assert!(matches!(all[1], LeiosNotification::VotesOffer { .. }));
 
-        let after_first = store.notifications_after(1);
+        let after_first = store.notifications_after(&mut 1);
         assert_eq!(after_first.len(), 1);
 
-        let after_all = store.notifications_after(2);
+        let after_all = store.notifications_after(&mut 2);
         assert!(after_all.is_empty());
     }
 
@@ -769,6 +823,56 @@ mod tests {
 
         // Recent entry stays.
         assert!(store.get_block(100, &[0x33; 32]).is_some());
+    }
+
+    #[test]
+    fn slot_retention_prunes_notifications() {
+        // Tight retention window so a few slot advances trigger eviction.
+        let (store, _rx) = LeiosStore::new_with_retention(1000, None, 5, 0);
+
+        // Three notifications at slot 1.
+        store.inject_block(
+            Point::Specific {
+                slot: 1,
+                hash: [0x11; 32],
+            },
+            vec![0xB0],
+        );
+        store.inject_block(
+            Point::Specific {
+                slot: 1,
+                hash: [0x12; 32],
+            },
+            vec![0xB1],
+        );
+        store.inject_votes(vec![(1, vec![0xAA])], vec![vec![0x01]]);
+        assert_eq!(store.notification_count(), 3);
+
+        // Inject a recent block to push max_slot past the retention
+        // window — cutoff = 100 - 5 = 95, all slot-1 notifications
+        // are now stale.
+        store.inject_block(
+            Point::Specific {
+                slot: 100,
+                hash: [0x33; 32],
+            },
+            vec![0xD0],
+        );
+
+        // The slot-1 notifications were front-pruned; only the
+        // slot-100 one remains.  The logical count still reflects
+        // every notification ever pushed.
+        assert_eq!(store.notification_count(), 4);
+        let mut cursor = 0;
+        let pending = store.notifications_after(&mut cursor);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(cursor, 3, "cursor advanced past the prune frontier");
+        assert!(matches!(
+            pending[0],
+            LeiosNotification::BlockOffer {
+                point: Point::Specific { slot: 100, .. }
+            }
+        ));
     }
 
     #[tokio::test]

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -231,6 +231,9 @@ impl LeiosStore {
     /// `ids` are `(slot, voter_id)` pairs; `data` are the corresponding
     /// opaque vote blobs (same length).
     pub fn inject_votes(&self, ids: Vec<(u64, Vec<u8>)>, data: Vec<Vec<u8>>) {
+        if ids.is_empty() {
+            return;
+        }
         let mut inner = self.inner.lock().unwrap();
         let max_in_batch = ids.iter().map(|(s, _)| *s).max().unwrap_or(0);
         for (id, blob) in ids.iter().zip(data.iter()) {
@@ -454,9 +457,7 @@ fn notification_evictable(n: &LeiosNotification, cutoff: u64) -> bool {
             Point::Specific { slot, .. } => *slot < cutoff,
             Point::Origin => true,
         },
-        LeiosNotification::VotesOffer { votes } => {
-            !votes.is_empty() && votes.iter().all(|(s, _)| *s < cutoff)
-        }
+        LeiosNotification::VotesOffer { votes } => votes.iter().all(|(s, _)| *s < cutoff),
     }
 }
 

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -655,14 +655,14 @@ fn log_event(node_id: &str, event: &NetworkEvent) {
         NetworkEvent::TransactionReceived { peer_id, body } => {
             // Accumulate received tx into local mempool for block inclusion.
             // (The tx was already received via TxSubmission from a peer.)
-            info!(node_id, %peer_id, bytes = body.len(), "transaction received");
+            tracing::debug!(node_id, %peer_id, bytes = body.len(), "transaction received");
         }
         NetworkEvent::PeersDiscovered { peers, .. } => {
             info!(node_id, count = peers.len(), "peers discovered");
         }
         NetworkEvent::PeerSnapshot { .. } => {} // handled by telemetry
         _ => {
-            info!(node_id, event = ?event, "network event");
+            tracing::debug!(node_id, event = ?event, "network event");
         }
     }
 }

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -698,7 +698,7 @@ impl MempoolState {
                 self.total_bytes -= old.size as usize;
                 let evicted_id = old.tx_id.clone();
                 self.prune_from_peer_sets(&evicted_id);
-                info!(
+                tracing::debug!(
                     evicted = ?hex_short(&evicted_id),
                     capacity = self.capacity,
                     "mempool: evicting oldest tx to make room"

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -131,6 +131,14 @@ pub struct MempoolState {
     /// TxSubmission server never re-announces the same tx to the same
     /// peer.
     pub peer_advertised: BTreeMap<PeerId, BTreeSet<TxId>>,
+    /// Per-peer "still owed to this peer" set — the inverse partition of
+    /// `peer_advertised` over the current mempool.  Lazily seeded on
+    /// the first peer-facing call (peek or mark), then maintained by
+    /// admit fan-out and pruned alongside `peer_advertised`.  Lets the
+    /// TxSubmission server return in `O(log P)` when the peer is
+    /// caught up, instead of scanning the entire mempool to find that
+    /// out.
+    pub peer_unannounced: BTreeMap<PeerId, BTreeSet<TxId>>,
     /// Bodies currently with the validator.  Cleared on
     /// `on_tx_validated` (body moves to `txs`) or
     /// `on_tx_validation_failed` (body dropped).
@@ -170,6 +178,7 @@ impl MempoolState {
             total_bytes: 0,
             capacity,
             peer_advertised: BTreeMap::new(),
+            peer_unannounced: BTreeMap::new(),
             pending_validation: BTreeMap::new(),
             eb_manifests: BTreeMap::new(),
             eb_pinned: BTreeMap::new(),
@@ -316,6 +325,7 @@ impl MempoolState {
     /// Drop per-peer advertised state on disconnect.
     pub fn forget_peer(&mut self, peer_id: PeerId) {
         self.peer_advertised.remove(&peer_id);
+        self.peer_unannounced.remove(&peer_id);
     }
 
     // -- Pure queries ------------------------------------------------------
@@ -350,24 +360,53 @@ impl MempoolState {
     }
 
     /// Return up to `max_count` txs not yet advertised to `peer_id`,
-    /// recording them so subsequent calls skip them.  The per-peer
-    /// advertised set is pruned automatically when txs leave the
-    /// mempool.  Hot path under TxSubmission pull traffic; the
-    /// `contains` check before the clone-and-insert avoids the heap
-    /// allocation for tx ids the peer already has.
+    /// moving each one from the per-peer "owed" set into the per-peer
+    /// "advertised" set so subsequent calls skip them.  Hot path under
+    /// TxSubmission pull traffic — when the peer is caught up the
+    /// per-peer owed set is empty and the call returns in `O(log P)`
+    /// (the BTreeMap lookup) without touching `self.txs`.
     pub fn peek_unannounced_for_peer(
         &mut self,
         peer_id: PeerId,
         max_count: usize,
     ) -> Vec<PendingTx> {
-        let mut result = Vec::with_capacity(max_count);
+        self.ensure_peer_registered(peer_id);
+        let unann = self
+            .peer_unannounced
+            .get_mut(&peer_id)
+            .expect("ensure_peer_registered");
+        if unann.is_empty() || max_count == 0 {
+            return Vec::new();
+        }
+        let to_send: Vec<TxId> = unann.iter().take(max_count).cloned().collect();
+        for id in &to_send {
+            unann.remove(id);
+        }
         let advertised = self.peer_advertised.entry(peer_id).or_default();
+        for id in &to_send {
+            advertised.insert(id.clone());
+        }
+        // Resolve bodies.  One scan over the free pool collects every
+        // id present there; eb-pinned bodies fill in for ids that have
+        // already drained out of `txs` into an EB closure.  The scan
+        // only runs when the owed set was non-empty — under steady
+        // TxSubmission traffic with a caught-up peer this branch
+        // doesn't execute at all.
+        let wanted: BTreeSet<&TxId> = to_send.iter().collect();
+        let mut result = Vec::with_capacity(to_send.len());
         for tx in &self.txs {
-            if result.len() >= max_count {
-                break;
+            if wanted.contains(&tx.tx_id) {
+                result.push(tx.clone());
+                if result.len() == to_send.len() {
+                    return result;
+                }
             }
-            if !advertised.contains(&tx.tx_id) {
-                advertised.insert(tx.tx_id.clone());
+        }
+        for id in &to_send {
+            if result.iter().any(|tx| &tx.tx_id == id) {
+                continue;
+            }
+            if let Some(tx) = self.eb_pinned.get(id) {
                 result.push(tx.clone());
             }
         }
@@ -375,15 +414,24 @@ impl MempoolState {
     }
 
     /// Mark `tx_id` as advertised to `peer_id`.  Returns `true` iff the
-    /// entry was newly inserted (the caller still needs to send the tx
-    /// body to that peer).  Used by the admit-fanout path to announce
-    /// a single just-admitted tx to every connected peer in O(log N)
-    /// per peer.
+    /// peer hadn't previously been told about `tx_id` (the caller still
+    /// needs to send the tx body to that peer).  Used by the
+    /// admit-fan-out path to announce a single just-admitted tx to
+    /// every connected peer in `O(log N)` per peer.
     pub fn mark_announced_to_peer(&mut self, peer_id: PeerId, tx_id: &TxId) -> bool {
-        self.peer_advertised
-            .entry(peer_id)
-            .or_default()
-            .insert(tx_id.clone())
+        self.ensure_peer_registered(peer_id);
+        let was_owed = self
+            .peer_unannounced
+            .get_mut(&peer_id)
+            .expect("ensure_peer_registered")
+            .remove(tx_id);
+        if was_owed {
+            self.peer_advertised
+                .entry(peer_id)
+                .or_default()
+                .insert(tx_id.clone());
+        }
+        was_owed
     }
 
     /// Drain txs from the front of the queue up to `max_bytes`.  At
@@ -449,6 +497,14 @@ impl MempoolState {
             .map(|s| s.len())
             .max()
             .unwrap_or(0);
+        let peer_unannounced_total: usize =
+            self.peer_unannounced.values().map(|s| s.len()).sum();
+        let peer_unannounced_max: usize = self
+            .peer_unannounced
+            .values()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
         let eb_manifest_entries_total: usize =
             self.eb_manifests.values().map(|v| v.len()).sum();
         info!(
@@ -459,6 +515,9 @@ impl MempoolState {
             peer_advertised = self.peer_advertised.len(),
             peer_advertised_total,
             peer_advertised_max,
+            peer_unannounced = self.peer_unannounced.len(),
+            peer_unannounced_total,
+            peer_unannounced_max,
             pending_validation = self.pending_validation.len(),
             eb_manifests = self.eb_manifests.len(),
             eb_manifest_entries_total,
@@ -652,6 +711,11 @@ impl MempoolState {
         }
         self.total_bytes += size as usize;
         self.tx_index.insert(tx_id.clone());
+        // Fan the new id out into every known peer's "owed" set so the
+        // next TxSubmission peek returns it without rescanning `txs`.
+        for set in self.peer_unannounced.values_mut() {
+            set.insert(tx_id.clone());
+        }
         self.txs.push_back(PendingTx {
             tx_id,
             body,
@@ -663,6 +727,20 @@ impl MempoolState {
     fn prune_from_peer_sets(&mut self, tx_id: &TxId) {
         for set in self.peer_advertised.values_mut() {
             set.remove(tx_id);
+        }
+        for set in self.peer_unannounced.values_mut() {
+            set.remove(tx_id);
+        }
+    }
+
+    /// Seed the "owed" set for `peer_id` from the current mempool the
+    /// first time the peer surfaces — the catch-up backlog any new
+    /// connection inherits.  Cheap re-call: skips the clone once an
+    /// entry exists.
+    fn ensure_peer_registered(&mut self, peer_id: PeerId) {
+        if !self.peer_unannounced.contains_key(&peer_id) {
+            self.peer_unannounced
+                .insert(peer_id, self.tx_index.clone());
         }
     }
 }


### PR DESCRIPTION
## Summary

Five commits on the net-rs network stack that together fix the CPU-runaway/memory-growth seen under sustained cluster load, and correctly layer protocol size enforcement:

- **shared-consensus** — O(log P) idle peek via per-peer "unannounced" set (replaces the O(N · log A · 32) mempool scan that was eating ~75% CPU under load).
- **net-core** — BlockFetch demuxer-buffer / per-message-size split.  First attempt (`e27fdf991`) widened `BlockFetch::size_limit` to `INGRESS_LIMIT`, justified by a misread of what was actually filling the buffer.  Final commit reverts to spec values and wires per-state caps at codec decode time.
- **net-core** — front-prune the LeiosStore notification queue alongside slot-window eviction, so the deque doesn't grow unboundedly.
- **net-node / shared-consensus** — demote per-tx / per-event INFO log lines to `debug!`; the overnight cluster filled the disk and locked up purely on log volume.

## Size enforcement (final commit)

Two distinct guards now correctly layered:

1. **Demuxer buffer cap** — `ProtocolConfig::ingress_limit`, fixed at registration to bound runaway accumulation.  Each protocol declares its own `INGRESS_LIMIT` (e.g. `230_686_940` for BlockFetch).
2. **Codec per-message cap** — `Runner::recv` passes `P::size_limit(state)` to `CodecRecv::recv`, which checks `consumed > max_msg_size` post-decode and returns `MuxError::MessageTooLarge` for spec-violating peers.

The previous design overrode (1) with (2) on every state transition, which raced against pipelined responses that legitimately arrive ahead of the local state machine.

## Test plan

- [x] `cargo test` — 323 net-core unit tests + 118 net-node tests pass.
- [x] `cargo clippy --all-targets` — clean (one pre-existing unrelated warning).
- [x] 25-node release-build cluster smoke test with UI: all nodes alive, blocks producing, no warnings/errors.
- [ ] Long-run cluster (e.g. overnight) to confirm CPU stays flat and memory plateaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)