### PR TITLE
ci: publish piranha-relay Docker image to GHCR

### DIFF
--- a/.github/workflows/net-node-docker.yaml
+++ b/.github/workflows/net-node-docker.yaml
@@ -1,6 +1,14 @@
 name: "net-node-docker"
 
 on:
+  pull_request:
+    paths:
+      - "net-rs/docker/**"
+      - "net-rs/net-core/**"
+      - "net-rs/net-node/**"
+      - "net-rs/Cargo.lock"
+      - "shared-rs/**"
+      - ".github/workflows/net-node-docker.yaml"
   push:
     branches:
       - main
@@ -36,10 +44,12 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # QEMU emulates linux/arm64 on the linux/amd64 runner so a single
-      # job can produce a multi-arch manifest. Adds ~10–15 min to the
+      # job can produce a multi-arch manifest. Adds ~10-15 min to the
       # build; if that becomes painful, split into a matrix job per
-      # platform and merge manifests at the end.
+      # platform and merge manifests at the end. Skipped on PRs, which
+      # build amd64-only for fast Dockerfile + workflow validation.
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3 # TODO: SHA-pin once a release SHA is verified.
 
       - name: Set up Docker Buildx
@@ -61,6 +71,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
+            type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
@@ -68,7 +79,7 @@ jobs:
         with:
           context: .
           file: ./net-rs/docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name == 'push' || github.event.inputs.push_image == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/net-node-docker.yaml
+++ b/.github/workflows/net-node-docker.yaml
@@ -1,0 +1,76 @@
+name: "net-node-docker"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "net-rs/docker/**"
+      - "net-rs/net-core/**"
+      - "net-rs/net-node/**"
+      - "net-rs/Cargo.lock"
+      - "shared-rs/**"
+      - ".github/workflows/net-node-docker.yaml"
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to GHCR'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}/leios-net-node
+
+jobs:
+  build:
+    name: "Build and publish leios-net-node"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # QEMU emulates linux/arm64 on the linux/amd64 runner so a single
+      # job can produce a multi-arch manifest. Adds ~10–15 min to the
+      # build; if that becomes painful, split into a matrix job per
+      # platform and merge manifests at the end.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3 # TODO: SHA-pin once a release SHA is verified.
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Container Registry
+        if: github.event_name == 'push' || github.event.inputs.push_image == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: .
+          file: ./net-rs/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' || github.event.inputs.push_image == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=leios-net-node
+          cache-to: type=gha,mode=max,scope=leios-net-node

--- a/.github/workflows/net-node-docker.yaml
+++ b/.github/workflows/net-node-docker.yaml
@@ -21,11 +21,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ${{ github.repository }}/leios-net-node
+  IMAGE: ${{ github.repository }}/piranha-relay
 
 jobs:
   build:
-    name: "Build and publish leios-net-node"
+    name: "Build and publish piranha-relay"
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -72,5 +72,5 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event.inputs.push_image == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=leios-net-node
-          cache-to: type=gha,mode=max,scope=leios-net-node
+          cache-from: type=gha,scope=piranha-relay
+          cache-to: type=gha,mode=max,scope=piranha-relay

--- a/net-rs/README.md
+++ b/net-rs/README.md
@@ -162,7 +162,7 @@ cargo clippy           # lint
 cargo fmt --check      # format check
 ```
 
-A Docker image is also available — see [`docker/README.md`](docker/README.md) for the build and run contract (`leios-net-node`, single passive relay, env-driven peers and listen port).
+A Docker image is also available — see [`docker/README.md`](docker/README.md) for the build and run contract (`piranha-relay`, single passive relay, env-driven peers and listen port).
 
 ## CLI Usage
 

--- a/net-rs/docker/Dockerfile
+++ b/net-rs/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 #
 # Build: from the repo root,
-#   docker build -f net-rs/docker/Dockerfile -t leios-net-node .
+#   docker build -f net-rs/docker/Dockerfile -t piranha-relay .
 #
 # Build context must be the repo root because net-node depends on a
 # sibling path crate at shared-rs/consensus.

--- a/net-rs/docker/README.md
+++ b/net-rs/docker/README.md
@@ -1,4 +1,4 @@
-# leios-net-node Docker image
+# piranha-relay Docker image
 
 Single-relay Docker image for `net-node`. Runs as a passive Leios participant: `stake = 0` and `tx_rate = 0.0`, so the node diffuses EBs, votes and EB-tx bodies for its peers without producing any blocks or transactions itself.
 
@@ -7,7 +7,7 @@ Single-relay Docker image for `net-node`. Runs as a passive Leios participant: `
 From the **repository root** (not from `net-rs/`):
 
 ```sh
-docker build -f net-rs/docker/Dockerfile -t leios-net-node .
+docker build -f net-rs/docker/Dockerfile -t piranha-relay .
 ```
 
 The build context must be the repo root because `net-node` depends on the sibling path crate at `shared-rs/consensus`. A per-Dockerfile `Dockerfile.dockerignore` next to the Dockerfile keeps the context to ~1.6 MB by allow-listing only `net-rs/` and `shared-rs/`. Requires BuildKit (signalled by `# syntax=docker/dockerfile:1.7` at the top of the Dockerfile); on Ubuntu, `sudo apt install docker-buildx` if `docker buildx version` reports the plugin missing.
