### PR TITLE
net-rs: Add handling of yaml topologies to net-rs

### DIFF
--- a/net-rs/README.md
+++ b/net-rs/README.md
@@ -39,8 +39,14 @@ Rust implementation of the Cardano node-to-node (N2N) network stack, covering bo
 - Fork-aware chain tree for tracking and visualizing competing branches
 
 **Cluster orchestrator** — spawn and manage multi-node test networks:
-- Auto-generated random topology with configurable degree and edge delays
-- Stake distribution (equal, weighted, or zipf)
+- Two topology sources under `[topology_source]`: `type = "random"`
+  (random connected graph with configurable degree and edge delays) or
+  `type = "yaml"` (load a `data/simulation/pseudo-mainnet/topology-v*.yaml`
+  file — same schema as `sim-rs` and `topology-checker`).  Mode-specific
+  fields live inside the variant, so writing a random-mode knob under
+  `type = "yaml"` is a parse-time error.
+- Stake distribution: `"equal"` or `"mainnet-shaped"` (random mode) /
+  YAML's per-node `stake` field (YAML mode)
 - HTTP telemetry aggregation from all nodes
 - Time-ordered event merge with watermark flushing to JSONL
 - Per-node log capture

--- a/net-rs/README.md
+++ b/net-rs/README.md
@@ -39,12 +39,12 @@ Rust implementation of the Cardano node-to-node (N2N) network stack, covering bo
 - Fork-aware chain tree for tracking and visualizing competing branches
 
 **Cluster orchestrator** — spawn and manage multi-node test networks:
-- Two topology sources under `[topology_source]`: `type = "random"`
-  (random connected graph with configurable degree and edge delays) or
-  `type = "yaml"` (load a `data/simulation/pseudo-mainnet/topology-v*.yaml`
-  file — same schema as `sim-rs` and `topology-checker`).  Mode-specific
-  fields live inside the variant, so writing a random-mode knob under
-  `type = "yaml"` is a parse-time error.
+- Two topology modes, selected by `topology_source = "random" | "yaml"`:
+  `"random"` reads `[topology_random]` (random connected graph with
+  configurable degree and edge delays); `"yaml"` reads `[topology_yaml]`
+  (load a `data/simulation/pseudo-mainnet/topology-v*.yaml` file — same
+  schema as `sim-rs` and `topology-checker`).  Only the selected mode's
+  section is read, and each section rejects unknown keys at parse time.
 - Stake distribution: `"equal"` or `"mainnet-shaped"` (random mode) /
   YAML's per-node `stake` field (YAML mode)
 - HTTP telemetry aggregation from all nodes

--- a/net-rs/net-cluster/Cargo.toml
+++ b/net-rs/net-cluster/Cargo.toml
@@ -13,8 +13,10 @@ clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", features = ["toml"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 toml = "0.8"
 rand = "0.8"
+indexmap = { version = "2", features = ["serde"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/net-rs/net-cluster/README.md
+++ b/net-rs/net-cluster/README.md
@@ -111,8 +111,8 @@ RUST_LOG=info cargo run -p net-cluster --release -- \
 ```
 
 **Sizing:** `node_limit` controls memory + CPU footprint linearly.
-v4-mainnet has 2,685 nodes and average degree ~35 — running the full
-graph as a process-per-node cluster will saturate any workstation.
+v4-mainnet has 2,685 nodes with a dense peer graph — running it in
+full as a process-per-node cluster will saturate any workstation.
 Rule of thumb on a stock laptop: ~50 nodes on 16 GB RAM, ~250 on 48 GB.
 
 `node_limit = 0` is rejected at startup (an empty cluster would boot
@@ -125,7 +125,7 @@ Key fields in the cluster TOML config:
 
 | Field | Description |
 |-------|-------------|
-| `[topology_source]` | Required topology selector.  `type = "random"` takes `num_nodes`, `degree`, `min_latency_ms`, `max_latency_ms`, `stake_distribution` (`"equal"` or `"mainnet-shaped"`). `type = "yaml"` takes `path` and optional `node_limit` (cap to top-N by stake). The schema rejects fields from the wrong variant at parse time. |
+| `[topology_source]` | Optional topology selector.  `type = "random"` takes `num_nodes`, `degree`, `min_latency_ms`, `max_latency_ms`, `stake_distribution` (`"equal"` or `"mainnet-shaped"`). `type = "yaml"` takes `path` and optional `node_limit` (cap to top-N by stake). The schema rejects fields from the wrong variant at parse time. |
 | `base_config` | Path to shared net-node base config |
 | `base_port` | Starting port for node allocation |
 | `seed` | RNG seed for reproducible topologies |

--- a/net-rs/net-cluster/README.md
+++ b/net-rs/net-cluster/README.md
@@ -4,14 +4,16 @@ Cluster orchestrator that spawns multiple `net-node` instances with auto-generat
 
 ## Features
 
-- Two topology sources: **random graph** (`[topology_source] type =
-  "random"` with `num_nodes` / `degree` / `min_latency_ms` /
-  `max_latency_ms` / `stake_distribution` inside the same table) or
-  **YAML** (`type = "yaml"` with `path` + optional `node_limit`, loading
+- Two topology modes, selected by the scalar `topology_source =
+  "random" | "yaml"`: **random graph** (`[topology_random]` with
+  `num_nodes` / `degree` / `min_latency_ms` / `max_latency_ms` /
+  `stake_distribution`) or **YAML** (`[topology_yaml]` with `path` +
+  optional `node_limit`, loading
   `data/simulation/pseudo-mainnet/topology-v*.yaml` — same schema as
   `sim-rs` and `topology-checker`)
-- Schema-level mode separation: random-mode fields under `type = "yaml"`
-  (or vice versa) are rejected at parse time, not silently ignored
+- Each section uses `deny_unknown_fields`, so a typo or stray key inside
+  a section is rejected at parse time; only the section matching the
+  selected mode is read, so an unused populated section is ignored
 - Stake distribution: `"equal"` or `"mainnet-shaped"` (random mode) —
   taken directly from the YAML's `stake` field (YAML mode)
 - Per-node TOML overlay generation (ports, peers, delays, stake)
@@ -50,11 +52,11 @@ RUST_LOG=info cargo run -p net-cluster -- \
   --net-node-bin target/debug/net-node
 
 # Override settings (note dotted-key form — random-mode knobs live
-# under `[topology_source]`):
+# under `[topology_random]`):
 cargo run -p net-cluster -- \
   --config net-cluster/configs/sample-cluster.toml \
   --net-node-bin target/debug/net-node \
-  --set topology_source.num_nodes=10 --set topology_source.degree=3
+  --set topology_random.num_nodes=10 --set topology_random.degree=3
 
 # Ctrl-C to stop. Check merged event output:
 cat cluster-events.jsonl | python3 -m json.tool --no-ensure-ascii | head
@@ -78,13 +80,13 @@ Mapping from YAML → cluster:
 | `nodes[].region`, `.cpu-core-count`, etc. | Ignored — net-core has no notion of geography or CPU caps |
 
 `num_nodes`/`degree`/`min_latency_ms`/`max_latency_ms`/
-`stake_distribution` are the random-mode knobs and only exist inside
-`[topology_source]` when `type = "random"`.  Writing them under
-`type = "yaml"` is a **parse-time error** — the schema enforces the
-split rather than silently ignoring leftover fields.  In YAML mode node
-count comes from the YAML (optionally capped by `node_limit`), edges
-and per-link latencies come from the YAML's `producers` arrays, and
-per-node stake comes from the YAML's `stake` field.
+`stake_distribution` are the random-mode knobs and live in
+`[topology_random]`.  With `topology_source = "yaml"` only
+`[topology_yaml]` is read, so any `[topology_random]` section is
+ignored.  In YAML mode node count comes from the YAML (optionally
+capped by `node_limit`), edges and per-link latencies come from the
+YAML's `producers` arrays, and per-node stake comes from the YAML's
+`stake` field.
 
 ```toml
 # net-cluster/configs/sample-cluster-v4-mini.toml
@@ -97,8 +99,9 @@ stats_interval_secs = 2
 rb_generation_probability = 0.05     # mainnet Praos f_block
 tx_rate = 1.0
 
-[topology_source]
-type = "yaml"
+topology_source = "yaml"
+
+[topology_yaml]
 path = "../data/simulation/pseudo-mainnet/topology-v4-mainnet.yaml"
 node_limit = 25                      # first-N in YAML = top-N by stake in v4
 ```
@@ -125,7 +128,9 @@ Key fields in the cluster TOML config:
 
 | Field | Description |
 |-------|-------------|
-| `[topology_source]` | Optional topology selector.  `type = "random"` takes `num_nodes`, `degree`, `min_latency_ms`, `max_latency_ms`, `stake_distribution` (`"equal"` or `"mainnet-shaped"`). `type = "yaml"` takes `path` and optional `node_limit` (cap to top-N by stake). The schema rejects fields from the wrong variant at parse time. |
+| `topology_source` | Topology mode: `"random"` (default) or `"yaml"`. Selects which section below is read. |
+| `[topology_random]` | Random-mode params: `num_nodes`, `degree`, `min_latency_ms`, `max_latency_ms`, `stake_distribution` (`"equal"` or `"mainnet-shaped"`). Unknown keys are rejected at parse time. |
+| `[topology_yaml]` | YAML-mode params: `path` and optional `node_limit` (cap to top-N by stake). Unknown keys are rejected at parse time. |
 | `base_config` | Path to shared net-node base config |
 | `base_port` | Starting port for node allocation |
 | `seed` | RNG seed for reproducible topologies |

--- a/net-rs/net-cluster/README.md
+++ b/net-rs/net-cluster/README.md
@@ -4,8 +4,16 @@ Cluster orchestrator that spawns multiple `net-node` instances with auto-generat
 
 ## Features
 
-- Random graph topology generation with configurable degree and edge delays
-- Stake distribution: equal, weighted, or zipf
+- Two topology sources: **random graph** (`[topology_source] type =
+  "random"` with `num_nodes` / `degree` / `min_latency_ms` /
+  `max_latency_ms` / `stake_distribution` inside the same table) or
+  **YAML** (`type = "yaml"` with `path` + optional `node_limit`, loading
+  `data/simulation/pseudo-mainnet/topology-v*.yaml` — same schema as
+  `sim-rs` and `topology-checker`)
+- Schema-level mode separation: random-mode fields under `type = "yaml"`
+  (or vice versa) are rejected at parse time, not silently ignored
+- Stake distribution: `"equal"` or `"mainnet-shaped"` (random mode) —
+  taken directly from the YAML's `stake` field (YAML mode)
 - Per-node TOML overlay generation (ports, peers, delays, stake)
 - Child process management with graceful shutdown
 - HTTP telemetry server (POST /events, POST /stats)
@@ -24,25 +32,29 @@ src/
 ├── process.rs    # Child process spawning, shutdown, log piping
 ├── server.rs     # axum HTTP server: POST /events, POST /stats
 ├── aggregator.rs # Time-ordered event merge, watermark flushing, JSONL output
+├── raw_topology.rs # YAML topology parser (v3/v4 schema)
 └── types.rs      # StatsSnapshot (Deserialize), IngestedEvent, event parsing
 ```
 
 ## Usage
 
+### Random topology (default)
+
 ```sh
 # Build the net-node binary first (net-cluster spawns it as child processes):
 cargo build -p net-node
 
-# Run a 5-node cluster with sample config:
+# Run a 25-node cluster with sample config:
 RUST_LOG=info cargo run -p net-cluster -- \
   --config net-cluster/configs/sample-cluster.toml \
   --net-node-bin target/debug/net-node
 
-# Override settings:
+# Override settings (note dotted-key form — random-mode knobs live
+# under `[topology_source]`):
 cargo run -p net-cluster -- \
   --config net-cluster/configs/sample-cluster.toml \
   --net-node-bin target/debug/net-node \
-  --set num_nodes=10 --set degree=3
+  --set topology_source.num_nodes=10 --set topology_source.degree=3
 
 # Ctrl-C to stop. Check merged event output:
 cat cluster-events.jsonl | python3 -m json.tool --no-ensure-ascii | head
@@ -50,23 +62,81 @@ cat cluster-events.jsonl | python3 -m json.tool --no-ensure-ascii | head
 # Node logs are in logs/node-{i}.log
 ```
 
+### YAML topology (mainnet-faithful)
+
+Drive the cluster from a pre-built [`topology-v*.yaml`](../../data/simulation/pseudo-mainnet/)
+file instead of generating a random graph. Same schema as `sim-rs` and
+`topology-checker`, so the same files work across all three tools.
+
+Mapping from YAML → cluster:
+
+| YAML field | Cluster effect |
+|------------|----------------|
+| `nodes[].stake` | Node's stake (drives VRF block-production lottery) |
+| `nodes[].producers[].latency-ms` | Per-link simulated delay (clamped to ≥0, rounded to whole ms) |
+| `nodes[].producers[].bandwidth-bytes-per-second` | Parsed but currently ignored (no per-peer shaping yet) |
+| `nodes[].region`, `.cpu-core-count`, etc. | Ignored — net-core has no notion of geography or CPU caps |
+
+`num_nodes`/`degree`/`min_latency_ms`/`max_latency_ms`/
+`stake_distribution` are the random-mode knobs and only exist inside
+`[topology_source]` when `type = "random"`.  Writing them under
+`type = "yaml"` is a **parse-time error** — the schema enforces the
+split rather than silently ignoring leftover fields.  In YAML mode node
+count comes from the YAML (optionally capped by `node_limit`), edges
+and per-link latencies come from the YAML's `producers` arrays, and
+per-node stake comes from the YAML's `stake` field.
+
+```toml
+# net-cluster/configs/sample-cluster-v4-mini.toml
+base_config = "net-node/configs/mainnet.toml"
+base_port = 30000
+seed = 42
+output_events = "cluster-v4-events.jsonl"
+aggregator_port = 9100
+stats_interval_secs = 2
+rb_generation_probability = 0.05     # mainnet Praos f_block
+tx_rate = 1.0
+
+[topology_source]
+type = "yaml"
+path = "../data/simulation/pseudo-mainnet/topology-v4-mainnet.yaml"
+node_limit = 25                      # first-N in YAML = top-N by stake in v4
+```
+
+```sh
+cargo build -p net-node --release
+RUST_LOG=info cargo run -p net-cluster --release -- \
+  --config net-cluster/configs/sample-cluster-v4-mini.toml \
+  --net-node-bin target/release/net-node
+```
+
+**Sizing:** `node_limit` controls memory + CPU footprint linearly.
+v4-mainnet has 2,685 nodes and average degree ~35 — running the full
+graph as a process-per-node cluster will saturate any workstation.
+Rule of thumb on a stock laptop: ~50 nodes on 16 GB RAM, ~250 on 48 GB.
+
+`node_limit = 0` is rejected at startup (an empty cluster would boot
+and idle silently); omit the field to load every node from the YAML,
+or set a positive integer to cap at top-N by stake.
+
 ## Config
 
 Key fields in the cluster TOML config:
 
 | Field | Description |
 |-------|-------------|
-| `num_nodes` | Number of nodes to spawn |
-| `degree` | Peers per node in the random graph |
-| `min_latency_ms` / `max_latency_ms` | Random edge delay range |
+| `[topology_source]` | Required topology selector.  `type = "random"` takes `num_nodes`, `degree`, `min_latency_ms`, `max_latency_ms`, `stake_distribution` (`"equal"` or `"mainnet-shaped"`). `type = "yaml"` takes `path` and optional `node_limit` (cap to top-N by stake). The schema rejects fields from the wrong variant at parse time. |
 | `base_config` | Path to shared net-node base config |
 | `base_port` | Starting port for node allocation |
 | `seed` | RNG seed for reproducible topologies |
 | `output_events` | Path for merged JSONL output |
 | `ordering_window_secs` | Watermark window for time-ordered merge |
 | `aggregator_port` | HTTP port for telemetry collection |
-| `stake_distribution` | `"equal"`, `"weighted"`, or `"zipf"` |
 | `stats_interval_secs` | Periodic stats reporting interval |
+| `rb_generation_probability` | Per-slot RB lottery rate override (applied to every node) |
+| `tx_rate` | Per-node Poisson transaction generation rate (tx/s) |
+| `behaviour` / `behaviour_selection` | Optional adversarial behaviour + which nodes run it |
 | `external_peers` | Additional peers outside the cluster |
 
-See `configs/sample-cluster.toml` for a complete example.
+See `configs/sample-cluster.toml` for a random-mode example and
+`configs/sample-cluster-v4-mini.toml` for a YAML-mode example.

--- a/net-rs/net-cluster/configs/cluster-100n-d10-NA0.200.toml
+++ b/net-rs/net-cluster/configs/cluster-100n-d10-NA0.200.toml
@@ -16,11 +16,6 @@
 #     --node-set fetch_policy.eb_txs.kind=broadcast \
 #     --node-set fetch_policy.eb_txs.n=3
 
-num_nodes = 100
-degree = 10
-min_latency_ms = 5
-max_latency_ms = 250
-
 base_config = "net-node/configs/mainnet.toml"
 
 # Avoid colliding with any other cluster on the same machine.
@@ -33,7 +28,14 @@ output_events = "cluster-events.jsonl"
 ordering_window_secs = 1.0
 aggregator_port = 9100
 stats_interval_secs = 1
-stake_distribution = "equal"
 
 # Match the baseline RB lottery cadence.
 rb_generation_probability = 0.05
+
+[topology_source]
+type = "random"
+num_nodes = 100
+degree = 10
+min_latency_ms = 5
+max_latency_ms = 250
+stake_distribution = "equal"

--- a/net-rs/net-cluster/configs/cluster-100n-d10-NA0.200.toml
+++ b/net-rs/net-cluster/configs/cluster-100n-d10-NA0.200.toml
@@ -32,8 +32,9 @@ stats_interval_secs = 1
 # Match the baseline RB lottery cadence.
 rb_generation_probability = 0.05
 
-[topology_source]
-type = "random"
+topology_source = "random"
+
+[topology_random]
 num_nodes = 100
 degree = 10
 min_latency_ms = 5

--- a/net-rs/net-cluster/configs/sample-cluster-equivocator.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-equivocator.toml
@@ -23,8 +23,9 @@ aggregator_port = 9200
 stats_interval_secs = 1
 rb_generation_probability = 0.05
 
-[topology_source]
-type = "random"
+topology_source = "random"
+
+[topology_random]
 num_nodes = 10
 degree = 3
 min_latency_ms = 5

--- a/net-rs/net-cluster/configs/sample-cluster-equivocator.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-equivocator.toml
@@ -14,11 +14,6 @@
 # gossiped through the topology — flags the slot in
 # `equivocating_rb_slots` via `note_header_for_equivocation`.
 
-num_nodes = 10
-degree = 3
-min_latency_ms = 5
-max_latency_ms = 100
-
 base_config = "net-node/configs/mainnet.toml"
 base_port = 30200
 seed = 42
@@ -26,8 +21,15 @@ output_events = "cluster-events-equivocator.jsonl"
 ordering_window_secs = 1.0
 aggregator_port = 9200
 stats_interval_secs = 1
-stake_distribution = "equal"
 rb_generation_probability = 0.05
+
+[topology_source]
+type = "random"
+num_nodes = 10
+degree = 3
+min_latency_ms = 5
+max_latency_ms = 100
+stake_distribution = "equal"
 
 # Per-node adversarial behaviour: install RbHeaderEquivocator on node 3.
 # Swap the selection variant for a different placement strategy —

--- a/net-rs/net-cluster/configs/sample-cluster-lazy-voter.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-lazy-voter.toml
@@ -18,11 +18,6 @@
 # (7 ≥ 6); raise `fraction` to 0.34 or above to push 4+ pools lazy
 # and force quorum failure.
 
-num_nodes = 30
-degree = 3
-min_latency_ms = 5
-max_latency_ms = 100
-
 base_config = "net-node/configs/mainnet.toml"
 base_port = 30300
 seed = 42
@@ -30,7 +25,6 @@ output_events = "cluster-events-lazy-voter.jsonl"
 ordering_window_secs = 1.0
 aggregator_port = 9300
 stats_interval_secs = 1
-stake_distribution = "mainnet-shaped"
 rb_generation_probability = 0.05
 
 # Drive the mempool from each node at 1 tx/s so RBs overflow into EBs
@@ -40,6 +34,14 @@ rb_generation_probability = 0.05
 # hub-spoke EB-tx fetch hard enough that MissingTX dominates the
 # no-vote signal and masks the lazy-stake effect.
 tx_rate = 1.0
+
+[topology_source]
+type = "random"
+num_nodes = 30
+degree = 3
+min_latency_ms = 5
+max_latency_ms = 100
+stake_distribution = "mainnet-shaped"
 
 [behaviour]
 kind = "lazy-voter"

--- a/net-rs/net-cluster/configs/sample-cluster-lazy-voter.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-lazy-voter.toml
@@ -35,8 +35,9 @@ rb_generation_probability = 0.05
 # no-vote signal and masks the lazy-stake effect.
 tx_rate = 1.0
 
-[topology_source]
-type = "random"
+topology_source = "random"
+
+[topology_random]
 num_nodes = 30
 degree = 3
 min_latency_ms = 5

--- a/net-rs/net-cluster/configs/sample-cluster-leios-baseline.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-leios-baseline.toml
@@ -19,8 +19,9 @@ stats_interval_secs = 1
 rb_generation_probability = 0.05
 tx_rate = 1.0
 
-[topology_source]
-type = "random"
+topology_source = "random"
+
+[topology_random]
 num_nodes = 30
 degree = 3
 min_latency_ms = 5

--- a/net-rs/net-cluster/configs/sample-cluster-leios-baseline.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-leios-baseline.toml
@@ -9,11 +9,6 @@
 # cluster reaches quorum on its own and to compute deltas when a
 # behaviour is enabled.
 
-num_nodes = 30
-degree = 3
-min_latency_ms = 5
-max_latency_ms = 100
-
 base_config = "net-node/configs/mainnet.toml"
 base_port = 30400
 seed = 42
@@ -21,6 +16,13 @@ output_events = "cluster-events-leios-baseline.jsonl"
 ordering_window_secs = 1.0
 aggregator_port = 9100
 stats_interval_secs = 1
-stake_distribution = "mainnet-shaped"
 rb_generation_probability = 0.05
 tx_rate = 1.0
+
+[topology_source]
+type = "random"
+num_nodes = 30
+degree = 3
+min_latency_ms = 5
+max_latency_ms = 100
+stake_distribution = "mainnet-shaped"

--- a/net-rs/net-cluster/configs/sample-cluster-t22.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-t22.toml
@@ -5,14 +5,9 @@
 #
 # Stake distribution is `mainnet-shaped`: ~71% of nodes are relays
 # (stake = 0, no votes) and ~29% are pools sharing the total stake
-# uniformly.  With `num_nodes = 30` that yields ~9 pool nodes.
+# uniformly.  With `num_nodes = 25` that yields ~7 pool nodes.
 #
 # Behaviour invokes T21/T22 threat model, parameter description is given below.
-
-num_nodes = 25
-degree = 5
-min_latency_ms = 5
-max_latency_ms = 100
 
 base_config = "net-node/configs/mainnet.toml"
 base_port = 30300
@@ -21,9 +16,16 @@ output_events = "cluster-events-t22.jsonl"
 ordering_window_secs = 1.0
 aggregator_port = 9100
 stats_interval_secs = 1
-stake_distribution = "mainnet-shaped"
 rb_generation_probability = 0.05
 tx_rate = 1.0
+
+[topology_source]
+type = "random"
+num_nodes = 25
+degree = 5
+min_latency_ms = 5
+max_latency_ms = 100
+stake_distribution = "mainnet-shaped"
 
 [behaviour]
 kind = "t22"

--- a/net-rs/net-cluster/configs/sample-cluster-t22.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-t22.toml
@@ -19,8 +19,9 @@ stats_interval_secs = 1
 rb_generation_probability = 0.05
 tx_rate = 1.0
 
-[topology_source]
-type = "random"
+topology_source = "random"
+
+[topology_random]
 num_nodes = 25
 degree = 5
 min_latency_ms = 5

--- a/net-rs/net-cluster/configs/sample-cluster-v4-mini.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-v4-mini.toml
@@ -12,11 +12,10 @@
 #     --config net-cluster/configs/sample-cluster-v4-mini.toml \
 #     --net-node-bin target/release/net-node
 #
-# This loads the first 25 nodes from topology-v4-mainnet.yaml (top-25
-# by stake) and wires them with the YAML's per-link latencies.  Random-
-# mode fields (`num_nodes`, `degree`, latency range, stake_distribution)
-# are not just ignored here — putting them under `[topology_source]` with
-# `type = "yaml"` would be a parse-time error.
+# This loads the first 100 nodes from topology-v4-mainnet.yaml (top-100
+# by stake) and wires them with the YAML's per-link latencies.  Because
+# `topology_source = "yaml"`, only the [topology_yaml] section is read;
+# any [topology_random] section is ignored.
 
 # Base net-node config shared by all spawned nodes.
 base_config = "net-node/configs/mainnet.toml"
@@ -48,11 +47,12 @@ rb_generation_probability = 0.05
 # is enough to fill RB bodies and exercise EB production / voting.
 tx_rate = 1.0
 
-# YAML topology source.  Path is relative to the cluster process's
+# YAML topology mode.  Path is relative to the cluster process's
 # working directory at startup (typically the net-rs/ directory).
 # Stake comes directly from the YAML's per-node `stake` field — no
-# top-level `stake_distribution` knob applies here.
-[topology_source]
-type = "yaml"
+# `stake_distribution` knob applies here.
+topology_source = "yaml"
+
+[topology_yaml]
 path = "../data/simulation/pseudo-mainnet/topology-v4-mainnet.yaml"
 node_limit = 100

--- a/net-rs/net-cluster/configs/sample-cluster-v4-mini.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-v4-mini.toml
@@ -1,0 +1,58 @@
+# Sample cluster configuration: drive a local cluster from the v4
+# mainnet-faithful YAML topology instead of a random graph.
+#
+# The v4 topology YAML is checked into the repo at
+# data/simulation/pseudo-mainnet/topology-v4-mainnet.yaml — see that
+# directory's topology-v4.md for how it was produced.  To rebuild it
+# from sources: sim-rs/scripts/generate-fused-topology.py.
+#
+# Build net-node and run from the net-rs/ directory:
+#   cargo build -p net-node --release
+#   RUST_LOG=info cargo run -p net-cluster --release -- \
+#     --config net-cluster/configs/sample-cluster-v4-mini.toml \
+#     --net-node-bin target/release/net-node
+#
+# This loads the first 25 nodes from topology-v4-mainnet.yaml (top-25
+# by stake) and wires them with the YAML's per-link latencies.  Random-
+# mode fields (`num_nodes`, `degree`, latency range, stake_distribution)
+# are not just ignored here — putting them under `[topology_source]` with
+# `type = "yaml"` would be a parse-time error.
+
+# Base net-node config shared by all spawned nodes.
+base_config = "net-node/configs/mainnet.toml"
+
+# Port allocation: node i gets base_port + i.
+base_port = 30000
+
+# Reproducible run.
+seed = 42
+
+# Merged time-ordered event log.
+output_events = "cluster-v4-events.jsonl"
+
+# Time window for cross-node event ordering.
+ordering_window_secs = 1.0
+
+# Telemetry aggregator HTTP port.
+aggregator_port = 9100
+
+# Periodic stats reporting interval (seconds).
+stats_interval_secs = 2
+
+# Praos block production rate (per slot per leader weight).
+# Mainnet f_block ≈ 0.05.  See sample-cluster.toml for why this
+# matters for end-to-end Leios certification.
+rb_generation_probability = 0.05
+
+# Per-node transaction generation rate (tx/s).  ~1 tx/s × 25 nodes
+# is enough to fill RB bodies and exercise EB production / voting.
+tx_rate = 1.0
+
+# YAML topology source.  Path is relative to the cluster process's
+# working directory at startup (typically the net-rs/ directory).
+# Stake comes directly from the YAML's per-node `stake` field — no
+# top-level `stake_distribution` knob applies here.
+[topology_source]
+type = "yaml"
+path = "../data/simulation/pseudo-mainnet/topology-v4-mainnet.yaml"
+node_limit = 100

--- a/net-rs/net-cluster/configs/sample-cluster.toml
+++ b/net-rs/net-cluster/configs/sample-cluster.toml
@@ -6,11 +6,6 @@
 # This spawns 25 nodes with degree-3 random topology, 5–250ms latency
 # (matching real intercontinental geography), and equal stake distribution.
 
-num_nodes = 25
-degree = 3
-min_latency_ms = 5
-max_latency_ms = 250
-
 # Base config shared by all nodes (genesis, protocol params, etc.)
 base_config = "net-node/configs/mainnet.toml"
 
@@ -32,9 +27,6 @@ aggregator_port = 9100
 # Stats reporting interval (seconds)
 stats_interval_secs = 1
 
-# Stake distribution
-stake_distribution = "equal"
-
 # Block production rate.  Mainnet Praos f_block ≈ 0.05/slot.  Higher
 # values pack more RBs into each Leios voting window, which means the
 # chain-tip RB likely moves past the EB-referencing RB before voters
@@ -49,3 +41,14 @@ rb_generation_probability = 0.05
 # end-to-end.  1.0 tx/s/node × 25 nodes ≈ 25 tx/s aggregate is enough
 # to overflow RB bodies into EBs without saturating txsubmission.
 tx_rate = 1.0
+
+# Random-graph topology source.  All random-mode knobs (`num_nodes`,
+# `degree`, latency range, stake distribution) live inside this table
+# now — putting them at the top level is a parse-time error.
+[topology_source]
+type = "random"
+num_nodes = 25
+degree = 3
+min_latency_ms = 5
+max_latency_ms = 250
+stake_distribution = "equal"

--- a/net-rs/net-cluster/configs/sample-cluster.toml
+++ b/net-rs/net-cluster/configs/sample-cluster.toml
@@ -42,11 +42,12 @@ rb_generation_probability = 0.05
 # to overflow RB bodies into EBs without saturating txsubmission.
 tx_rate = 1.0
 
-# Random-graph topology source.  All random-mode knobs (`num_nodes`,
-# `degree`, latency range, stake distribution) live inside this table
-# now — putting them at the top level is a parse-time error.
-[topology_source]
-type = "random"
+# Topology mode selector.  "random" reads the [topology_random] section
+# below; "yaml" would read a [topology_yaml] section instead.
+topology_source = "random"
+
+# Random-graph parameters.  Unknown keys here are a parse-time error.
+[topology_random]
 num_nodes = 25
 degree = 3
 min_latency_ms = 5

--- a/net-rs/net-cluster/src/config.rs
+++ b/net-rs/net-cluster/src/config.rs
@@ -83,7 +83,7 @@ pub enum TopologySource {
         /// YAML (in YAML insertion order; the v4 generator orders by
         /// stake-rank descending, so this is effectively top-N by stake).
         /// `None` loads every node — beware, v4-mainnet has 2,685 nodes
-        /// and average degree ~70, which is impractical for a local
+        /// with a dense peer graph, which is impractical for a local
         /// process-per-node cluster.
         #[serde(default)]
         node_limit: Option<usize>,

--- a/net-rs/net-cluster/src/config.rs
+++ b/net-rs/net-cluster/src/config.rs
@@ -1,6 +1,6 @@
 //! TOML-based cluster configuration with figment loading.
 
-use figment::providers::{Format, Serialized, Toml};
+use figment::providers::{Format, Toml};
 use figment::Figment;
 use serde::{Deserialize, Serialize};
 
@@ -20,12 +20,20 @@ fn default_inject_count() -> usize {
 }
 
 /// Subset of ClusterConfig controllable via the REST API.
+///
+/// `topology_source` overrides the whole topology mode wholesale — sending
+/// `type = "random"` switches the cluster to a random graph (with whichever
+/// random-mode fields you supply), and `type = "yaml"` switches it to a
+/// YAML-driven topology.  There's intentionally no way to override just one
+/// random-mode field through this struct: that would silently mix modes.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterControlConfig {
-    pub num_nodes: Option<usize>,
-    pub degree: Option<usize>,
-    pub min_latency_ms: Option<u64>,
-    pub max_latency_ms: Option<u64>,
+    /// Topology mode + its mode-specific params (e.g. `num_nodes`, `degree`
+    /// for Random; `path`, `node_limit` for Yaml).  When `None`, the
+    /// current cluster topology source is left untouched.
+    #[serde(default)]
+    pub topology_source: Option<TopologySource>,
+    #[serde(default)]
     pub seed: Option<u64>,
     /// Node-level config overrides written into each node's overlay TOML.
     /// Keys are dotted TOML paths (e.g. "production.rb_generation_probability").
@@ -37,22 +45,36 @@ pub struct ClusterControlConfig {
 ///
 /// Defaults to [`TopologySource::Random`] (the historical behaviour) so
 /// existing TOML configs that don't mention `topology_source` continue to
-/// generate a random graph from `num_nodes`/`degree`/`min_latency_ms`/
-/// `max_latency_ms`.
+/// generate a random graph from the default `num_nodes`/`degree`/
+/// `min_latency_ms`/`max_latency_ms`/`stake_distribution`.
 ///
 /// Selecting [`TopologySource::Yaml`] loads `data/simulation/pseudo-mainnet/
 /// topology-v*.yaml`-style files (same schema as sim-rs and topology-checker).
-/// In YAML mode the `num_nodes`/`degree`/`min_latency_ms`/`max_latency_ms`
-/// fields are **ignored** — node count comes from the YAML (optionally
-/// capped by `node_limit`), edges come from the YAML's `producers` arrays,
-/// and per-link latencies come from `latency-ms`.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+/// All mode-specific parameters live **inside** the variant: writing
+/// `degree = 7` under `type = "yaml"` is a parse-time error, not a silent
+/// ignore.  This is enforced by `#[serde(deny_unknown_fields)]` on the
+/// enum, which forwards to each variant struct.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum TopologySource {
-    /// Generate a random connected graph (`num_nodes`, `degree`,
-    /// `min/max_latency_ms`).
-    #[default]
-    Random,
+    /// Generate a random connected graph.
+    Random {
+        /// Number of net-node instances to spawn.
+        #[serde(default = "default_num_nodes")]
+        num_nodes: usize,
+        /// Target number of peers per node.
+        #[serde(default = "default_degree")]
+        degree: usize,
+        /// Minimum simulated link latency (ms).
+        #[serde(default = "default_min_latency")]
+        min_latency_ms: u64,
+        /// Maximum simulated link latency (ms).
+        #[serde(default = "default_max_latency")]
+        max_latency_ms: u64,
+        /// Stake distribution strategy ("equal", "mainnet-shaped").
+        #[serde(default = "default_stake_distribution")]
+        stake_distribution: String,
+    },
     /// Load a YAML topology (v3/v4 schema).  `path` is interpreted
     /// relative to the process's current directory at startup.
     Yaml {
@@ -68,27 +90,23 @@ pub enum TopologySource {
     },
 }
 
+impl Default for TopologySource {
+    fn default() -> Self {
+        Self::Random {
+            num_nodes: default_num_nodes(),
+            degree: default_degree(),
+            min_latency_ms: default_min_latency(),
+            max_latency_ms: default_max_latency(),
+            stake_distribution: default_stake_distribution(),
+        }
+    }
+}
+
 /// Top-level cluster configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterConfig {
-    /// Number of net-node instances to spawn (random topology only;
-    /// overwritten by the loaded node count when `topology_source` is
-    /// `yaml`).
-    pub num_nodes: usize,
-
-    /// Target number of peers per node (random topology only).
-    #[serde(default = "default_degree")]
-    pub degree: usize,
-
-    /// Minimum simulated link latency (ms) (random topology only).
-    #[serde(default = "default_min_latency")]
-    pub min_latency_ms: u64,
-
-    /// Maximum simulated link latency (ms) (random topology only).
-    #[serde(default = "default_max_latency")]
-    pub max_latency_ms: u64,
-
-    /// Where the topology comes from.  See [`TopologySource`].
+    /// Where the topology comes from + its mode-specific parameters.
+    /// See [`TopologySource`].
     #[serde(default)]
     pub topology_source: TopologySource,
 
@@ -100,6 +118,7 @@ pub struct ClusterConfig {
     pub base_port: u16,
 
     /// PRNG seed for reproducible topology. Optional.
+    #[serde(default)]
     pub seed: Option<u64>,
 
     /// Path for merged event JSONL output.
@@ -114,10 +133,6 @@ pub struct ClusterConfig {
     #[serde(default = "default_aggregator_port")]
     pub aggregator_port: u16,
 
-    /// Stake distribution strategy ("equal").
-    #[serde(default = "default_stake_distribution")]
-    pub stake_distribution: String,
-
     /// How often nodes should report stats (seconds).
     #[serde(default = "default_stats_interval")]
     pub stats_interval_secs: u64,
@@ -127,6 +142,7 @@ pub struct ClusterConfig {
     pub event_window_size: usize,
 
     /// Override rb_generation_probability for all nodes.
+    #[serde(default)]
     pub rb_generation_probability: Option<f64>,
 
     /// Override the per-node Poisson transaction generation rate
@@ -136,6 +152,7 @@ pub struct ClusterConfig {
     /// must keep the mempool busy enough to overflow into EBs.  When
     /// `None`, the base config's value is used (`mainnet.toml` defaults
     /// to `0.0` = no generation).
+    #[serde(default)]
     pub tx_rate: Option<f64>,
 
     /// Per-node adversarial / experimental behaviour.  See
@@ -158,6 +175,9 @@ pub struct ClusterConfig {
     pub external_peers: Vec<ExternalPeerConfig>,
 }
 
+fn default_num_nodes() -> usize {
+    5
+}
 fn default_degree() -> usize {
     3
 }
@@ -192,17 +212,12 @@ fn default_stats_interval() -> u64 {
 impl Default for ClusterConfig {
     fn default() -> Self {
         Self {
-            num_nodes: 5,
-            degree: default_degree(),
-            min_latency_ms: default_min_latency(),
-            max_latency_ms: default_max_latency(),
             base_config: "net-node/configs/mainnet.toml".to_string(),
             base_port: default_base_port(),
             seed: None,
             output_events: default_output_events(),
             ordering_window_secs: default_ordering_window(),
             aggregator_port: default_aggregator_port(),
-            stake_distribution: default_stake_distribution(),
             stats_interval_secs: default_stats_interval(),
             event_window_size: default_event_window_size(),
             rb_generation_probability: None,
@@ -279,33 +294,74 @@ pub struct ActiveAttack {
     pub started_at_s: f64,
 }
 
+impl TopologySource {
+    /// Borrow the Random variant's parameters, or `None` for Yaml.
+    /// Sugar for callers that only need to read the random-mode knobs
+    /// (currently the tests; the production code pattern-matches the
+    /// enum directly to keep all fields visible at the call site).
+    #[cfg(test)]
+    pub fn as_random(&self) -> Option<RandomParams<'_>> {
+        match self {
+            TopologySource::Random {
+                num_nodes,
+                degree,
+                min_latency_ms,
+                max_latency_ms,
+                stake_distribution,
+            } => Some(RandomParams {
+                num_nodes: *num_nodes,
+                degree: *degree,
+                min_latency_ms: *min_latency_ms,
+                max_latency_ms: *max_latency_ms,
+                stake_distribution,
+            }),
+            TopologySource::Yaml { .. } => None,
+        }
+    }
+}
+
+/// Borrowed view of [`TopologySource::Random`] parameters.  Test-only
+/// today — production code matches the enum directly.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy)]
+pub struct RandomParams<'a> {
+    pub num_nodes: usize,
+    pub degree: usize,
+    pub min_latency_ms: u64,
+    pub max_latency_ms: u64,
+    pub stake_distribution: &'a str,
+}
+
 impl ClusterConfig {
     /// Apply optional overrides from a control config, returning a new config.
+    ///
+    /// `topology_source` (when present) replaces the entire topology source
+    /// wholesale — there's no per-field merge.  This intentionally prevents
+    /// mixing modes (e.g. overriding just `degree` on a YAML-backed cluster).
     pub fn with_overrides(
         &self,
         overrides: &ClusterControlConfig,
     ) -> Result<ClusterConfig, String> {
         let mut config = self.clone();
-        if let Some(n) = overrides.num_nodes {
-            config.num_nodes = n;
-        }
-        if let Some(d) = overrides.degree {
-            config.degree = d;
-        }
-        if let Some(min) = overrides.min_latency_ms {
-            config.min_latency_ms = min;
-        }
-        if let Some(max) = overrides.max_latency_ms {
-            config.max_latency_ms = max;
+        if let Some(ts) = &overrides.topology_source {
+            config.topology_source = ts.clone();
         }
         if let Some(s) = overrides.seed {
             config.seed = Some(s);
         }
-        if config.num_nodes == 0 {
-            return Err("num_nodes must be at least 1".into());
-        }
-        if config.min_latency_ms > config.max_latency_ms {
-            return Err("min_latency_ms must be <= max_latency_ms".into());
+        if let TopologySource::Random {
+            num_nodes,
+            min_latency_ms,
+            max_latency_ms,
+            ..
+        } = &config.topology_source
+        {
+            if *num_nodes == 0 {
+                return Err("num_nodes must be at least 1".into());
+            }
+            if min_latency_ms > max_latency_ms {
+                return Err("min_latency_ms must be <= max_latency_ms".into());
+            }
         }
         Ok(config)
     }
@@ -329,10 +385,7 @@ impl ClusterConfig {
             node_config.insert("transactions.tx_rate".into(), serde_json::json!(r));
         }
         ClusterControlConfig {
-            num_nodes: Some(self.num_nodes),
-            degree: Some(self.degree),
-            min_latency_ms: Some(self.min_latency_ms),
-            max_latency_ms: Some(self.max_latency_ms),
+            topology_source: Some(self.topology_source.clone()),
             seed: self.seed,
             node_config,
         }
@@ -340,12 +393,21 @@ impl ClusterConfig {
 }
 
 /// Load cluster configuration from a TOML file with optional --set overrides.
+///
+/// Defaults strategy: we *don't* serialise the entire
+/// `ClusterConfig::default()` into figment as defaults — that would
+/// leak `topology_source = Random { num_nodes, degree, … }` into every
+/// load, and then any TOML that selects `type = "yaml"` would merge
+/// the stale Random fields under it and trip `deny_unknown_fields` at
+/// extraction time.  Instead, every top-level field that has a default
+/// declares it via `#[serde(default = "...")]` on `ClusterConfig` and
+/// each variant declares its per-field defaults internally.  Figment
+/// only carries the user-supplied TOML and any `--set` overrides.
 pub fn load(
     config_file: &str,
     set_overrides: &[String],
 ) -> Result<ClusterConfig, Box<dyn std::error::Error + Send + Sync>> {
-    let mut figment = Figment::from(Serialized::defaults(ClusterConfig::default()))
-        .merge(Toml::file(config_file));
+    let mut figment = Figment::from(Toml::file(config_file));
 
     for override_str in set_overrides {
         let toml_fragment = set_override_to_toml(override_str)?;
@@ -354,11 +416,21 @@ pub fn load(
 
     let config: ClusterConfig = figment.extract()?;
 
-    if config.num_nodes == 0 {
-        return Err("num_nodes must be at least 1".into());
-    }
-    if config.min_latency_ms > config.max_latency_ms {
-        return Err("min_latency_ms must be <= max_latency_ms".into());
+    // Random-mode-only validation.  Yaml mode rejects the empty case
+    // inside `topology::build_from_raw` instead.
+    if let TopologySource::Random {
+        num_nodes,
+        min_latency_ms,
+        max_latency_ms,
+        ..
+    } = &config.topology_source
+    {
+        if *num_nodes == 0 {
+            return Err("num_nodes must be at least 1".into());
+        }
+        if min_latency_ms > max_latency_ms {
+            return Err("min_latency_ms must be <= max_latency_ms".into());
+        }
     }
 
     Ok(config)
@@ -432,10 +504,54 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = ClusterConfig::default();
-        assert_eq!(config.num_nodes, 5);
-        assert_eq!(config.degree, 3);
-        assert_eq!(config.min_latency_ms, 5);
-        assert_eq!(config.max_latency_ms, 300);
+        let random = config
+            .topology_source
+            .as_random()
+            .expect("default is random");
+        assert_eq!(random.num_nodes, 5);
+        assert_eq!(random.degree, 3);
+        assert_eq!(random.min_latency_ms, 5);
+        assert_eq!(random.max_latency_ms, 300);
+        assert_eq!(random.stake_distribution, "equal");
+    }
+
+    /// Smallest valid config: just `base_config`.  Every other top-level
+    /// field has to have a serde default, otherwise the user will hit a
+    /// "missing field `X`" error the moment they trim their config.  This
+    /// test pins that contract explicitly so it can't regress silently
+    /// (e.g. by someone adding a new required field without realising).
+    #[test]
+    fn test_load_minimal_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("minimal.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, r#"base_config = "mainnet.toml""#).unwrap();
+
+        let config = load(path.to_str().unwrap(), &[]).expect("minimal config must load");
+
+        // base_config is the only field the user wrote — everything else
+        // must come from defaults.
+        assert_eq!(config.base_config, "mainnet.toml");
+        assert_eq!(config.base_port, 30000);
+        assert_eq!(config.aggregator_port, 9100);
+        assert!(config.seed.is_none());
+        assert!(config.rb_generation_probability.is_none());
+        assert!(config.tx_rate.is_none());
+        assert!(config.behaviour.is_none());
+        assert!(config.behaviour_selection.is_none());
+        assert!(config.external_peers.is_empty());
+
+        // topology_source defaults to Random with all variant fields at
+        // their per-field defaults.
+        let random = config
+            .topology_source
+            .as_random()
+            .expect("default topology_source is random");
+        assert_eq!(random.num_nodes, 5);
+        assert_eq!(random.degree, 3);
+        assert_eq!(random.min_latency_ms, 5);
+        assert_eq!(random.max_latency_ms, 300);
+        assert_eq!(random.stake_distribution, "equal");
     }
 
     #[test]
@@ -446,17 +562,21 @@ mod tests {
         writeln!(
             f,
             r#"
-num_nodes = 8
-degree = 4
 base_config = "mainnet.toml"
 seed = 123
+
+[topology_source]
+type = "random"
+num_nodes = 8
+degree = 4
 "#
         )
         .unwrap();
 
         let config = load(path.to_str().unwrap(), &[]).unwrap();
-        assert_eq!(config.num_nodes, 8);
-        assert_eq!(config.degree, 4);
+        let random = config.topology_source.as_random().expect("random mode");
+        assert_eq!(random.num_nodes, 8);
+        assert_eq!(random.degree, 4);
         assert_eq!(config.seed, Some(123));
         // Defaults should fill in the rest.
         assert_eq!(config.aggregator_port, 9100);
@@ -470,14 +590,22 @@ seed = 123
         writeln!(
             f,
             r#"
-num_nodes = 3
 base_config = "mainnet.toml"
+
+[topology_source]
+type = "random"
+num_nodes = 3
 "#
         )
         .unwrap();
 
-        let config = load(path.to_str().unwrap(), &["num_nodes=10".to_string()]).unwrap();
-        assert_eq!(config.num_nodes, 10);
+        // --set drills into the topology_source table by dotted key.
+        let config = load(
+            path.to_str().unwrap(),
+            &["topology_source.num_nodes=10".to_string()],
+        )
+        .unwrap();
+        assert_eq!(config.topology_source.as_random().unwrap().num_nodes, 10);
     }
 
     #[test]
@@ -488,13 +616,72 @@ base_config = "mainnet.toml"
         writeln!(
             f,
             r#"
-num_nodes = 0
 base_config = "mainnet.toml"
+
+[topology_source]
+type = "random"
+num_nodes = 0
 "#
         )
         .unwrap();
 
         let result = load(path.to_str().unwrap(), &[]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_yaml_rejects_random_fields() {
+        // Schema-level rejection: `degree` is meaningless under
+        // `type = "yaml"`, so the parse must fail rather than silently
+        // ignore it.  This is the core invariant of the refactor.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+base_config = "mainnet.toml"
+
+[topology_source]
+type = "yaml"
+path = "topology.yaml"
+degree = 7
+"#
+        )
+        .unwrap();
+
+        let err = load(path.to_str().unwrap(), &[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("degree") || msg.contains("unknown field"),
+            "expected unknown-field error mentioning 'degree', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_random_rejects_yaml_fields() {
+        // Symmetric: `path` is meaningless under `type = "random"`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+base_config = "mainnet.toml"
+
+[topology_source]
+type = "random"
+num_nodes = 5
+path = "topology.yaml"
+"#
+        )
+        .unwrap();
+
+        let err = load(path.to_str().unwrap(), &[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path") || msg.contains("unknown field"),
+            "expected unknown-field error mentioning 'path', got: {msg}"
+        );
     }
 }

--- a/net-rs/net-cluster/src/config.rs
+++ b/net-rs/net-cluster/src/config.rs
@@ -21,18 +21,23 @@ fn default_inject_count() -> usize {
 
 /// Subset of ClusterConfig controllable via the REST API.
 ///
-/// `topology_source` overrides the whole topology mode wholesale — sending
-/// `type = "random"` switches the cluster to a random graph (with whichever
-/// random-mode fields you supply), and `type = "yaml"` switches it to a
-/// YAML-driven topology.  There's intentionally no way to override just one
-/// random-mode field through this struct: that would silently mix modes.
+/// `topology_source` selects the topology mode (`"random"` or `"yaml"`), and
+/// `topology_random` / `topology_yaml` carry that mode's parameters.  Each is
+/// optional: a field left `None` leaves the cluster's current value untouched.
+/// In practice the UI sends `topology_source = "random"` together with a fresh
+/// `topology_random` when restarting a random cluster, and omits all three in
+/// YAML mode (the cluster restarts with whatever YAML it loaded at startup).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterControlConfig {
-    /// Topology mode + its mode-specific params (e.g. `num_nodes`, `degree`
-    /// for Random; `path`, `node_limit` for Yaml).  When `None`, the
-    /// current cluster topology source is left untouched.
+    /// Which topology mode to switch to.  `None` leaves it unchanged.
     #[serde(default)]
     pub topology_source: Option<TopologySource>,
+    /// Replacement random-mode parameters.  `None` leaves them unchanged.
+    #[serde(default)]
+    pub topology_random: Option<RandomTopologyConfig>,
+    /// Replacement YAML-mode parameters.  `None` leaves them unchanged.
+    #[serde(default)]
+    pub topology_yaml: Option<YamlTopologyConfig>,
     #[serde(default)]
     pub seed: Option<u64>,
     /// Node-level config overrides written into each node's overlay TOML.
@@ -41,58 +46,56 @@ pub struct ClusterControlConfig {
     pub node_config: std::collections::HashMap<String, serde_json::Value>,
 }
 
-/// Where the cluster topology comes from.
+/// Which topology mode the cluster runs in.
 ///
-/// Defaults to [`TopologySource::Random`] (the historical behaviour) so
-/// existing TOML configs that don't mention `topology_source` continue to
-/// generate a random graph from the default `num_nodes`/`degree`/
-/// `min_latency_ms`/`max_latency_ms`/`stake_distribution`.
+/// Selected by the top-level scalar `topology_source = "random" | "yaml"`.
+/// The mode-specific parameters live in the always-present `[topology_random]`
+/// and `[topology_yaml]` sections (see [`ClusterConfig`]); only the section
+/// matching the selected mode is read.  Defaults to [`TopologySource::Random`]
+/// (the historical behaviour) so existing configs that don't mention
+/// `topology_source` keep generating a random graph.
 ///
 /// Selecting [`TopologySource::Yaml`] loads `data/simulation/pseudo-mainnet/
 /// topology-v*.yaml`-style files (same schema as sim-rs and topology-checker).
-/// All mode-specific parameters live **inside** the variant: writing
-/// `degree = 7` under `type = "yaml"` is a parse-time error, not a silent
-/// ignore.  This is enforced by `#[serde(deny_unknown_fields)]` on the
-/// enum, which forwards to each variant struct.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TopologySource {
-    /// Generate a random connected graph.
-    Random {
-        /// Number of net-node instances to spawn.
-        #[serde(default = "default_num_nodes")]
-        num_nodes: usize,
-        /// Target number of peers per node.
-        #[serde(default = "default_degree")]
-        degree: usize,
-        /// Minimum simulated link latency (ms).
-        #[serde(default = "default_min_latency")]
-        min_latency_ms: u64,
-        /// Maximum simulated link latency (ms).
-        #[serde(default = "default_max_latency")]
-        max_latency_ms: u64,
-        /// Stake distribution strategy ("equal", "mainnet-shaped").
-        #[serde(default = "default_stake_distribution")]
-        stake_distribution: String,
-    },
-    /// Load a YAML topology (v3/v4 schema).  `path` is interpreted
-    /// relative to the process's current directory at startup.
-    Yaml {
-        path: String,
-        /// Optional cap: load only the first `node_limit` nodes from the
-        /// YAML (in YAML insertion order; the v4 generator orders by
-        /// stake-rank descending, so this is effectively top-N by stake).
-        /// `None` loads every node — beware, v4-mainnet has 2,685 nodes
-        /// with a dense peer graph, which is impractical for a local
-        /// process-per-node cluster.
-        #[serde(default)]
-        node_limit: Option<usize>,
-    },
+    /// Generate a random connected graph from `[topology_random]`.
+    #[default]
+    Random,
+    /// Load a YAML topology from `[topology_yaml]`.
+    Yaml,
 }
 
-impl Default for TopologySource {
+/// Parameters for [`TopologySource::Random`] (the `[topology_random]` section).
+///
+/// `deny_unknown_fields` rejects typos and stray keys within the section.
+/// The section is always present in the config (with per-field defaults), so a
+/// YAML-mode config can omit it entirely; conversely, leaving a populated
+/// `[topology_random]` section while in YAML mode is silently ignored.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RandomTopologyConfig {
+    /// Number of net-node instances to spawn.
+    #[serde(default = "default_num_nodes")]
+    pub num_nodes: usize,
+    /// Target number of peers per node.
+    #[serde(default = "default_degree")]
+    pub degree: usize,
+    /// Minimum simulated link latency (ms).
+    #[serde(default = "default_min_latency")]
+    pub min_latency_ms: u64,
+    /// Maximum simulated link latency (ms).
+    #[serde(default = "default_max_latency")]
+    pub max_latency_ms: u64,
+    /// Stake distribution strategy ("equal", "mainnet-shaped").
+    #[serde(default = "default_stake_distribution")]
+    pub stake_distribution: String,
+}
+
+impl Default for RandomTopologyConfig {
     fn default() -> Self {
-        Self::Random {
+        Self {
             num_nodes: default_num_nodes(),
             degree: default_degree(),
             min_latency_ms: default_min_latency(),
@@ -102,13 +105,44 @@ impl Default for TopologySource {
     }
 }
 
+/// Parameters for [`TopologySource::Yaml`] (the `[topology_yaml]` section).
+///
+/// `path` defaults to the empty string so a random-mode config need not
+/// declare the section; `load` rejects an empty `path` when the selected mode
+/// is YAML.  `deny_unknown_fields` rejects stray keys within the section.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct YamlTopologyConfig {
+    /// Path to the YAML topology (v3/v4 schema), interpreted relative to the
+    /// process's current directory at startup.
+    #[serde(default)]
+    pub path: String,
+    /// Optional cap: load only the first `node_limit` nodes from the YAML (in
+    /// YAML insertion order; the v4 generator orders by stake-rank descending,
+    /// so this is effectively top-N by stake).  `None` loads every node —
+    /// beware, v4-mainnet has 2,685 nodes with a dense peer graph, which is
+    /// impractical for a local process-per-node cluster.
+    #[serde(default)]
+    pub node_limit: Option<usize>,
+}
+
 /// Top-level cluster configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterConfig {
-    /// Where the topology comes from + its mode-specific parameters.
-    /// See [`TopologySource`].
+    /// Which topology mode to run (`"random"` or `"yaml"`).  See
+    /// [`TopologySource`].  Parameters live in `topology_random` /
+    /// `topology_yaml`; only the section matching this mode is read.
     #[serde(default)]
     pub topology_source: TopologySource,
+
+    /// Random-mode parameters (`[topology_random]`).  See
+    /// [`RandomTopologyConfig`].
+    #[serde(default)]
+    pub topology_random: RandomTopologyConfig,
+
+    /// YAML-mode parameters (`[topology_yaml]`).  See [`YamlTopologyConfig`].
+    #[serde(default)]
+    pub topology_yaml: YamlTopologyConfig,
 
     /// Path to the base net-node config (e.g. "net-node/configs/mainnet.toml").
     pub base_config: String,
@@ -226,6 +260,8 @@ impl Default for ClusterConfig {
             behaviour_selection: None,
             external_peers: Vec::new(),
             topology_source: TopologySource::default(),
+            topology_random: RandomTopologyConfig::default(),
+            topology_yaml: YamlTopologyConfig::default(),
         }
     }
 }
@@ -294,72 +330,36 @@ pub struct ActiveAttack {
     pub started_at_s: f64,
 }
 
-impl TopologySource {
-    /// Borrow the Random variant's parameters, or `None` for Yaml.
-    /// Sugar for callers that only need to read the random-mode knobs
-    /// (currently the tests; the production code pattern-matches the
-    /// enum directly to keep all fields visible at the call site).
-    #[cfg(test)]
-    pub fn as_random(&self) -> Option<RandomParams<'_>> {
-        match self {
-            TopologySource::Random {
-                num_nodes,
-                degree,
-                min_latency_ms,
-                max_latency_ms,
-                stake_distribution,
-            } => Some(RandomParams {
-                num_nodes: *num_nodes,
-                degree: *degree,
-                min_latency_ms: *min_latency_ms,
-                max_latency_ms: *max_latency_ms,
-                stake_distribution,
-            }),
-            TopologySource::Yaml { .. } => None,
-        }
-    }
-}
-
-/// Borrowed view of [`TopologySource::Random`] parameters.  Test-only
-/// today — production code matches the enum directly.
-#[cfg(test)]
-#[derive(Debug, Clone, Copy)]
-pub struct RandomParams<'a> {
-    pub num_nodes: usize,
-    pub degree: usize,
-    pub min_latency_ms: u64,
-    pub max_latency_ms: u64,
-    pub stake_distribution: &'a str,
-}
-
 impl ClusterConfig {
     /// Apply optional overrides from a control config, returning a new config.
     ///
-    /// `topology_source` (when present) replaces the entire topology source
-    /// wholesale — there's no per-field merge.  This intentionally prevents
-    /// mixing modes (e.g. overriding just `degree` on a YAML-backed cluster).
+    /// `topology_source` (when present) switches the mode; `topology_random` /
+    /// `topology_yaml` (when present) replace that mode's parameters wholesale.
+    /// There's no per-field merge, so a caller can't mix modes by overriding a
+    /// single random knob on a YAML-backed cluster.
     pub fn with_overrides(
         &self,
         overrides: &ClusterControlConfig,
     ) -> Result<ClusterConfig, String> {
         let mut config = self.clone();
-        if let Some(ts) = &overrides.topology_source {
-            config.topology_source = ts.clone();
+        if let Some(kind) = overrides.topology_source {
+            config.topology_source = kind;
+        }
+        if let Some(random) = &overrides.topology_random {
+            config.topology_random = random.clone();
+        }
+        if let Some(yaml) = &overrides.topology_yaml {
+            config.topology_yaml = yaml.clone();
         }
         if let Some(s) = overrides.seed {
             config.seed = Some(s);
         }
-        if let TopologySource::Random {
-            num_nodes,
-            min_latency_ms,
-            max_latency_ms,
-            ..
-        } = &config.topology_source
-        {
-            if *num_nodes == 0 {
+        if config.topology_source == TopologySource::Random {
+            let random = &config.topology_random;
+            if random.num_nodes == 0 {
                 return Err("num_nodes must be at least 1".into());
             }
-            if min_latency_ms > max_latency_ms {
+            if random.min_latency_ms > random.max_latency_ms {
                 return Err("min_latency_ms must be <= max_latency_ms".into());
             }
         }
@@ -385,7 +385,9 @@ impl ClusterConfig {
             node_config.insert("transactions.tx_rate".into(), serde_json::json!(r));
         }
         ClusterControlConfig {
-            topology_source: Some(self.topology_source.clone()),
+            topology_source: Some(self.topology_source),
+            topology_random: Some(self.topology_random.clone()),
+            topology_yaml: Some(self.topology_yaml.clone()),
             seed: self.seed,
             node_config,
         }
@@ -394,15 +396,9 @@ impl ClusterConfig {
 
 /// Load cluster configuration from a TOML file with optional --set overrides.
 ///
-/// Defaults strategy: we *don't* serialise the entire
-/// `ClusterConfig::default()` into figment as defaults — that would
-/// leak `topology_source = Random { num_nodes, degree, … }` into every
-/// load, and then any TOML that selects `type = "yaml"` would merge
-/// the stale Random fields under it and trip `deny_unknown_fields` at
-/// extraction time.  Instead, every top-level field that has a default
-/// declares it via `#[serde(default = "...")]` on `ClusterConfig` and
-/// each variant declares its per-field defaults internally.  Figment
-/// only carries the user-supplied TOML and any `--set` overrides.
+/// Every field with a default declares it via `#[serde(default = "...")]`, so
+/// figment only needs to carry the user-supplied TOML and any `--set`
+/// overrides — we don't seed `ClusterConfig::default()` as a base layer.
 pub fn load(
     config_file: &str,
     set_overrides: &[String],
@@ -416,20 +412,24 @@ pub fn load(
 
     let config: ClusterConfig = figment.extract()?;
 
-    // Random-mode-only validation.  Yaml mode rejects the empty case
-    // inside `topology::build_from_raw` instead.
-    if let TopologySource::Random {
-        num_nodes,
-        min_latency_ms,
-        max_latency_ms,
-        ..
-    } = &config.topology_source
-    {
-        if *num_nodes == 0 {
-            return Err("num_nodes must be at least 1".into());
+    // Mode-specific validation.  Only the selected mode's section is checked;
+    // the other section is ignored even if populated.
+    match config.topology_source {
+        TopologySource::Random => {
+            let random = &config.topology_random;
+            if random.num_nodes == 0 {
+                return Err("num_nodes must be at least 1".into());
+            }
+            if random.min_latency_ms > random.max_latency_ms {
+                return Err("min_latency_ms must be <= max_latency_ms".into());
+            }
         }
-        if min_latency_ms > max_latency_ms {
-            return Err("min_latency_ms must be <= max_latency_ms".into());
+        TopologySource::Yaml => {
+            if config.topology_yaml.path.is_empty() {
+                return Err(
+                    "topology_yaml.path must be set when topology_source = \"yaml\"".into(),
+                );
+            }
         }
     }
 
@@ -504,10 +504,8 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = ClusterConfig::default();
-        let random = config
-            .topology_source
-            .as_random()
-            .expect("default is random");
+        assert_eq!(config.topology_source, TopologySource::Random);
+        let random = &config.topology_random;
         assert_eq!(random.num_nodes, 5);
         assert_eq!(random.degree, 3);
         assert_eq!(random.min_latency_ms, 5);
@@ -541,12 +539,10 @@ mod tests {
         assert!(config.behaviour_selection.is_none());
         assert!(config.external_peers.is_empty());
 
-        // topology_source defaults to Random with all variant fields at
-        // their per-field defaults.
-        let random = config
-            .topology_source
-            .as_random()
-            .expect("default topology_source is random");
+        // topology_source defaults to Random with the [topology_random]
+        // section's fields at their per-field defaults.
+        assert_eq!(config.topology_source, TopologySource::Random);
+        let random = &config.topology_random;
         assert_eq!(random.num_nodes, 5);
         assert_eq!(random.degree, 3);
         assert_eq!(random.min_latency_ms, 5);
@@ -564,9 +560,9 @@ mod tests {
             r#"
 base_config = "mainnet.toml"
 seed = 123
+topology_source = "random"
 
-[topology_source]
-type = "random"
+[topology_random]
 num_nodes = 8
 degree = 4
 "#
@@ -574,9 +570,9 @@ degree = 4
         .unwrap();
 
         let config = load(path.to_str().unwrap(), &[]).unwrap();
-        let random = config.topology_source.as_random().expect("random mode");
-        assert_eq!(random.num_nodes, 8);
-        assert_eq!(random.degree, 4);
+        assert_eq!(config.topology_source, TopologySource::Random);
+        assert_eq!(config.topology_random.num_nodes, 8);
+        assert_eq!(config.topology_random.degree, 4);
         assert_eq!(config.seed, Some(123));
         // Defaults should fill in the rest.
         assert_eq!(config.aggregator_port, 9100);
@@ -591,21 +587,21 @@ degree = 4
             f,
             r#"
 base_config = "mainnet.toml"
+topology_source = "random"
 
-[topology_source]
-type = "random"
+[topology_random]
 num_nodes = 3
 "#
         )
         .unwrap();
 
-        // --set drills into the topology_source table by dotted key.
+        // --set drills into the [topology_random] table by dotted key.
         let config = load(
             path.to_str().unwrap(),
-            &["topology_source.num_nodes=10".to_string()],
+            &["topology_random.num_nodes=10".to_string()],
         )
         .unwrap();
-        assert_eq!(config.topology_source.as_random().unwrap().num_nodes, 10);
+        assert_eq!(config.topology_random.num_nodes, 10);
     }
 
     #[test]
@@ -617,9 +613,9 @@ num_nodes = 3
             f,
             r#"
 base_config = "mainnet.toml"
+topology_source = "random"
 
-[topology_source]
-type = "random"
+[topology_random]
 num_nodes = 0
 "#
         )
@@ -630,10 +626,10 @@ num_nodes = 0
     }
 
     #[test]
-    fn test_yaml_rejects_random_fields() {
-        // Schema-level rejection: `degree` is meaningless under
-        // `type = "yaml"`, so the parse must fail rather than silently
-        // ignore it.  This is the core invariant of the refactor.
+    fn test_yaml_section_rejects_unknown_fields() {
+        // `deny_unknown_fields` on YamlTopologyConfig still catches typos and
+        // stray keys: `degree` is meaningless in [topology_yaml], so the parse
+        // must fail rather than silently ignore it.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.toml");
         let mut f = std::fs::File::create(&path).unwrap();
@@ -641,9 +637,9 @@ num_nodes = 0
             f,
             r#"
 base_config = "mainnet.toml"
+topology_source = "yaml"
 
-[topology_source]
-type = "yaml"
+[topology_yaml]
 path = "topology.yaml"
 degree = 7
 "#
@@ -659,8 +655,8 @@ degree = 7
     }
 
     #[test]
-    fn test_random_rejects_yaml_fields() {
-        // Symmetric: `path` is meaningless under `type = "random"`.
+    fn test_random_section_rejects_unknown_fields() {
+        // Symmetric: `path` is meaningless in [topology_random].
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.toml");
         let mut f = std::fs::File::create(&path).unwrap();
@@ -668,9 +664,9 @@ degree = 7
             f,
             r#"
 base_config = "mainnet.toml"
+topology_source = "random"
 
-[topology_source]
-type = "random"
+[topology_random]
 num_nodes = 5
 path = "topology.yaml"
 "#
@@ -683,5 +679,35 @@ path = "topology.yaml"
             msg.contains("path") || msg.contains("unknown field"),
             "expected unknown-field error mentioning 'path', got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_unused_section_is_ignored() {
+        // Accepted tradeoff of the flat layout: a fully-valid but unused
+        // section is silently ignored.  Here YAML mode is selected, but a
+        // populated [topology_random] section is present — it must not cause
+        // an error, and the YAML path must still take effect.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mixed.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+base_config = "mainnet.toml"
+topology_source = "yaml"
+
+[topology_random]
+num_nodes = 99
+degree = 7
+
+[topology_yaml]
+path = "topology.yaml"
+"#
+        )
+        .unwrap();
+
+        let config = load(path.to_str().unwrap(), &[]).expect("unused section is ignored");
+        assert_eq!(config.topology_source, TopologySource::Yaml);
+        assert_eq!(config.topology_yaml.path, "topology.yaml");
     }
 }

--- a/net-rs/net-cluster/src/config.rs
+++ b/net-rs/net-cluster/src/config.rs
@@ -33,23 +33,64 @@ pub struct ClusterControlConfig {
     pub node_config: std::collections::HashMap<String, serde_json::Value>,
 }
 
+/// Where the cluster topology comes from.
+///
+/// Defaults to [`TopologySource::Random`] (the historical behaviour) so
+/// existing TOML configs that don't mention `topology_source` continue to
+/// generate a random graph from `num_nodes`/`degree`/`min_latency_ms`/
+/// `max_latency_ms`.
+///
+/// Selecting [`TopologySource::Yaml`] loads `data/simulation/pseudo-mainnet/
+/// topology-v*.yaml`-style files (same schema as sim-rs and topology-checker).
+/// In YAML mode the `num_nodes`/`degree`/`min_latency_ms`/`max_latency_ms`
+/// fields are **ignored** — node count comes from the YAML (optionally
+/// capped by `node_limit`), edges come from the YAML's `producers` arrays,
+/// and per-link latencies come from `latency-ms`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TopologySource {
+    /// Generate a random connected graph (`num_nodes`, `degree`,
+    /// `min/max_latency_ms`).
+    #[default]
+    Random,
+    /// Load a YAML topology (v3/v4 schema).  `path` is interpreted
+    /// relative to the process's current directory at startup.
+    Yaml {
+        path: String,
+        /// Optional cap: load only the first `node_limit` nodes from the
+        /// YAML (in YAML insertion order; the v4 generator orders by
+        /// stake-rank descending, so this is effectively top-N by stake).
+        /// `None` loads every node — beware, v4-mainnet has 2,685 nodes
+        /// and average degree ~70, which is impractical for a local
+        /// process-per-node cluster.
+        #[serde(default)]
+        node_limit: Option<usize>,
+    },
+}
+
 /// Top-level cluster configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterConfig {
-    /// Number of net-node instances to spawn.
+    /// Number of net-node instances to spawn (random topology only;
+    /// overwritten by the loaded node count when `topology_source` is
+    /// `yaml`).
     pub num_nodes: usize,
 
-    /// Target number of peers per node.
+    /// Target number of peers per node (random topology only).
     #[serde(default = "default_degree")]
     pub degree: usize,
 
-    /// Minimum simulated link latency (ms).
+    /// Minimum simulated link latency (ms) (random topology only).
     #[serde(default = "default_min_latency")]
     pub min_latency_ms: u64,
 
-    /// Maximum simulated link latency (ms).
+    /// Maximum simulated link latency (ms) (random topology only).
     #[serde(default = "default_max_latency")]
     pub max_latency_ms: u64,
+
+    /// Where the topology comes from.  See [`TopologySource`].
+    #[serde(default)]
+    pub topology_source: TopologySource,
 
     /// Path to the base net-node config (e.g. "net-node/configs/mainnet.toml").
     pub base_config: String,
@@ -169,6 +210,7 @@ impl Default for ClusterConfig {
             behaviour: None,
             behaviour_selection: None,
             external_peers: Vec::new(),
+            topology_source: TopologySource::default(),
         }
     }
 }

--- a/net-rs/net-cluster/src/main.rs
+++ b/net-rs/net-cluster/src/main.rs
@@ -374,12 +374,15 @@ fn build_topology(
     current_config: &config::ClusterConfig,
     total_stake: u64,
 ) -> Result<topology::Topology, Box<dyn std::error::Error + Send + Sync>> {
-    match &current_config.topology_source {
-        config::TopologySource::Random { .. } => {
-            Ok(topology::generate(current_config, total_stake))
-        }
-        config::TopologySource::Yaml { path, node_limit } => {
-            topology::load_from_yaml(current_config, std::path::Path::new(path), *node_limit)
+    match current_config.topology_source {
+        config::TopologySource::Random => Ok(topology::generate_random(current_config, total_stake)),
+        config::TopologySource::Yaml => {
+            let yaml = &current_config.topology_yaml;
+            topology::load_from_yaml(
+                current_config,
+                std::path::Path::new(&yaml.path),
+                yaml.node_limit,
+            )
         }
     }
 }
@@ -388,27 +391,25 @@ fn build_topology(
 /// topology source: in random mode we surface the graph-gen knobs; in YAML
 /// mode we surface the path / limit instead.
 fn log_cluster_config_summary(config: &config::ClusterConfig) {
-    match &config.topology_source {
-        config::TopologySource::Random {
-            num_nodes,
-            degree,
-            min_latency_ms,
-            max_latency_ms,
-            ..
-        } => {
+    match config.topology_source {
+        config::TopologySource::Random => {
+            let r = &config.topology_random;
             tracing::info!(
                 "loaded cluster config: random topology, {} nodes, degree={}, latency={}–{}ms, ports {}–{}",
-                num_nodes,
-                degree,
-                min_latency_ms,
-                max_latency_ms,
+                r.num_nodes,
+                r.degree,
+                r.min_latency_ms,
+                r.max_latency_ms,
                 config.base_port,
-                config.base_port + num_nodes.saturating_sub(1) as u16,
+                config.base_port + r.num_nodes.saturating_sub(1) as u16,
             );
         }
-        config::TopologySource::Yaml { path, node_limit } => {
+        config::TopologySource::Yaml => {
+            let y = &config.topology_yaml;
             tracing::info!(
-                "loaded cluster config: YAML topology from {path}, node_limit={node_limit:?}, base_port={}",
+                "loaded cluster config: YAML topology from {}, node_limit={:?}, base_port={}",
+                y.path,
+                y.node_limit,
                 config.base_port,
             );
         }

--- a/net-rs/net-cluster/src/main.rs
+++ b/net-rs/net-cluster/src/main.rs
@@ -8,6 +8,7 @@ mod aggregator;
 mod config;
 mod overlay;
 mod process;
+mod raw_topology;
 mod server;
 mod topology;
 mod types;
@@ -106,21 +107,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Step 1: Load cluster config.
     let mut current_config = config::load(&cli.config, &cli.set)?;
-    tracing::info!(
-        "loaded cluster config: {} nodes, degree={}, latency={}–{}ms, ports {}–{}",
-        current_config.num_nodes,
-        current_config.degree,
-        current_config.min_latency_ms,
-        current_config.max_latency_ms,
-        current_config.base_port,
-        current_config.base_port + current_config.num_nodes as u16 - 1,
-    );
+    log_cluster_config_summary(&current_config);
 
-    // Step 2: Read total_stake from the base config.
+    // Step 2: Read total_stake from the base config (random topology only;
+    // YAML mode uses per-node stakes directly).
     let total_stake = read_total_stake(&current_config.base_config)?;
 
-    // Step 3: Generate initial topology.
-    let topo = topology::generate(&current_config, total_stake);
+    // Step 3: Build initial topology (random graph or YAML, depending on
+    // `topology_source`).  YAML mode overwrites `num_nodes` with the
+    // actual node count loaded so downstream code (port allocation,
+    // control_fields, the REST API) sees a consistent value.
+    let topo = build_topology(&mut current_config, total_stake)?;
     log_topology(&topo);
 
     // Step 4: Create shared event window, restart channel, and start HTTP server.
@@ -229,7 +226,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
                 // Generate new topology and update server state.
                 let new_total_stake = read_total_stake(&current_config.base_config)?;
-                let new_topo = topology::generate(&current_config, new_total_stake);
+                let new_topo = build_topology(&mut current_config, new_total_stake)?;
                 log_topology(&new_topo);
 
                 // Build control config with current node_config for the UI.
@@ -361,6 +358,65 @@ fn dotted_keys_to_dynamic_config(
         update.insert(field.to_string(), value.clone());
     }
     serde_json::Value::Object(update)
+}
+
+/// Dispatch on `current_config.topology_source` and build the cluster topology.
+///
+/// In YAML mode the loaded node count overwrites `current_config.num_nodes`
+/// so port allocation (`base_port + num_nodes`), the REST API, and overlay
+/// generation all see the same value downstream.
+fn build_topology(
+    current_config: &mut config::ClusterConfig,
+    total_stake: u64,
+) -> Result<topology::Topology, Box<dyn std::error::Error + Send + Sync>> {
+    match current_config.topology_source.clone() {
+        config::TopologySource::Random => Ok(topology::generate(current_config, total_stake)),
+        config::TopologySource::Yaml { path, node_limit } => {
+            let topo =
+                topology::load_from_yaml(current_config, std::path::Path::new(&path), node_limit)?;
+            // Reconcile num_nodes with the YAML-loaded count.  The user's
+            // num_nodes (if any) is now meaningless in YAML mode and is
+            // overridden silently — we log so it's obvious which value
+            // is actually in effect.
+            let loaded = topo.nodes.len();
+            if current_config.num_nodes != loaded {
+                tracing::info!(
+                    yaml_path = %path,
+                    config_num_nodes = current_config.num_nodes,
+                    loaded_num_nodes = loaded,
+                    node_limit = ?node_limit,
+                    "YAML topology: overriding num_nodes with loaded node count"
+                );
+                current_config.num_nodes = loaded;
+            }
+            Ok(topo)
+        }
+    }
+}
+
+/// Log a one-line summary of the cluster config at startup.  Splits on
+/// topology source: in random mode we surface the graph-gen knobs; in YAML
+/// mode we surface the path / limit instead (those knobs are ignored).
+fn log_cluster_config_summary(config: &config::ClusterConfig) {
+    match &config.topology_source {
+        config::TopologySource::Random => {
+            tracing::info!(
+                "loaded cluster config: random topology, {} nodes, degree={}, latency={}–{}ms, ports {}–{}",
+                config.num_nodes,
+                config.degree,
+                config.min_latency_ms,
+                config.max_latency_ms,
+                config.base_port,
+                config.base_port + config.num_nodes.saturating_sub(1) as u16,
+            );
+        }
+        config::TopologySource::Yaml { path, node_limit } => {
+            tracing::info!(
+                "loaded cluster config: YAML topology from {path}, node_limit={node_limit:?}, base_port={}",
+                config.base_port,
+            );
+        }
+    }
 }
 
 fn log_topology(topo: &topology::Topology) {

--- a/net-rs/net-cluster/src/main.rs
+++ b/net-rs/net-cluster/src/main.rs
@@ -114,10 +114,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let total_stake = read_total_stake(&current_config.base_config)?;
 
     // Step 3: Build initial topology (random graph or YAML, depending on
-    // `topology_source`).  YAML mode overwrites `num_nodes` with the
-    // actual node count loaded so downstream code (port allocation,
-    // control_fields, the REST API) sees a consistent value.
-    let topo = build_topology(&mut current_config, total_stake)?;
+    // `topology_source`).  The Topology is now the single source of
+    // truth for node count; main.rs reads `topo.nodes.len()` rather
+    // than carrying a redundant `num_nodes` on the config.
+    let topo = build_topology(&current_config, total_stake)?;
     log_topology(&topo);
 
     // Step 4: Create shared event window, restart channel, and start HTTP server.
@@ -147,7 +147,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Step 5: Spawn the aggregator task (persists across restarts).
     let output_path = PathBuf::from(&current_config.output_events);
-    let num_nodes = current_config.num_nodes;
+    let num_nodes = topo.nodes.len();
     let ordering_window = current_config.ordering_window_secs;
     let agg_window = event_window.clone();
     let aggregator_handle = tokio::spawn(async move {
@@ -226,7 +226,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
                 // Generate new topology and update server state.
                 let new_total_stake = read_total_stake(&current_config.base_config)?;
-                let new_topo = build_topology(&mut current_config, new_total_stake)?;
+                let new_topo = build_topology(&current_config, new_total_stake)?;
                 log_topology(&new_topo);
 
                 // Build control config with current node_config for the UI.
@@ -306,7 +306,10 @@ async fn handle_attack_command(
                 return;
             }
             let update_json = serde_json::json!({ "behaviour": request.behaviour });
-            cluster.pm.send_config_update_to(&indices, &update_json).await;
+            cluster
+                .pm
+                .send_config_update_to(&indices, &update_json)
+                .await;
 
             let started_at_s = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -362,52 +365,45 @@ fn dotted_keys_to_dynamic_config(
 
 /// Dispatch on `current_config.topology_source` and build the cluster topology.
 ///
-/// In YAML mode the loaded node count overwrites `current_config.num_nodes`
-/// so port allocation (`base_port + num_nodes`), the REST API, and overlay
-/// generation all see the same value downstream.
+/// Random mode reads the random-variant params straight off the enum;
+/// YAML mode reads `path` / `node_limit`.  Either way the resulting
+/// `Topology` is the single source of truth for downstream node count
+/// (port allocation, overlay generation, the REST API) — no separate
+/// `num_nodes` field exists on `ClusterConfig` any more.
 fn build_topology(
-    current_config: &mut config::ClusterConfig,
+    current_config: &config::ClusterConfig,
     total_stake: u64,
 ) -> Result<topology::Topology, Box<dyn std::error::Error + Send + Sync>> {
-    match current_config.topology_source.clone() {
-        config::TopologySource::Random => Ok(topology::generate(current_config, total_stake)),
+    match &current_config.topology_source {
+        config::TopologySource::Random { .. } => {
+            Ok(topology::generate(current_config, total_stake))
+        }
         config::TopologySource::Yaml { path, node_limit } => {
-            let topo =
-                topology::load_from_yaml(current_config, std::path::Path::new(&path), node_limit)?;
-            // Reconcile num_nodes with the YAML-loaded count.  The user's
-            // num_nodes (if any) is now meaningless in YAML mode and is
-            // overridden silently — we log so it's obvious which value
-            // is actually in effect.
-            let loaded = topo.nodes.len();
-            if current_config.num_nodes != loaded {
-                tracing::info!(
-                    yaml_path = %path,
-                    config_num_nodes = current_config.num_nodes,
-                    loaded_num_nodes = loaded,
-                    node_limit = ?node_limit,
-                    "YAML topology: overriding num_nodes with loaded node count"
-                );
-                current_config.num_nodes = loaded;
-            }
-            Ok(topo)
+            topology::load_from_yaml(current_config, std::path::Path::new(path), *node_limit)
         }
     }
 }
 
 /// Log a one-line summary of the cluster config at startup.  Splits on
 /// topology source: in random mode we surface the graph-gen knobs; in YAML
-/// mode we surface the path / limit instead (those knobs are ignored).
+/// mode we surface the path / limit instead.
 fn log_cluster_config_summary(config: &config::ClusterConfig) {
     match &config.topology_source {
-        config::TopologySource::Random => {
+        config::TopologySource::Random {
+            num_nodes,
+            degree,
+            min_latency_ms,
+            max_latency_ms,
+            ..
+        } => {
             tracing::info!(
                 "loaded cluster config: random topology, {} nodes, degree={}, latency={}–{}ms, ports {}–{}",
-                config.num_nodes,
-                config.degree,
-                config.min_latency_ms,
-                config.max_latency_ms,
+                num_nodes,
+                degree,
+                min_latency_ms,
+                max_latency_ms,
                 config.base_port,
-                config.base_port + config.num_nodes.saturating_sub(1) as u16,
+                config.base_port + num_nodes.saturating_sub(1) as u16,
             );
         }
         config::TopologySource::Yaml { path, node_limit } => {

--- a/net-rs/net-cluster/src/overlay.rs
+++ b/net-rs/net-cluster/src/overlay.rs
@@ -249,9 +249,8 @@ mod tests {
         // A node with a behaviour spec should emit a `[behaviour]` table
         // that round-trips through the toml parser.
         let mut node = sample_node();
-        node.behaviour = Some(
-            shared_consensus::behaviour::BehaviourSpec::RbHeaderEquivocator { ways: 2 },
-        );
+        node.behaviour =
+            Some(shared_consensus::behaviour::BehaviourSpec::RbHeaderEquivocator { ways: 2 });
         let toml_str = render_overlay(&node, 9100, 5, 1, &[]);
         let parsed: toml::Value = toml::from_str(&toml_str).expect("generated TOML should parse");
         assert_eq!(

--- a/net-rs/net-cluster/src/overlay.rs
+++ b/net-rs/net-cluster/src/overlay.rs
@@ -60,6 +60,7 @@ pub fn generate_overlays(
             aggregator_port,
             stats_interval_secs,
             num_nodes,
+            topology.total_stake,
             &stake_registry,
         );
         let path = temp_dir.join(format!("node-{}.toml", node.index));
@@ -80,6 +81,7 @@ fn render_overlay(
     aggregator_port: u16,
     stats_interval_secs: u64,
     num_nodes: usize,
+    total_stake: u64,
     stake_registry: &[(String, u64)],
 ) -> String {
     let mut s = String::new();
@@ -92,6 +94,10 @@ fn render_overlay(
     writeln!(s).ok();
     writeln!(s, "[production]").ok();
     writeln!(s, "stake = {}", node.stake).ok();
+    // Override the base config's `total_stake` with the cluster's actual
+    // sum-of-stakes so the Praos lottery threshold uses the right ratio.
+    // See `Topology::total_stake` for the rationale.
+    writeln!(s, "total_stake = {total_stake}").ok();
     writeln!(s).ok();
     for (id, stake) in stake_registry {
         writeln!(s, "[[production.stake_registry]]").ok();
@@ -200,7 +206,7 @@ mod tests {
     #[test]
     fn test_render_overlay() {
         let node = sample_node();
-        let toml = render_overlay(&node, 9100, 5, 5, &[]);
+        let toml = render_overlay(&node, 9100, 5, 5, 500, &[]);
 
         assert!(toml.contains("node_id = \"node-0\""));
         assert!(toml.contains("listen_address = \"127.0.0.1:30000\""));
@@ -219,9 +225,27 @@ mod tests {
     #[test]
     fn test_render_parses_as_toml() {
         let node = sample_node();
-        let toml_str = render_overlay(&node, 9100, 5, 5, &[]);
+        let toml_str = render_overlay(&node, 9100, 5, 5, 500, &[]);
         let parsed: toml::Value = toml::from_str(&toml_str).expect("generated TOML should parse");
         assert_eq!(parsed["node_id"].as_str(), Some("node-0"));
+    }
+
+    #[test]
+    fn test_render_overlay_writes_total_stake() {
+        // The cluster-level total_stake must land in `[production]
+        // total_stake` so it overrides the base config (where
+        // `mainnet.toml` carries the synthetic `1000`).  Without this
+        // override, YAML-loaded clusters saturate the Praos lottery
+        // because every node's stake/total_stake ratio is huge.
+        let node = sample_node();
+        let toml_str = render_overlay(&node, 9100, 5, 5, 1_982_130_062, &[]);
+        let parsed: toml::Value = toml::from_str(&toml_str).expect("generated TOML should parse");
+        assert_eq!(
+            parsed["production"]["total_stake"].as_integer(),
+            Some(1_982_130_062)
+        );
+        // Per-node stake stays separate.
+        assert_eq!(parsed["production"]["stake"].as_integer(), Some(500));
     }
 
     #[test]
@@ -232,7 +256,7 @@ mod tests {
             ("node-1".to_string(), 300u64),
             ("node-2".to_string(), 0u64),
         ];
-        let toml_str = render_overlay(&node, 9100, 5, 3, &registry);
+        let toml_str = render_overlay(&node, 9100, 5, 3, 800, &registry);
         let parsed: toml::Value = toml::from_str(&toml_str).expect("generated TOML should parse");
         let entries = parsed["production"]["stake_registry"]
             .as_array()
@@ -251,7 +275,7 @@ mod tests {
         let mut node = sample_node();
         node.behaviour =
             Some(shared_consensus::behaviour::BehaviourSpec::RbHeaderEquivocator { ways: 2 });
-        let toml_str = render_overlay(&node, 9100, 5, 1, &[]);
+        let toml_str = render_overlay(&node, 9100, 5, 1, 500, &[]);
         let parsed: toml::Value = toml::from_str(&toml_str).expect("generated TOML should parse");
         assert_eq!(
             parsed["behaviour"]["kind"].as_str(),
@@ -267,7 +291,7 @@ mod tests {
         // honest path stays implicit; net-node falls through to
         // HonestBehaviour).
         let node = sample_node();
-        let toml_str = render_overlay(&node, 9100, 5, 1, &[]);
+        let toml_str = render_overlay(&node, 9100, 5, 1, 500, &[]);
         assert!(
             !toml_str.contains("[behaviour]"),
             "expected no behaviour section, got: {toml_str}"
@@ -279,6 +303,7 @@ mod tests {
         let topo = crate::topology::Topology {
             nodes: vec![sample_node()],
             edges: Vec::new(),
+            total_stake: 500,
         };
         let dir = tempfile::tempdir().unwrap();
         let overlays = generate_overlays(&topo, dir.path(), 9100, 5, &HashMap::new()).unwrap();

--- a/net-rs/net-cluster/src/raw_topology.rs
+++ b/net-rs/net-cluster/src/raw_topology.rs
@@ -1,0 +1,204 @@
+//! YAML topology parser.
+//!
+//! Mirrors the on-disk schema used by `sim-rs`, `topology-checker`, and the
+//! `data/simulation/pseudo-mainnet/topology-v*.yaml` files:
+//!
+//! ```yaml
+//! nodes:
+//!   node-0:
+//!     stake: 12345
+//!     location: [10.05, 49.70]      # (lon, lat) — ignored by net-cluster
+//!     cpu-core-count: 4              # ignored by net-cluster
+//!     producers:
+//!       node-1:
+//!         latency-ms: 45.3
+//!         bandwidth-bytes-per-second: 125000000   # ignored in v1
+//! ```
+//!
+//! Only the fields net-cluster needs (`stake`, `producers[*].latency-ms`)
+//! drive behaviour; the rest are accepted-and-ignored so we can ingest the
+//! existing topology YAMLs without surgery.
+
+use std::path::Path;
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+/// Raw YAML topology, as produced by the v3/v4 generators.
+#[derive(Debug, Deserialize)]
+pub struct RawTopology {
+    /// Node-id → node entry.  Uses `IndexMap` to preserve **YAML insertion
+    /// order**, which is load-bearing: the v4 generator emits nodes in
+    /// stake-rank-descending order (`node-0` = highest stake, `node-2684`
+    /// = lowest), and our `node_limit` semantics rely on that to behave
+    /// as "first-N by YAML order ≈ top-N by stake".
+    ///
+    /// A `BTreeMap` here would iterate **lexicographically**
+    /// (`node-0, node-1, node-10, node-100, …, node-2`) which silently
+    /// breaks the top-N invariant — see the regression test
+    /// `numeric_node_ids_preserve_yaml_order` below.
+    pub nodes: IndexMap<String, RawNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawNode {
+    /// Stake (lovelace-equivalent).  Defaults to 0 for relays / pure
+    /// consumers that the YAML omits the field for.
+    #[serde(default)]
+    pub stake: u64,
+
+    /// Geographic placement.  Ignored by net-cluster (localhost ports
+    /// don't model geography); kept for round-trip parsing.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub location: Option<RawNodeLocation>,
+
+    /// CPU core count.  Currently unused.
+    #[serde(default, rename = "cpu-core-count")]
+    #[allow(dead_code)]
+    pub cpu_core_count: Option<u32>,
+
+    /// Outbound producer edges with per-link latency / bandwidth.
+    /// Insertion-ordered to match the rest of the YAML faithfully.
+    #[serde(default)]
+    pub producers: IndexMap<String, RawLinkInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+#[allow(dead_code)]
+pub enum RawNodeLocation {
+    /// Symbolic cluster name (older v1/v2 YAMLs).
+    Cluster { cluster: String },
+    /// `[lon, lat]` literal coordinates (v3/v4 YAMLs).
+    Coords([f64; 2]),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawLinkInfo {
+    #[serde(rename = "latency-ms")]
+    pub latency_ms: f64,
+
+    /// Per-link bandwidth.  Honouring this requires per-peer shaping in
+    /// `net-core`'s coordinator, which doesn't exist today — the loader
+    /// logs a one-time warning when any link carries a value and then
+    /// ignores it.
+    #[serde(default, rename = "bandwidth-bytes-per-second")]
+    pub bandwidth_bytes_per_second: Option<u64>,
+}
+
+/// Read a topology YAML from disk and parse it.
+pub fn load_from_path(
+    path: &Path,
+) -> Result<RawTopology, Box<dyn std::error::Error + Send + Sync>> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read topology YAML at {}: {e}", path.display()))?;
+    let raw: RawTopology = serde_yaml::from_str(&content)
+        .map_err(|e| format!("failed to parse topology YAML at {}: {e}", path.display()))?;
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+nodes:
+  node-0:
+    stake: 100
+    location: [10.0, 49.7]
+    cpu-core-count: 4
+    producers:
+      node-1:
+        latency-ms: 45.3
+        bandwidth-bytes-per-second: 125000000
+      node-2:
+        latency-ms: 12.0
+  node-1:
+    stake: 0
+    location: [-77.5, 38.9]
+    producers:
+      node-0:
+        latency-ms: 45.3
+  node-2:
+    stake: 200
+    location:
+      cluster: "us-east"
+    producers: {}
+"#;
+
+    #[test]
+    fn parses_v4_style_yaml() {
+        let raw: RawTopology = serde_yaml::from_str(SAMPLE).unwrap();
+        assert_eq!(raw.nodes.len(), 3);
+
+        let n0 = &raw.nodes["node-0"];
+        assert_eq!(n0.stake, 100);
+        assert_eq!(n0.cpu_core_count, Some(4));
+        assert_eq!(n0.producers.len(), 2);
+        assert!((n0.producers["node-1"].latency_ms - 45.3).abs() < 1e-9);
+        assert_eq!(
+            n0.producers["node-1"].bandwidth_bytes_per_second,
+            Some(125_000_000)
+        );
+        assert_eq!(n0.producers["node-2"].bandwidth_bytes_per_second, None);
+    }
+
+    #[test]
+    fn defaults_missing_stake_to_zero() {
+        let raw: RawTopology = serde_yaml::from_str(SAMPLE).unwrap();
+        assert_eq!(raw.nodes["node-1"].stake, 0);
+    }
+
+    #[test]
+    fn parses_cluster_location() {
+        // Older v1/v2 YAMLs use `location: { cluster: "..." }` instead of
+        // a `[lon, lat]` array.  We accept both for forward compat.
+        let raw: RawTopology = serde_yaml::from_str(SAMPLE).unwrap();
+        assert!(raw.nodes["node-2"].location.is_some());
+    }
+
+    #[test]
+    fn missing_producers_section_is_empty() {
+        let raw: RawTopology = serde_yaml::from_str("nodes:\n  solo: {}\n").unwrap();
+        assert_eq!(raw.nodes.len(), 1);
+        assert!(raw.nodes["solo"].producers.is_empty());
+        assert_eq!(raw.nodes["solo"].stake, 0);
+    }
+
+    /// Regression test for the lexicographic-vs-insertion-order bug.
+    ///
+    /// The v4 YAMLs use IDs like `node-0`, `node-1`, …, `node-2684` in
+    /// **stake-rank-descending** insertion order.  A `BTreeMap` would
+    /// iterate them lexicographically (`node-0, node-1, node-10, node-100,
+    /// …, node-2, node-20, …`), silently breaking `node_limit` semantics.
+    ///
+    /// This test pins the iteration to YAML order regardless of how the
+    /// IDs sort as strings.
+    #[test]
+    fn numeric_node_ids_preserve_yaml_order() {
+        // Twelve nodes in *insertion* order: 0, 1, 2, …, 11.
+        // Lexicographic order would be: 0, 1, 10, 11, 2, 3, …, 9.
+        let yaml = (0..12)
+            .map(|i| {
+                format!(
+                    "  node-{i}:\n    stake: {}\n    producers: {{}}\n",
+                    1000 - i
+                )
+            })
+            .collect::<String>();
+        let raw: RawTopology = serde_yaml::from_str(&format!("nodes:\n{yaml}")).unwrap();
+        let ids: Vec<&str> = raw.nodes.keys().map(String::as_str).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "node-0", "node-1", "node-2", "node-3", "node-4", "node-5", "node-6", "node-7",
+                "node-8", "node-9", "node-10", "node-11",
+            ],
+            "iteration must follow YAML insertion order, not lexicographic"
+        );
+        // And the corresponding stakes are descending, as in v4.
+        let stakes: Vec<u64> = raw.nodes.values().map(|n| n.stake).collect();
+        assert!(stakes.windows(2).all(|w| w[0] > w[1]));
+    }
+}

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -611,6 +611,8 @@ mod tests {
             attack_tx,
             current_config: RwLock::new(ClusterControlConfig {
                 topology_source: None,
+                topology_random: None,
+                topology_yaml: None,
                 seed: None,
                 node_config: HashMap::new(),
             }),

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -602,6 +602,7 @@ mod tests {
             topology: RwLock::new(Topology {
                 nodes: Vec::new(),
                 edges: Vec::new(),
+                total_stake: 0,
             }),
             event_window,
             event_broadcast,

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -610,10 +610,7 @@ mod tests {
             update_tx,
             attack_tx,
             current_config: RwLock::new(ClusterControlConfig {
-                num_nodes: Some(5),
-                degree: Some(3),
-                min_latency_ms: Some(5),
-                max_latency_ms: Some(300),
+                topology_source: None,
                 seed: None,
                 node_config: HashMap::new(),
             }),

--- a/net-rs/net-cluster/src/topology.rs
+++ b/net-rs/net-cluster/src/topology.rs
@@ -69,6 +69,21 @@ pub struct Edge {
 pub struct Topology {
     pub nodes: Vec<NodeTopology>,
     pub edges: Vec<Edge>,
+    /// Sum of `nodes[*].stake` — written into each per-node overlay TOML
+    /// as `production.total_stake` so the Praos lottery threshold
+    /// (`stake_i / total_stake`) is computed against the cluster's
+    /// actual stake total rather than whatever value the base config
+    /// happens to carry.
+    ///
+    /// In random mode this equals the `total_stake` passed to
+    /// [`generate`] (the random `distribute_stake` is sum-preserving),
+    /// so behaviour is unchanged.  In YAML mode this is the sum of the
+    /// YAML's per-node `stake` fields, which is critical: a v4 YAML
+    /// carries real mainnet ADA values (~1e8 per pool), and if
+    /// `total_stake` stays at the base config's synthetic `1000` the
+    /// per-node win probability saturates and every node produces a
+    /// block every slot.
+    pub total_stake: u64,
 }
 
 /// Generate a random cluster topology from the given config.
@@ -138,7 +153,14 @@ pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
         }
     }
 
-    Topology { nodes, edges }
+    // `distribute_stake` is sum-preserving so this equals the input
+    // `total_stake`; recomputing keeps the invariant local.
+    let cluster_total_stake = nodes.iter().map(|n| n.stake).sum();
+    Topology {
+        nodes,
+        edges,
+        total_stake: cluster_total_stake,
+    }
 }
 
 /// Load a cluster topology from a v3/v4-style YAML file.
@@ -341,7 +363,16 @@ fn build_from_raw(
         }
     }
 
-    Ok(Topology { nodes, edges })
+    // Sum of the loaded per-node stakes — overwrites the base config's
+    // `total_stake`.  Critical for YAML mode where the YAML carries real
+    // mainnet ADA values; without this each node's `stake / total_stake`
+    // ratio explodes and the Praos lottery saturates.
+    let total_stake = nodes.iter().map(|n| n.stake).sum();
+    Ok(Topology {
+        nodes,
+        edges,
+        total_stake,
+    })
 }
 
 /// Build a random undirected graph with target degree, ensuring connectivity.
@@ -1146,6 +1177,40 @@ nodes:
         assert_eq!(topo.nodes.len(), 3);
         let stakes: Vec<u64> = topo.nodes.iter().map(|n| n.stake).collect();
         assert_eq!(stakes, vec![12_000, 11_000, 10_000]);
+    }
+
+    #[test]
+    fn yaml_total_stake_is_sum_of_loaded_stakes() {
+        // YAML mode must compute `total_stake` from the actual loaded
+        // nodes — not inherit the base config's value — so the Praos
+        // lottery ratio is sane.  The fixture has stakes 1000+500+0+250
+        // = 1750.
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, None).unwrap();
+        assert_eq!(topo.total_stake, 1750);
+    }
+
+    #[test]
+    fn yaml_total_stake_respects_node_limit() {
+        // With node_limit = 2, only the first two YAML nodes count
+        // toward total_stake.  Fixture: node-A (1000) + node-B (700).
+        // Wait — yaml_test_config uses the fixture with stakes
+        // 1000/500/0/250.  node_limit = 2 → 1000 + 500 = 1500.
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, Some(2)).unwrap();
+        assert_eq!(topo.total_stake, 1500);
+    }
+
+    #[test]
+    fn random_topology_total_stake_equals_input() {
+        // Sanity check for the random path: distribute_stake is
+        // sum-preserving, so Topology.total_stake should equal the
+        // input total_stake.
+        let config = test_config(5, 2);
+        let topo = generate(&config, 12_345);
+        assert_eq!(topo.total_stake, 12_345);
     }
 
     #[test]

--- a/net-rs/net-cluster/src/topology.rs
+++ b/net-rs/net-cluster/src/topology.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use rand::prelude::*;
 use serde::Serialize;
 
-use crate::config::{BehaviourSelection, ClusterConfig};
+use crate::config::{BehaviourSelection, ClusterConfig, TopologySource};
 use crate::raw_topology::{self, RawTopology};
 
 /// A peer link from one node to another.
@@ -89,19 +89,31 @@ pub struct Topology {
 /// Generate a random cluster topology from the given config.
 ///
 /// The `total_stake` parameter comes from the base config and is divided
-/// among nodes according to the stake distribution strategy.
+/// among nodes according to the stake distribution strategy.  The caller
+/// is responsible for ensuring `config.topology_source` is the `Random`
+/// variant.
 pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
-    let n = config.num_nodes;
+    let TopologySource::Random {
+        num_nodes,
+        degree,
+        min_latency_ms,
+        max_latency_ms,
+        stake_distribution,
+    } = &config.topology_source
+    else {
+        panic!("topology::generate called with non-Random topology_source");
+    };
+    let n = *num_nodes;
     let mut rng = match config.seed {
         Some(s) => StdRng::seed_from_u64(s),
         None => StdRng::from_entropy(),
     };
 
     // Step 1: Build random graph edges.
-    let edges = build_random_graph(n, config.degree, config, &mut rng);
+    let edges = build_random_graph(n, *degree, *min_latency_ms, *max_latency_ms, &mut rng);
 
     // Step 2: Distribute stake.
-    let stakes = distribute_stake(n, total_stake, &config.stake_distribution);
+    let stakes = distribute_stake(n, total_stake, stake_distribution);
 
     // Step 3: Build node topologies.
     let behaviour_set = resolve_behaviour_nodes(config, &stakes);
@@ -379,7 +391,8 @@ fn build_from_raw(
 fn build_random_graph(
     n: usize,
     degree: usize,
-    config: &ClusterConfig,
+    min_latency_ms: u64,
+    max_latency_ms: u64,
     rng: &mut StdRng,
 ) -> Vec<Edge> {
     if n <= 1 {
@@ -398,7 +411,7 @@ fn build_random_graph(
 
         let needed = degree.saturating_sub(adj[i].len());
         for &j in candidates.iter().take(needed) {
-            let latency = rng.gen_range(config.min_latency_ms..=config.max_latency_ms);
+            let latency = rng.gen_range(min_latency_ms..=max_latency_ms);
             adj[i].insert(j);
             adj[j].insert(i);
             edges.push(Edge {
@@ -416,7 +429,7 @@ fn build_random_graph(
             let a = pair[0][0];
             let b = pair[1][0];
             if !adj[a].contains(&b) {
-                let latency = rng.gen_range(config.min_latency_ms..=config.max_latency_ms);
+                let latency = rng.gen_range(min_latency_ms..=max_latency_ms);
                 adj[a].insert(b);
                 adj[b].insert(a);
                 edges.push(Edge {
@@ -630,10 +643,13 @@ mod tests {
 
     fn test_config(num_nodes: usize, degree: usize) -> ClusterConfig {
         ClusterConfig {
-            num_nodes,
-            degree,
-            min_latency_ms: 10,
-            max_latency_ms: 100,
+            topology_source: TopologySource::Random {
+                num_nodes,
+                degree,
+                min_latency_ms: 10,
+                max_latency_ms: 100,
+                stake_distribution: "equal".to_string(),
+            },
             base_config: "test.toml".to_string(),
             base_port: 30000,
             seed: Some(42),
@@ -969,8 +985,11 @@ nodes:
 "#;
 
     fn yaml_test_config() -> ClusterConfig {
+        // Note: when YAML mode is exercised through `build_from_raw` we
+        // don't actually need to set `topology_source = Yaml { .. }` —
+        // the loader doesn't read it — but we keep the default Random
+        // here so the rest of the ClusterConfig stays valid.
         ClusterConfig {
-            num_nodes: 4,
             base_config: "test.toml".to_string(),
             base_port: 31000,
             seed: Some(7),
@@ -1163,7 +1182,6 @@ nodes:
         let raw: crate::raw_topology::RawTopology = serde_yaml::from_str(&yaml).unwrap();
 
         let config = ClusterConfig {
-            num_nodes: 3,
             base_config: "test.toml".to_string(),
             base_port: 32000,
             seed: Some(7),

--- a/net-rs/net-cluster/src/topology.rs
+++ b/net-rs/net-cluster/src/topology.rs
@@ -2,7 +2,7 @@
 //!
 //! Two sources, selected by [`crate::config::TopologySource`]:
 //!
-//! - [`generate`] — random connected graph (legacy default); honours
+//! - [`generate_random`] — random connected graph (legacy default); honours
 //!   `num_nodes` / `degree` / `min_latency_ms` / `max_latency_ms` /
 //!   `stake_distribution`.
 //! - [`load_from_yaml`] — read a v3/v4-style topology YAML
@@ -21,7 +21,7 @@ use std::path::Path;
 use rand::prelude::*;
 use serde::Serialize;
 
-use crate::config::{BehaviourSelection, ClusterConfig, TopologySource};
+use crate::config::{BehaviourSelection, ClusterConfig};
 use crate::raw_topology::{self, RawTopology};
 
 /// A peer link from one node to another.
@@ -76,7 +76,7 @@ pub struct Topology {
     /// happens to carry.
     ///
     /// In random mode this equals the `total_stake` passed to
-    /// [`generate`] (the random `distribute_stake` is sum-preserving),
+    /// [`generate_random`] (the random `distribute_stake` is sum-preserving),
     /// so behaviour is unchanged.  In YAML mode this is the sum of the
     /// YAML's per-node `stake` fields, which is critical: a v4 YAML
     /// carries real mainnet ADA values (~1e8 per pool), and if
@@ -89,20 +89,17 @@ pub struct Topology {
 /// Generate a random cluster topology from the given config.
 ///
 /// The `total_stake` parameter comes from the base config and is divided
-/// among nodes according to the stake distribution strategy.  The caller
-/// is responsible for ensuring `config.topology_source` is the `Random`
-/// variant.
-pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
-    let TopologySource::Random {
+/// among nodes according to the stake distribution strategy.  Reads the
+/// random-mode knobs from `config.topology_random`; the caller selects this
+/// path when `config.topology_source` is `Random`.
+pub fn generate_random(config: &ClusterConfig, total_stake: u64) -> Topology {
+    let crate::config::RandomTopologyConfig {
         num_nodes,
         degree,
         min_latency_ms,
         max_latency_ms,
         stake_distribution,
-    } = &config.topology_source
-    else {
-        panic!("topology::generate called with non-Random topology_source");
-    };
+    } = &config.topology_random;
     let n = *num_nodes;
     let mut rng = match config.seed {
         Some(s) => StdRng::seed_from_u64(s),
@@ -178,7 +175,7 @@ pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
 /// Load a cluster topology from a v3/v4-style YAML file.
 ///
 /// The YAML is parsed into [`RawTopology`] (see [`crate::raw_topology`]) and
-/// then converted into the same [`Topology`] shape produced by [`generate`].
+/// then converted into the same [`Topology`] shape produced by [`generate_random`].
 /// Per-node fields:
 ///
 /// - `node_id`, `index`: synthesised as `node-{i}` over the loaded slice
@@ -643,7 +640,8 @@ mod tests {
 
     fn test_config(num_nodes: usize, degree: usize) -> ClusterConfig {
         ClusterConfig {
-            topology_source: TopologySource::Random {
+            topology_source: crate::config::TopologySource::Random,
+            topology_random: crate::config::RandomTopologyConfig {
                 num_nodes,
                 degree,
                 min_latency_ms: 10,
@@ -660,7 +658,7 @@ mod tests {
     #[test]
     fn test_single_node() {
         let config = test_config(1, 0);
-        let topo = generate(&config, 1000);
+        let topo = generate_random(&config, 1000);
         assert_eq!(topo.nodes.len(), 1);
         assert!(topo.edges.is_empty());
         assert_eq!(topo.nodes[0].stake, 1000);
@@ -669,7 +667,7 @@ mod tests {
     #[test]
     fn test_two_nodes() {
         let config = test_config(2, 1);
-        let topo = generate(&config, 1000);
+        let topo = generate_random(&config, 1000);
         assert_eq!(topo.nodes.len(), 2);
         assert!(!topo.edges.is_empty());
         // Directional: only the `from` node has a peer link.
@@ -680,7 +678,7 @@ mod tests {
     #[test]
     fn test_connectivity() {
         let config = test_config(10, 2);
-        let topo = generate(&config, 10000);
+        let topo = generate_random(&config, 10000);
 
         // Verify connectivity via BFS from node 0.
         let adj = build_adjacency(&topo);
@@ -691,7 +689,7 @@ mod tests {
     #[test]
     fn test_port_allocation() {
         let config = test_config(5, 2);
-        let topo = generate(&config, 5000);
+        let topo = generate_random(&config, 5000);
         for (i, node) in topo.nodes.iter().enumerate() {
             assert_eq!(node.listen_port, 30000 + i as u16);
             assert_eq!(node.node_id, format!("node-{i}"));
@@ -891,7 +889,7 @@ mod tests {
     #[test]
     fn test_latency_range() {
         let config = test_config(5, 3);
-        let topo = generate(&config, 5000);
+        let topo = generate_random(&config, 5000);
         for edge in &topo.edges {
             assert!(edge.latency_ms >= 10);
             assert!(edge.latency_ms <= 100);
@@ -901,8 +899,8 @@ mod tests {
     #[test]
     fn test_deterministic_with_seed() {
         let config = test_config(5, 2);
-        let topo1 = generate(&config, 5000);
-        let topo2 = generate(&config, 5000);
+        let topo1 = generate_random(&config, 5000);
+        let topo2 = generate_random(&config, 5000);
         assert_eq!(topo1.edges.len(), topo2.edges.len());
         for (e1, e2) in topo1.edges.iter().zip(topo2.edges.iter()) {
             assert_eq!(e1.from, e2.from);
@@ -920,7 +918,7 @@ mod tests {
                 address: "relay.example.com:3001".to_string(),
                 inject_into_nodes: 2,
             });
-        let topo = generate(&config, 5000);
+        let topo = generate_random(&config, 5000);
         let count = topo
             .nodes
             .iter()
@@ -986,9 +984,9 @@ nodes:
 
     fn yaml_test_config() -> ClusterConfig {
         // Note: when YAML mode is exercised through `build_from_raw` we
-        // don't actually need to set `topology_source = Yaml { .. }` —
-        // the loader doesn't read it — but we keep the default Random
-        // here so the rest of the ClusterConfig stays valid.
+        // don't actually need to set `topology_source = "yaml"` — the
+        // builder doesn't read it — but we keep the default Random here
+        // so the rest of the ClusterConfig stays valid.
         ClusterConfig {
             base_config: "test.toml".to_string(),
             base_port: 31000,
@@ -1227,7 +1225,7 @@ nodes:
         // sum-preserving, so Topology.total_stake should equal the
         // input total_stake.
         let config = test_config(5, 2);
-        let topo = generate(&config, 12_345);
+        let topo = generate_random(&config, 12_345);
         assert_eq!(topo.total_stake, 12_345);
     }
 

--- a/net-rs/net-cluster/src/topology.rs
+++ b/net-rs/net-cluster/src/topology.rs
@@ -1,12 +1,26 @@
-//! Random network topology generation.
+//! Cluster topology generation.
 //!
-//! Generates a connected random graph with configurable degree, port
-//! allocation, latency assignment, and stake distribution.
+//! Two sources, selected by [`crate::config::TopologySource`]:
+//!
+//! - [`generate`] — random connected graph (legacy default); honours
+//!   `num_nodes` / `degree` / `min_latency_ms` / `max_latency_ms` /
+//!   `stake_distribution`.
+//! - [`load_from_yaml`] — read a v3/v4-style topology YAML
+//!   (`data/simulation/pseudo-mainnet/topology-v4-*.yaml`); honours each
+//!   node's `stake` and each link's `latency-ms` verbatim.  Geographic
+//!   placement and per-link bandwidth in the YAML are accepted-and-ignored.
+//!
+//! Both paths return the same [`Topology`] shape, which downstream code
+//! (overlay generation, port allocation, behaviour assignment) consumes
+//! uniformly.
+
+use std::path::Path;
 
 use rand::prelude::*;
 use serde::Serialize;
 
 use crate::config::{BehaviourSelection, ClusterConfig};
+use crate::raw_topology::{self, RawTopology};
 
 /// A peer link from one node to another.
 #[derive(Debug, Clone, Serialize)]
@@ -123,6 +137,191 @@ pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
     }
 
     Topology { nodes, edges }
+}
+
+/// Load a cluster topology from a v3/v4-style YAML file.
+///
+/// The YAML is parsed into [`RawTopology`] (see [`crate::raw_topology`]) and
+/// then converted into the same [`Topology`] shape produced by [`generate`].
+/// Per-node fields:
+///
+/// - `node_id`, `index`: synthesised as `node-{i}` over the loaded slice
+///   (the YAML's own IDs are *not* reused as host identifiers — see below).
+/// - `listen_address`: `127.0.0.1:{base_port + i}` — same scheme as the
+///   random path, so every YAML node maps onto a localhost port.
+/// - `stake`: read verbatim from the YAML's per-node `stake` field.
+/// - `seed`: `config.seed.unwrap_or(0) + i`, matching the random path.
+///
+/// Per-link fields:
+///
+/// - `producers` arrays in the YAML become directed `Edge` entries with
+///   `latency_ms = round(link.latency_ms as f64)`.  We log a one-time
+///   warning if any link has a noticeable fractional component, since
+///   `inbound_delay_ms: u64` truncates.
+/// - `bandwidth-bytes-per-second` is **accepted-and-ignored** — net-core
+///   has no per-peer bandwidth shaping yet.  A one-time warning fires if
+///   any link carries a value, so the dropped data isn't silent.
+///
+/// If `node_limit` is set we take the *first N* nodes in YAML iteration
+/// order (the v4 generator emits them stake-rank descending, so this is
+/// effectively top-N by stake).  Producer edges pointing at nodes beyond
+/// the cutoff are dropped.
+pub fn load_from_yaml(
+    config: &ClusterConfig,
+    path: &Path,
+    node_limit: Option<usize>,
+) -> Result<Topology, Box<dyn std::error::Error + Send + Sync>> {
+    let raw = raw_topology::load_from_path(path)?;
+    build_from_raw(config, raw, node_limit)
+}
+
+/// Internal worker: convert a `RawTopology` into a cluster `Topology`.
+/// Factored out so tests can feed in a parsed YAML without touching disk.
+fn build_from_raw(
+    config: &ClusterConfig,
+    raw: RawTopology,
+    node_limit: Option<usize>,
+) -> Result<Topology, Box<dyn std::error::Error + Send + Sync>> {
+    if raw.nodes.is_empty() {
+        return Err("topology YAML contains no nodes".into());
+    }
+
+    let limit = node_limit.unwrap_or(usize::MAX);
+    let kept_ids: Vec<&String> = raw.nodes.keys().take(limit).collect();
+    let kept_count = kept_ids.len();
+    let id_to_index: std::collections::HashMap<&str, usize> = kept_ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| (id.as_str(), i))
+        .collect();
+
+    // ---- Pass 1: build NodeTopology entries (no peers yet) ----------------
+    let stakes: Vec<u64> = kept_ids
+        .iter()
+        .map(|id| raw.nodes[id.as_str()].stake)
+        .collect();
+    let behaviour_set = resolve_behaviour_nodes(config, &stakes);
+
+    let mut nodes: Vec<NodeTopology> = (0..kept_count)
+        .map(|i| {
+            let port = config.base_port + i as u16;
+            let behaviour = if config.behaviour.is_some() && behaviour_set.contains(&i) {
+                config.behaviour.clone()
+            } else {
+                None
+            };
+            NodeTopology {
+                index: i,
+                node_id: format!("node-{i}"),
+                listen_address: format!("127.0.0.1:{port}"),
+                listen_port: port,
+                stake: stakes[i],
+                seed: config.seed.unwrap_or(0) + i as u64,
+                behaviour,
+                peers: Vec::new(),
+            }
+        })
+        .collect();
+
+    // ---- Pass 2: build edges + peer links from the YAML producers ---------
+    // Edges are directed (one direction per `producers` entry) and we keep
+    // them ordered by (src_index, dst_index) for determinism.  Skipped:
+    // - destinations beyond `node_limit`
+    // - self-loops (shouldn't appear in well-formed topologies)
+    let mut edges: Vec<Edge> = Vec::new();
+    let mut frac_latency_warned = false;
+    let mut bandwidth_warned = false;
+    let mut dropped_targets: u64 = 0;
+
+    for (src_id, raw_node) in raw.nodes.iter().take(kept_count) {
+        let &src = id_to_index
+            .get(src_id.as_str())
+            .expect("src is in kept set");
+
+        for (dst_id, link) in &raw_node.producers {
+            let Some(&dst) = id_to_index.get(dst_id.as_str()) else {
+                dropped_targets += 1;
+                continue; // destination was capped out by node_limit
+            };
+            if src == dst {
+                continue; // skip self-loops
+            }
+
+            // Latency: f64 ms in the YAML, u64 ms in net-core.  Round
+            // (not truncate) so 45.6 → 46.  Warn once if any link
+            // carried a non-trivial fractional component (>0.05 ms), so
+            // operators know precision is being dropped.
+            let latency_f = link.latency_ms.max(0.0);
+            let latency_ms = latency_f.round() as u64;
+            if !frac_latency_warned && latency_f.fract().abs() > 0.05 {
+                tracing::warn!(
+                    yaml_latency = latency_f,
+                    rounded = latency_ms,
+                    "topology YAML contains fractional latency-ms values; rounding to whole ms (further warnings suppressed)"
+                );
+                frac_latency_warned = true;
+            }
+
+            if link.bandwidth_bytes_per_second.is_some() && !bandwidth_warned {
+                tracing::warn!(
+                    "topology YAML contains bandwidth-bytes-per-second values; \
+                     net-cluster does not currently model per-peer bandwidth and will ignore them"
+                );
+                bandwidth_warned = true;
+            }
+
+            edges.push(Edge {
+                from: src,
+                to: dst,
+                latency_ms,
+            });
+            let to_addr = nodes[dst].listen_address.clone();
+            nodes[src].peers.push(PeerLink {
+                address: to_addr,
+                inbound_delay_ms: latency_ms,
+            });
+        }
+    }
+
+    if dropped_targets > 0 {
+        tracing::info!(
+            kept_nodes = kept_count,
+            yaml_nodes = raw.nodes.len(),
+            dropped_edge_targets = dropped_targets,
+            "topology YAML truncated by node_limit; producer edges pointing at dropped nodes were skipped"
+        );
+    }
+
+    // ---- Pass 3: inject external peers ------------------------------------
+    // Same shape as the random path, but the RNG is seeded fresh here:
+    // unlike the random path there's no prior `build_random_graph` to
+    // advance the RNG, so we derive the YAML-mode seed by offsetting
+    // `config.seed` (or falling back to entropy).  Determinism for YAML
+    // mode is therefore tied to `config.seed`, not to any graph-gen
+    // history.
+    let n = nodes.len();
+    if !config.external_peers.is_empty() {
+        let mut rng = match config.seed {
+            Some(s) => StdRng::seed_from_u64(s.wrapping_add(0xEA70_BEEF)),
+            None => StdRng::from_entropy(),
+        };
+        for ext in &config.external_peers {
+            let count = ext.inject_into_nodes.min(n);
+            let chosen: Vec<usize> = (0..n)
+                .collect::<Vec<_>>()
+                .partial_shuffle(&mut rng, count)
+                .0
+                .to_vec();
+            for &i in &chosen {
+                nodes[i].peers.push(PeerLink {
+                    address: ext.address.clone(),
+                    inbound_delay_ms: 0,
+                });
+            }
+        }
+    }
+
+    Ok(Topology { nodes, edges })
 }
 
 /// Build a random undirected graph with target degree, ensuring connectivity.
@@ -676,5 +875,248 @@ mod tests {
             adj[edge.to].insert(edge.from);
         }
         adj
+    }
+
+    // --- YAML-loaded topology --------------------------------------------------
+
+    /// Small hand-written v4-style YAML fixture: 4 nodes, mixed stakes,
+    /// asymmetric producer edges, one self-loop (which must be skipped),
+    /// one fractional latency, one explicit bandwidth value.
+    const YAML_FIXTURE: &str = r#"
+nodes:
+  node-0:
+    stake: 1000
+    location: [10.0, 49.7]
+    producers:
+      node-1:
+        latency-ms: 45.3
+        bandwidth-bytes-per-second: 125000000
+      node-2:
+        latency-ms: 12.0
+      node-3:
+        latency-ms: 200.0
+      node-0:                   # self-loop (must be skipped)
+        latency-ms: 0.0
+  node-1:
+    stake: 500
+    location: [-77.5, 38.9]
+    producers:
+      node-0:
+        latency-ms: 45.6        # rounds to 46
+      node-2:
+        latency-ms: 50.0
+  node-2:
+    stake: 0
+    location: [120.0, 30.0]
+    producers:
+      node-0:
+        latency-ms: 12.0
+  node-3:
+    stake: 250
+    location: [-3.0, 51.5]
+    producers: {}
+"#;
+
+    fn yaml_test_config() -> ClusterConfig {
+        ClusterConfig {
+            num_nodes: 4,
+            base_config: "test.toml".to_string(),
+            base_port: 31000,
+            seed: Some(7),
+            ..ClusterConfig::default()
+        }
+    }
+
+    fn parse_yaml_fixture() -> crate::raw_topology::RawTopology {
+        serde_yaml::from_str(YAML_FIXTURE).unwrap()
+    }
+
+    #[test]
+    fn yaml_basic_shape() {
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, None).unwrap();
+
+        // 4 nodes loaded; ports allocated linearly from base_port.
+        assert_eq!(topo.nodes.len(), 4);
+        for (i, n) in topo.nodes.iter().enumerate() {
+            assert_eq!(n.index, i);
+            assert_eq!(n.node_id, format!("node-{i}"));
+            assert_eq!(n.listen_port, 31000 + i as u16);
+            assert_eq!(n.listen_address, format!("127.0.0.1:{}", 31000 + i as u16));
+        }
+
+        // Stakes flow through verbatim.
+        assert_eq!(topo.nodes[0].stake, 1000);
+        assert_eq!(topo.nodes[1].stake, 500);
+        assert_eq!(topo.nodes[2].stake, 0);
+        assert_eq!(topo.nodes[3].stake, 250);
+
+        // Edges: 3 from node-0 (self-loop skipped) + 2 from node-1 + 1 from
+        // node-2 + 0 from node-3 = 6 total.
+        assert_eq!(topo.edges.len(), 6);
+
+        // Self-loop must not appear.
+        assert!(topo.edges.iter().all(|e| e.from != e.to));
+    }
+
+    #[test]
+    fn yaml_latency_rounds_to_whole_ms() {
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, None).unwrap();
+
+        // 45.3 → 45, 12.0 → 12, 200.0 → 200, 45.6 → 46.
+        let n1_link = topo
+            .edges
+            .iter()
+            .find(|e| e.from == 0 && e.to == 1)
+            .unwrap();
+        assert_eq!(n1_link.latency_ms, 45);
+        let back_link = topo
+            .edges
+            .iter()
+            .find(|e| e.from == 1 && e.to == 0)
+            .unwrap();
+        assert_eq!(back_link.latency_ms, 46);
+
+        // PeerLink.inbound_delay_ms mirrors the edge latency.
+        let pl = topo.nodes[0]
+            .peers
+            .iter()
+            .find(|p| p.address.ends_with(":31001"))
+            .unwrap();
+        assert_eq!(pl.inbound_delay_ms, 45);
+    }
+
+    #[test]
+    fn yaml_node_limit_truncates_and_drops_external_edges() {
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, Some(2)).unwrap();
+
+        // Only the first two YAML nodes survive.
+        assert_eq!(topo.nodes.len(), 2);
+        // Edges from node-0 that pointed at node-2 / node-3 are dropped;
+        // only the node-0 → node-1 edge remains.  Plus node-1 → node-0.
+        assert_eq!(topo.edges.len(), 2);
+        let pairs: Vec<_> = topo.edges.iter().map(|e| (e.from, e.to)).collect();
+        assert!(pairs.contains(&(0, 1)));
+        assert!(pairs.contains(&(1, 0)));
+    }
+
+    #[test]
+    fn yaml_empty_topology_is_rejected() {
+        let config = yaml_test_config();
+        let raw: crate::raw_topology::RawTopology = serde_yaml::from_str("nodes: {}\n").unwrap();
+        let err = build_from_raw(&config, raw, None).unwrap_err();
+        assert!(err.to_string().contains("no nodes"));
+    }
+
+    #[test]
+    fn yaml_external_peers_still_injected() {
+        let mut config = yaml_test_config();
+        config
+            .external_peers
+            .push(crate::config::ExternalPeerConfig {
+                address: "relay.example.com:3001".to_string(),
+                inject_into_nodes: 2,
+            });
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, None).unwrap();
+        let count = topo
+            .nodes
+            .iter()
+            .filter(|n| {
+                n.peers
+                    .iter()
+                    .any(|p| p.address == "relay.example.com:3001")
+            })
+            .count();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn yaml_load_is_deterministic_for_same_seed() {
+        let config = yaml_test_config();
+        let raw1 = parse_yaml_fixture();
+        let raw2 = parse_yaml_fixture();
+        let topo1 = build_from_raw(&config, raw1, None).unwrap();
+        let topo2 = build_from_raw(&config, raw2, None).unwrap();
+        assert_eq!(topo1.edges.len(), topo2.edges.len());
+        for (e1, e2) in topo1.edges.iter().zip(topo2.edges.iter()) {
+            assert_eq!(e1.from, e2.from);
+            assert_eq!(e1.to, e2.to);
+            assert_eq!(e1.latency_ms, e2.latency_ms);
+        }
+    }
+
+    #[test]
+    fn yaml_behaviour_selection_honoured() {
+        // StakeOrdered{count=2} should attach to nodes 0 and 1 (the two
+        // highest stakes among the four in YAML_FIXTURE: 1000 > 500 > 250 > 0).
+        let mut config = yaml_test_config();
+        config.behaviour = Some(shared_consensus::behaviour::BehaviourSpec::Honest);
+        config.behaviour_selection =
+            Some(crate::config::BehaviourSelection::StakeOrdered { count: 2 });
+        let raw = parse_yaml_fixture();
+        let topo = build_from_raw(&config, raw, None).unwrap();
+        assert!(topo.nodes[0].behaviour.is_some());
+        assert!(topo.nodes[1].behaviour.is_some());
+        assert!(topo.nodes[2].behaviour.is_none()); // stake = 0, not eligible
+        assert!(topo.nodes[3].behaviour.is_none()); // stake = 250, but count=2
+    }
+
+    /// Regression test: when the YAML uses numeric IDs (`node-0`, `node-1`,
+    /// …, `node-12`) in stake-rank-descending order, `node_limit = 3` must
+    /// keep `node-0`, `node-1`, `node-2` (the three highest stakes) — not
+    /// some lexicographic mix like `node-0`, `node-1`, `node-10`.
+    ///
+    /// This is what would have caught the `BTreeMap` ordering bug — the
+    /// hand-written A/B/C fixture above happens to iterate identically
+    /// in any ordered map.
+    #[test]
+    fn yaml_numeric_ids_node_limit_takes_top_by_yaml_order() {
+        // 12 nodes, stakes 12000, 11000, …, 1000 in YAML order.
+        let yaml = {
+            let mut s = String::from("nodes:\n");
+            for i in 0..12 {
+                s.push_str(&format!(
+                    "  node-{i}:\n    stake: {}\n    producers: {{}}\n",
+                    12_000 - i * 1_000
+                ));
+            }
+            s
+        };
+        let raw: crate::raw_topology::RawTopology = serde_yaml::from_str(&yaml).unwrap();
+
+        let config = ClusterConfig {
+            num_nodes: 3,
+            base_config: "test.toml".to_string(),
+            base_port: 32000,
+            seed: Some(7),
+            ..ClusterConfig::default()
+        };
+        let topo = build_from_raw(&config, raw, Some(3)).unwrap();
+
+        // Three nodes, stakes 12000, 11000, 10000 — the top three in YAML
+        // order.  Lexicographic order would give 12000, 11000, 2000 (from
+        // node-0, node-1, node-10).
+        assert_eq!(topo.nodes.len(), 3);
+        let stakes: Vec<u64> = topo.nodes.iter().map(|n| n.stake).collect();
+        assert_eq!(stakes, vec![12_000, 11_000, 10_000]);
+    }
+
+    #[test]
+    fn yaml_load_from_path_round_trip() {
+        // End-to-end: write the fixture to a temp file and load via the
+        // public entry point.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("topology.yaml");
+        std::fs::write(&path, YAML_FIXTURE).unwrap();
+        let config = yaml_test_config();
+        let topo = load_from_yaml(&config, &path, None).unwrap();
+        assert_eq!(topo.nodes.len(), 4);
+        assert_eq!(topo.edges.len(), 6);
     }
 }

--- a/net-rs/net-cluster/src/topology.rs
+++ b/net-rs/net-cluster/src/topology.rs
@@ -7,8 +7,10 @@
 //!   `stake_distribution`.
 //! - [`load_from_yaml`] — read a v3/v4-style topology YAML
 //!   (`data/simulation/pseudo-mainnet/topology-v4-*.yaml`); honours each
-//!   node's `stake` and each link's `latency-ms` verbatim.  Geographic
-//!   placement and per-link bandwidth in the YAML are accepted-and-ignored.
+//!   node's `stake` directly and each link's `latency-ms` after clamping
+//!   negatives to zero and rounding to whole milliseconds (the inbound
+//!   delay model is integer-millisecond).  Geographic placement and
+//!   per-link bandwidth in the YAML are accepted-and-ignored.
 //!
 //! Both paths return the same [`Topology`] shape, which downstream code
 //! (overlay generation, port allocation, behaviour assignment) consumes
@@ -154,10 +156,12 @@ pub fn generate(config: &ClusterConfig, total_stake: u64) -> Topology {
 ///
 /// Per-link fields:
 ///
-/// - `producers` arrays in the YAML become directed `Edge` entries with
-///   `latency_ms = round(link.latency_ms as f64)`.  We log a one-time
-///   warning if any link has a noticeable fractional component, since
-///   `inbound_delay_ms: u64` truncates.
+/// - `producers` arrays in the YAML become directed `Edge` entries.
+///   `link.latency_ms` (f64) is clamped to `>= 0.0` and rounded to the
+///   nearest whole millisecond before storing as `u64` — net-core's
+///   inbound-delay model is integer-millisecond.  A one-time warning
+///   fires if any link has a noticeable fractional component (>0.05 ms)
+///   so operators know sub-ms precision is being dropped.
 /// - `bandwidth-bytes-per-second` is **accepted-and-ignored** — net-core
 ///   has no per-peer bandwidth shaping yet.  A one-time warning fires if
 ///   any link carries a value, so the dropped data isn't silent.
@@ -182,13 +186,26 @@ fn build_from_raw(
     raw: RawTopology,
     node_limit: Option<usize>,
 ) -> Result<Topology, Box<dyn std::error::Error + Send + Sync>> {
-    if raw.nodes.is_empty() {
-        return Err("topology YAML contains no nodes".into());
-    }
-
     let limit = node_limit.unwrap_or(usize::MAX);
     let kept_ids: Vec<&String> = raw.nodes.keys().take(limit).collect();
     let kept_count = kept_ids.len();
+
+    // Reject the empty cases up-front.  Two ways to arrive here:
+    // 1. YAML has no nodes at all.
+    // 2. YAML has nodes but `node_limit = Some(0)` discarded all of them.
+    // Either way, downstream (port allocation, overlay generation,
+    // num_nodes override in main.rs) would silently produce a 0-node
+    // cluster that boots and does nothing — surface it as an error
+    // instead.
+    if kept_count == 0 {
+        return Err(format!(
+            "topology YAML produced zero nodes (yaml_nodes={}, node_limit={:?})",
+            raw.nodes.len(),
+            node_limit,
+        )
+        .into());
+    }
+
     let id_to_index: std::collections::HashMap<&str, usize> = kept_ids
         .iter()
         .enumerate()
@@ -224,8 +241,11 @@ fn build_from_raw(
         .collect();
 
     // ---- Pass 2: build edges + peer links from the YAML producers ---------
-    // Edges are directed (one direction per `producers` entry) and we keep
-    // them ordered by (src_index, dst_index) for determinism.  Skipped:
+    // Edges are directed (one direction per `producers` entry) and emitted
+    // in **YAML insertion order** — outer loop over `raw.nodes`, inner
+    // loop over each node's `producers`.  Both are `IndexMap`s which
+    // preserve YAML order, so the resulting `edges` / per-node `peers`
+    // vectors are deterministic given the YAML file.  Skipped:
     // - destinations beyond `node_limit`
     // - self-loops (shouldn't appear in well-formed topologies)
     let mut edges: Vec<Edge> = Vec::new();
@@ -1007,10 +1027,31 @@ nodes:
 
     #[test]
     fn yaml_empty_topology_is_rejected() {
+        // Empty `nodes:` map → no nodes to load → error.
         let config = yaml_test_config();
         let raw: crate::raw_topology::RawTopology = serde_yaml::from_str("nodes: {}\n").unwrap();
         let err = build_from_raw(&config, raw, None).unwrap_err();
-        assert!(err.to_string().contains("no nodes"));
+        assert!(
+            err.to_string().contains("zero nodes"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn yaml_node_limit_zero_is_rejected() {
+        // Non-empty YAML but `node_limit = Some(0)` discards everything.
+        // Previously this silently produced an empty `Topology`, which
+        // then propagated as `num_nodes = 0` through main.rs and the
+        // cluster booted with no children.  Must be a hard error.
+        let config = yaml_test_config();
+        let raw = parse_yaml_fixture();
+        let err = build_from_raw(&config, raw, Some(0)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("zero nodes"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("node_limit=Some(0)") || msg.contains("Some(0)"),
+            "error should mention the node_limit value, got: {msg}"
+        );
     }
 
     #[test]

--- a/net-rs/net-ui/src/components/ControlPanel.tsx
+++ b/net-rs/net-ui/src/components/ControlPanel.tsx
@@ -26,12 +26,17 @@ export function ControlPanel() {
   const [rbGenProb, setRbGenProb] = useState("0.05");
   const [rbBodyValidationMs, setRbBodyValidationMs] = useState("1000");
 
+  const topologySource = clusterConfig?.topology_source ?? null;
+  const isYaml = topologySource?.type === "yaml";
+
   useEffect(() => {
     if (clusterConfig) {
-      if (clusterConfig.num_nodes != null) setNumNodes(String(clusterConfig.num_nodes));
-      if (clusterConfig.degree != null) setDegree(String(clusterConfig.degree));
-      if (clusterConfig.min_latency_ms != null) setMinLatency(String(clusterConfig.min_latency_ms));
-      if (clusterConfig.max_latency_ms != null) setMaxLatency(String(clusterConfig.max_latency_ms));
+      if (topologySource?.type === "random") {
+        setNumNodes(String(topologySource.num_nodes));
+        setDegree(String(topologySource.degree));
+        setMinLatency(String(topologySource.min_latency_ms));
+        setMaxLatency(String(topologySource.max_latency_ms));
+      }
       setSeed(clusterConfig.seed != null ? String(clusterConfig.seed) : "");
 
       const nc = clusterConfig.node_config ?? {};
@@ -40,12 +45,13 @@ export function ControlPanel() {
       const rbVal = nc["validation.rb_body_validation_ms_constant"];
       if (rbVal != null) setRbBodyValidationMs(String(rbVal));
     }
-  }, [clusterConfig]);
+  }, [clusterConfig, topologySource]);
 
   const numNodesN = Number(numNodes) || 0;
   const minLatencyN = Number(minLatency) || 0;
   const maxLatencyN = Number(maxLatency) || 0;
-  const valid = numNodesN >= 1 && minLatencyN <= maxLatencyN;
+  // YAML-mode restarts don't edit topology params, so we don't validate them.
+  const valid = isYaml || (numNodesN >= 1 && minLatencyN <= maxLatencyN);
 
   const busy = restarting || updating;
 
@@ -56,10 +62,24 @@ export function ControlPanel() {
 
   const handleRestart = () => {
     restartCluster({
-      num_nodes: numNodesN,
-      degree: Number(degree) || 1,
-      min_latency_ms: minLatencyN,
-      max_latency_ms: maxLatencyN,
+      // In YAML mode we don't override topology_source — the cluster
+      // restarts with whatever YAML was loaded at startup.  In random
+      // mode we send back the edited params.
+      topology_source: isYaml
+        ? undefined
+        : {
+            type: "random",
+            num_nodes: numNodesN,
+            degree: Number(degree) || 1,
+            min_latency_ms: minLatencyN,
+            max_latency_ms: maxLatencyN,
+            // Preserve whatever stake distribution the cluster was
+            // configured with (we don't expose a UI for it yet).
+            stake_distribution:
+              topologySource?.type === "random"
+                ? topologySource.stake_distribution
+                : "equal",
+          },
       seed: seed !== "" ? Number(seed) : undefined,
       node_config: nodeConfigPayload(),
     });
@@ -122,46 +142,81 @@ export function ControlPanel() {
       <Typography variant="subtitle2" sx={{ color: "#90caf9", fontWeight: 700 }}>
         Cluster Topology
       </Typography>
-      <TextField
-        label="Nodes"
-        type="number"
-        size="small"
-        value={numNodes}
-        onChange={(e) => setNumNodes(e.target.value)}
-        disabled={busy}
-        slotProps={{ htmlInput: { min: 1, max: 100 } }}
-        sx={numberFieldSx}
-      />
-      <TextField
-        label="Degree"
-        type="number"
-        size="small"
-        value={degree}
-        onChange={(e) => setDegree(e.target.value)}
-        disabled={busy}
-        slotProps={{ htmlInput: { min: 1, max: 50 } }}
-        sx={numberFieldSx}
-      />
-      <TextField
-        label="Min latency (ms)"
-        type="number"
-        size="small"
-        value={minLatency}
-        onChange={(e) => setMinLatency(e.target.value)}
-        disabled={busy}
-        slotProps={{ htmlInput: { min: 0 } }}
-        sx={numberFieldSx}
-      />
-      <TextField
-        label="Max latency (ms)"
-        type="number"
-        size="small"
-        value={maxLatency}
-        onChange={(e) => setMaxLatency(e.target.value)}
-        disabled={busy}
-        slotProps={{ htmlInput: { min: 0 } }}
-        sx={numberFieldSx}
-      />
+
+      {isYaml && topologySource?.type === "yaml" && (
+        <Box
+          sx={{
+            p: 1,
+            borderRadius: 1,
+            border: "1px solid rgba(255,255,255,0.1)",
+            background: "rgba(144,202,249,0.05)",
+            fontSize: 12,
+            color: "rgba(255,255,255,0.75)",
+          }}
+        >
+          <Typography variant="caption" sx={{ display: "block", color: "#90caf9", fontWeight: 600 }}>
+            YAML-loaded topology
+          </Typography>
+          <Box sx={{ mt: 0.5, fontFamily: "ui-monospace, monospace", fontSize: 11, wordBreak: "break-all" }}>
+            {topologySource.path}
+          </Box>
+          {topologySource.node_limit != null && (
+            <Box sx={{ mt: 0.5 }}>
+              capped at first <b>{topologySource.node_limit}</b> nodes (top-N by stake)
+            </Box>
+          )}
+          <Box sx={{ mt: 0.5, opacity: 0.7 }}>
+            Topology params (nodes / degree / latencies) come from the YAML file and aren't editable here.
+            "Restart Cluster" reloads the same YAML.
+          </Box>
+        </Box>
+      )}
+
+      {!isYaml && (
+        <>
+          <TextField
+            label="Nodes"
+            type="number"
+            size="small"
+            value={numNodes}
+            onChange={(e) => setNumNodes(e.target.value)}
+            disabled={busy}
+            slotProps={{ htmlInput: { min: 1, max: 100 } }}
+            sx={numberFieldSx}
+          />
+          <TextField
+            label="Degree"
+            type="number"
+            size="small"
+            value={degree}
+            onChange={(e) => setDegree(e.target.value)}
+            disabled={busy}
+            slotProps={{ htmlInput: { min: 1, max: 50 } }}
+            sx={numberFieldSx}
+          />
+          <TextField
+            label="Min latency (ms)"
+            type="number"
+            size="small"
+            value={minLatency}
+            onChange={(e) => setMinLatency(e.target.value)}
+            disabled={busy}
+            slotProps={{ htmlInput: { min: 0 } }}
+            sx={numberFieldSx}
+          />
+          <TextField
+            label="Max latency (ms)"
+            type="number"
+            size="small"
+            value={maxLatency}
+            onChange={(e) => setMaxLatency(e.target.value)}
+            disabled={busy}
+            slotProps={{ htmlInput: { min: 0 } }}
+            sx={numberFieldSx}
+          />
+        </>
+      )}
+
       <TextField
         label="Seed (optional)"
         type="number"

--- a/net-rs/net-ui/src/components/ControlPanel.tsx
+++ b/net-rs/net-ui/src/components/ControlPanel.tsx
@@ -27,15 +27,17 @@ export function ControlPanel() {
   const [rbBodyValidationMs, setRbBodyValidationMs] = useState("1000");
 
   const topologySource = clusterConfig?.topology_source ?? null;
-  const isYaml = topologySource?.type === "yaml";
+  const isYaml = topologySource === "yaml";
+  const randomConfig = clusterConfig?.topology_random ?? null;
+  const yamlConfig = clusterConfig?.topology_yaml ?? null;
 
   useEffect(() => {
     if (clusterConfig) {
-      if (topologySource?.type === "random") {
-        setNumNodes(String(topologySource.num_nodes));
-        setDegree(String(topologySource.degree));
-        setMinLatency(String(topologySource.min_latency_ms));
-        setMaxLatency(String(topologySource.max_latency_ms));
+      if (randomConfig) {
+        setNumNodes(String(randomConfig.num_nodes));
+        setDegree(String(randomConfig.degree));
+        setMinLatency(String(randomConfig.min_latency_ms));
+        setMaxLatency(String(randomConfig.max_latency_ms));
       }
       setSeed(clusterConfig.seed != null ? String(clusterConfig.seed) : "");
 
@@ -45,7 +47,7 @@ export function ControlPanel() {
       const rbVal = nc["validation.rb_body_validation_ms_constant"];
       if (rbVal != null) setRbBodyValidationMs(String(rbVal));
     }
-  }, [clusterConfig, topologySource]);
+  }, [clusterConfig, randomConfig]);
 
   const numNodesN = Number(numNodes) || 0;
   const minLatencyN = Number(minLatency) || 0;
@@ -62,23 +64,20 @@ export function ControlPanel() {
 
   const handleRestart = () => {
     restartCluster({
-      // In YAML mode we don't override topology_source — the cluster
-      // restarts with whatever YAML was loaded at startup.  In random
-      // mode we send back the edited params.
-      topology_source: isYaml
+      // In YAML mode we don't override the topology — the cluster restarts
+      // with whatever YAML was loaded at startup.  In random mode we send
+      // back the mode selector plus the edited params.
+      topology_source: isYaml ? undefined : "random",
+      topology_random: isYaml
         ? undefined
         : {
-            type: "random",
             num_nodes: numNodesN,
             degree: Number(degree) || 1,
             min_latency_ms: minLatencyN,
             max_latency_ms: maxLatencyN,
             // Preserve whatever stake distribution the cluster was
             // configured with (we don't expose a UI for it yet).
-            stake_distribution:
-              topologySource?.type === "random"
-                ? topologySource.stake_distribution
-                : "equal",
+            stake_distribution: randomConfig?.stake_distribution ?? "equal",
           },
       seed: seed !== "" ? Number(seed) : undefined,
       node_config: nodeConfigPayload(),
@@ -143,7 +142,7 @@ export function ControlPanel() {
         Cluster Topology
       </Typography>
 
-      {isYaml && topologySource?.type === "yaml" && (
+      {isYaml && yamlConfig && (
         <Box
           sx={{
             p: 1,
@@ -158,11 +157,11 @@ export function ControlPanel() {
             YAML-loaded topology
           </Typography>
           <Box sx={{ mt: 0.5, fontFamily: "ui-monospace, monospace", fontSize: 11, wordBreak: "break-all" }}>
-            {topologySource.path}
+            {yamlConfig.path}
           </Box>
-          {topologySource.node_limit != null && (
+          {yamlConfig.node_limit != null && (
             <Box sx={{ mt: 0.5 }}>
-              capped at first <b>{topologySource.node_limit}</b> nodes (top-N by stake)
+              capped at first <b>{yamlConfig.node_limit}</b> nodes (top-N by stake)
             </Box>
           )}
           <Box sx={{ mt: 0.5, opacity: 0.7 }}>

--- a/net-rs/net-ui/src/types.ts
+++ b/net-rs/net-ui/src/types.ts
@@ -81,11 +81,38 @@ export interface NodeSeriesPoint {
   blocks: number;
 }
 
+/**
+ * Mirrors net-cluster's `TopologySource` enum (internally tagged on `type`,
+ * snake_case).  See net-cluster/src/config.rs.
+ *
+ * `random` mode: cluster generates a random connected graph from these
+ * params.  `yaml` mode: cluster loads a pre-built topology from disk;
+ * `num_nodes`/`degree`/etc. don't exist in this variant because they're
+ * either derived from the YAML or don't apply.
+ */
+export type TopologySource =
+  | {
+      type: "random";
+      num_nodes: number;
+      degree: number;
+      min_latency_ms: number;
+      max_latency_ms: number;
+      stake_distribution: string;
+    }
+  | {
+      type: "yaml";
+      path: string;
+      node_limit?: number | null;
+    };
+
 export interface ClusterControlConfig {
-  num_nodes?: number;
-  degree?: number;
-  min_latency_ms?: number;
-  max_latency_ms?: number;
+  /**
+   * When present in a POST body, replaces the cluster's current
+   * topology source wholesale.  When `null`/omitted, leaves the
+   * topology unchanged.  When read from GET /api/config, always
+   * reflects the cluster's current source.
+   */
+  topology_source?: TopologySource | null;
   seed?: number;
   node_config: Record<string, unknown>;
 }

--- a/net-rs/net-ui/src/types.ts
+++ b/net-rs/net-ui/src/types.ts
@@ -82,37 +82,38 @@ export interface NodeSeriesPoint {
 }
 
 /**
- * Mirrors net-cluster's `TopologySource` enum (internally tagged on `type`,
- * snake_case).  See net-cluster/src/config.rs.
- *
- * `random` mode: cluster generates a random connected graph from these
- * params.  `yaml` mode: cluster loads a pre-built topology from disk;
- * `num_nodes`/`degree`/etc. don't exist in this variant because they're
- * either derived from the YAML or don't apply.
+ * Mirrors net-cluster's topology config (see net-cluster/src/config.rs).
+ * `topology_source` is a scalar selector; the mode-specific params live in
+ * separate `topology_random` / `topology_yaml` objects.
  */
-export type TopologySource =
-  | {
-      type: "random";
-      num_nodes: number;
-      degree: number;
-      min_latency_ms: number;
-      max_latency_ms: number;
-      stake_distribution: string;
-    }
-  | {
-      type: "yaml";
-      path: string;
-      node_limit?: number | null;
-    };
+export type TopologySource = "random" | "yaml";
+
+export interface RandomTopologyConfig {
+  num_nodes: number;
+  degree: number;
+  min_latency_ms: number;
+  max_latency_ms: number;
+  stake_distribution: string;
+}
+
+export interface YamlTopologyConfig {
+  path: string;
+  node_limit?: number | null;
+}
 
 export interface ClusterControlConfig {
   /**
-   * When present in a POST body, replaces the cluster's current
-   * topology source wholesale.  When `null`/omitted, leaves the
-   * topology unchanged.  When read from GET /api/config, always
-   * reflects the cluster's current source.
+   * Topology mode.  In a POST body, switches the mode (omit to leave
+   * unchanged).  From GET /api/config, reflects the cluster's current mode.
    */
   topology_source?: TopologySource | null;
+  /**
+   * Random-mode params.  In a POST body, replaces them wholesale (omit to
+   * leave unchanged).  From GET /api/config, reflects current values.
+   */
+  topology_random?: RandomTopologyConfig | null;
+  /** YAML-mode params; same semantics as `topology_random`. */
+  topology_yaml?: YamlTopologyConfig | null;
   seed?: number;
   node_config: Record<string, unknown>;
 }


### PR DESCRIPTION
Adds a YAML topology loader to `net-cluster` so a local cluster can be driven from the v3/v4-style `data/simulation/pseudo-mainnet/topology-v*.yaml` files instead of always generating a random graph.

## What's added

- `topology_source` config enum: `Random` (default, unchanged) or `Yaml { path, node_limit? }`
- `net-cluster/src/raw_topology.rs` — parser for the schema (same shape as `sim-rs` / `topology-checker`)
- `topology.rs::load_from_yaml` — feeds the parsed YAML into the same `Topology` shape the random path produces, so overlay / port allocation / behaviour selection work unchanged

YAML mode reads each node's `stake` directly and each link's `latency-ms` (clamped to ≥0, rounded to whole ms). `bandwidth-bytes-per-second` is accepted-and-ignored (no per-peer shaping in net-core yet). `num_nodes` is overridden with the loaded count.

## How to run

```toml
# /tmp/cluster.toml
num_nodes = 25
base_config = "net-node/configs/mainnet.toml"
base_port = 30000
seed = 42
output_events = "/tmp/cluster-events.jsonl"
aggregator_port = 9100
stats_interval_secs = 2
rb_generation_probability = 0.05
tx_rate = 1.0

[topology_source]
kind = "yaml"
path = "/tmp/topology-v4-mainnet.yaml"
node_limit = 25
```

```bash
cd net-rs
cargo build -p net-node --release
RUST_LOG=info cargo run -p net-cluster --release -- \
    --config /tmp/cluster.toml \
    --net-node-bin target/release/net-node
```

`node_limit` caps the loaded count (first-N in YAML insertion order — that's top-N by stake in v4). Keep it modest: ~50 on a 16GB box, ~250 on 48GB. See `net-cluster/configs/sample-cluster-v4-mini.toml` for a worked example.