@@ -39,11 +39,11 @@ Standalone relay, two outbound peers:
 
 ```sh
 docker run --rm \
-  --name leios-relay \
+  --name piranha-relay \
   -p 3001:3001 \
   -e NET_NODE_ID=relay-eu-1 \
   -e NET_NODE_PEERS="relay-a.example:3001,relay-b.example:3001" \
-  leios-net-node
+  piranha-relay
 ```
 
 With a user TOML overlay (e.g. to override telemetry sinks or enable production):
@@ -55,7 +55,7 @@ docker run --rm \
   -e NET_NODE_CONFIG=/etc/leios/user.toml \
   -e NET_NODE_ID=relay-eu-1 \
   -e NET_NODE_PEERS="relay-a.example:3001" \
-  leios-net-node
+  piranha-relay
 ```
 
 Non-default port:
@@ -65,7 +65,7 @@ docker run --rm \
   -p 4001:4001 \
   -e NET_NODE_LISTEN_PORT=4001 \
   -e NET_NODE_PEERS="relay-a.example:3001" \
-  leios-net-node
+  piranha-relay
 ```
 
 ### Container details

--- a/net-rs/docker/relay.toml
+++ b/net-rs/docker/relay.toml
@@ -1,4 +1,4 @@
-# Relay defaults for the leios-net-node Docker image.
+# Relay defaults for the piranha-relay Docker image.
 #
 # Passive Leios participant: no block production, no tx generation,
 # Leios protocols enabled so the node can diffuse EBs, votes and


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/net-node-docker.yaml` builds `net-rs/docker/Dockerfile` and publishes the resulting image to `ghcr.io/${{ github.repository }}/piranha-relay`. Modelled on `antithesis-leios.yaml`.
- **Trigger matrix:**
  - `pull_request` (path-filtered): build only, `linux/amd64`, QEMU skipped — fast Dockerfile + workflow smoke test (~5 min).
  - `push` to `main` (path-filtered): build + push, `linux/amd64` + `linux/arm64` via QEMU — the multi-arch publish path.
  - `workflow_dispatch` with optional `push_image` flag: re-publish or re-run manually after the workflow is live on main.
- Image name `piranha-relay` aligns with the Piranha Cluster branding already used by net-ui; renamed mechanically across Dockerfile, entrypoint, relay.toml, and the docker README.
- Auth via `secrets.GITHUB_TOKEN` + `permissions: packages: write`, same pattern as `antithesis-leios.yaml`.
- Action SHAs pinned to match `antithesis-leios.yaml` where the actions overlap. `docker/setup-qemu-action` left at `@v3` with a `TODO` to pin once a release SHA is verified.

## Test plan

- [ ] PR run (this PR) builds amd64-only on `pull_request` and goes green.
- [ ] After merge, first push-to-main run produces a multi-arch manifest at `ghcr.io/input-output-hk/ouroboros-leios/piranha-relay` with tags `latest`, `main`, and short-SHA.
- [ ] First publish: the GHCR package will land as private (repo default); flip visibility manually from Settings → Packages if public access is desired.
- [ ] `workflow_dispatch` appears in the Actions UI after the file is on main and can be re-run on demand (`push_image=true` to actually publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)