### PR TITLE
net-rs: spec-faithful Praos lottery threshold (φ(σ) = 1 − (1−f)^σ)

### DIFF
--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -843,8 +843,11 @@ mod tests {
         let _ = leios.drain_telemetry();
 
         let eb_hash = point_hash(0);
+        // 8 voters out of 10 pools clears the τ = 0.75 quorum: in
+        // `EveryoneVotes` each pool has weight 1, so the threshold
+        // `ceil(0.75 × 10) = 8`.
         let voters = [
-            "test", "peer-0", "peer-1", "peer-2", "peer-3", "peer-4", "peer-5",
+            "test", "peer-0", "peer-1", "peer-2", "peer-3", "peer-4", "peer-5", "peer-6",
         ];
         let bodies: Vec<Vec<u8>> = voters
             .iter()
@@ -868,13 +871,13 @@ mod tests {
         } = cert
         {
             assert_eq!(*eb_slot, 0);
-            assert_eq!(*voted_weight, 7);
-            assert_eq!(*voters, 7);
+            assert_eq!(*voted_weight, 8);
+            assert_eq!(*voters, 8);
         }
 
         // Subsequent votes don't re-fire.
-        let body8 = crate::production::VoteBody::stub_persistent(0, b"peer-6", 100, &eb_hash);
-        leios.on_validated_votes(&[body8.encode(130)]);
+        let body_extra = crate::production::VoteBody::stub_persistent(0, b"peer-7", 100, &eb_hash);
+        leios.on_validated_votes(&[body_extra.encode(130)]);
         let drained2 = leios.drain_telemetry();
         assert!(!drained2
             .iter()
@@ -894,8 +897,9 @@ mod tests {
 
         let hash0 = point_hash(0);
         let hash5 = point_hash(5);
+        // 8 voters per EB clears the τ = 0.75 quorum (ceil(0.75 × 10) = 8).
         let voters = [
-            "test", "peer-0", "peer-1", "peer-2", "peer-3", "peer-4", "peer-5",
+            "test", "peer-0", "peer-1", "peer-2", "peer-3", "peer-4", "peer-5", "peer-6",
         ];
         let mut all_bodies = Vec::new();
         for slot in [0u64, 5u64] {

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -383,12 +383,14 @@ impl BlockProducer {
     }
 
     /// Run the Praos f_block lottery.  Returns true on win.  Threshold
-    /// math lives in [`shared_consensus::lottery::rb_win_threshold`]; this site
-    /// just supplies the `f64` draw.
+    /// math lives in [`shared_consensus::lottery::LotteryParams`]; this site
+    /// supplies the `u64` draw.  When a real VRF replaces the PRNG, only
+    /// the draw source changes — the integer comparison stays.
     fn run_lottery(&mut self, probability: f64) -> bool {
-        let threshold = shared_consensus::lottery::rb_win_threshold(probability, self.stake);
-        let roll: f64 = self.rng.gen();
-        roll < threshold as f64 / self.total_stake as f64
+        let params = shared_consensus::lottery::LotteryParams::new(probability);
+        let threshold = params.rb_win_threshold(self.stake, self.total_stake);
+        let draw: u64 = self.rng.gen();
+        draw < threshold
     }
 
     /// Build a fake block with valid Shelley+ CBOR structure.
@@ -714,6 +716,11 @@ mod tests {
 
     #[test]
     fn approximate_production_rate() {
+        // Expected win rate per slot is the spec-faithful Praos
+        // φ(σ) = 1 − (1 − f)^σ.  For stake=100, total_stake=1000, f=0.5:
+        // φ = 1 − 0.5^0.1 ≈ 0.0670, so ~670 wins out of 10 000 slots.
+        // Bounds span 4σ (≈100 wins) of binomial variance to keep the
+        // test stable across PRNG seeds.
         let config = ProductionConfig {
             stake: 100,
             rb_generation_probability: 0.5,
@@ -729,8 +736,8 @@ mod tests {
             })
             .count();
         assert!(
-            (400..=600).contains(&wins),
-            "wins={wins}, expected ~500 (5%)"
+            (570..=770).contains(&wins),
+            "wins={wins}, expected ~670 (6.7%)"
         );
     }
 

--- a/shared-rs/consensus/src/lottery.rs
+++ b/shared-rs/consensus/src/lottery.rs
@@ -7,74 +7,208 @@
 //! net-rs, a deterministic VRF-style draw oracle for sim-rs) and the
 //! comparison itself.
 //!
-//! The formula is the linear approximation `φ(α) ≈ α·f` of Ouroboros
-//! Praos's exact `φ(α) = 1 − (1−f)^α`.  Relative error is well under
-//! 1% for realistic stake distributions; fine for research, not
-//! spec-faithful for adversarial fairness analysis at the extreme
-//! tails.  Production-strength fidelity is a follow-on concern for
-//! whoever plugs in real VRF later.
+//! The formula is the spec-faithful Ouroboros Praos lottery
+//! probability `φ(σ) = 1 − (1 − f)^σ`, where `σ = stake / total_stake`
+//! and `f` is the network-wide active-slot coefficient.  The threshold
+//! is returned as a `u64` over the half-open range `[0, 2^64)`; a
+//! uniform integer draw `d` wins iff `d < threshold`.  The integer
+//! comparison shape matches what a real VRF check will use — when a
+//! VRF lands, only the draw source changes.
+//!
+//! Internally the threshold is computed in `f64` and quantized.  Float
+//! precision is well below the `1 / 2^64` resolution of the comparison
+//! for any realistic `(f, σ)`, so the quantization step is the only
+//! place precision is lost.  The internal evaluation uses `exp_m1` to
+//! avoid catastrophic cancellation when `φ` is small (the common case
+//! for low-stake nodes).
 
-/// Upper bound of the success set for the Praos f_block lottery.
-/// A draw `d` from a uniform distribution over `[0, total_stake)` is a
-/// win iff `d < threshold`.
+/// Per-epoch lottery context.
 ///
-/// `rb_success_rate` is the network-wide active-slot coefficient
-/// (`f_block`); `stake` is the node's own stake.  `total_stake` does
-/// not appear here — it cancels with the draw range and stays the
-/// caller's concern.
-pub fn rb_win_threshold(rb_success_rate: f64, stake: u64) -> u64 {
-    (stake as f64 * rb_success_rate) as u64
+/// Holds `ln(1 − f)` precomputed once so per-slot threshold evaluation
+/// is a single `exp_m1` and a quantization.
+#[derive(Debug, Clone, Copy)]
+pub struct LotteryParams {
+    /// `ln(1 − f)`.  Always non-positive.  Set to `f64::NEG_INFINITY`
+    /// when `f == 1.0`, in which case every non-zero-stake threshold
+    /// saturates at `u64::MAX`.
+    ln_one_minus_f: f64,
+}
+
+impl LotteryParams {
+    /// `f` is the active-slot coefficient.  Must lie in `[0.0, 1.0]`.
+    pub fn new(f: f64) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&f),
+            "active-slot coefficient f must lie in [0,1]; got {f}"
+        );
+        Self {
+            ln_one_minus_f: (1.0 - f).ln(),
+        }
+    }
+
+    /// Threshold over `[0, 2^64)` for the Praos f_block lottery: a
+    /// uniform draw `d` wins iff `d < threshold`.
+    ///
+    /// `stake / total_stake` may exceed 1 only through caller bug; the
+    /// math is still well-defined and saturates at `u64::MAX`.
+    pub fn rb_win_threshold(&self, stake: u64, total_stake: u64) -> u64 {
+        if stake == 0 || total_stake == 0 {
+            return 0;
+        }
+        let sigma = stake as f64 / total_stake as f64;
+        // φ(σ) = 1 − (1 − f)^σ = 1 − exp(σ · ln(1 − f)) = −expm1(σ · ln(1 − f)).
+        // `exp_m1` keeps full f64 precision when its argument is near 0,
+        // which is the small-σ regime; computing `1 - exp(x)` directly
+        // would cancel away most of the bits there.
+        let phi = -(sigma * self.ln_one_minus_f).exp_m1();
+        quantize_phi(phi)
+    }
+}
+
+/// Map a probability `φ ∈ [0, 1]` to the `[0, 2^64)` integer range.
+/// Saturates at `u64::MAX` for `φ ≥ 1`; returns 0 for `φ ≤ 0`.
+fn quantize_phi(phi: f64) -> u64 {
+    // `2^64` is exactly representable in f64 (it's a power of two and
+    // fits in the exponent), but it doesn't fit in u64 — anything that
+    // would round up to `2^64` must saturate.
+    const TWO_POW_64: f64 = 18446744073709551616.0;
+    if !phi.is_finite() || phi <= 0.0 {
+        return 0;
+    }
+    if phi >= 1.0 {
+        return u64::MAX;
+    }
+    let scaled = phi * TWO_POW_64;
+    if scaled >= TWO_POW_64 {
+        u64::MAX
+    } else {
+        scaled as u64
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn full_stake_full_rate_threshold_equals_stake() {
-        assert_eq!(rb_win_threshold(1.0, 1000), 1000);
+    const TWO_POW_64: f64 = 18446744073709551616.0;
+
+    fn rate(params: &LotteryParams, stake: u64, total_stake: u64) -> f64 {
+        params.rb_win_threshold(stake, total_stake) as f64 / TWO_POW_64
     }
 
     #[test]
-    fn zero_rate_zero_threshold() {
-        assert_eq!(rb_win_threshold(0.0, 1000), 0);
+    fn zero_f_zero_threshold() {
+        let p = LotteryParams::new(0.0);
+        assert_eq!(p.rb_win_threshold(1000, 1000), 0);
     }
 
     #[test]
     fn zero_stake_zero_threshold() {
-        assert_eq!(rb_win_threshold(0.05, 0), 0);
+        let p = LotteryParams::new(0.05);
+        assert_eq!(p.rb_win_threshold(0, 1000), 0);
     }
 
     #[test]
-    fn linear_in_stake_at_fixed_rate() {
-        let rate = 0.05;
-        assert_eq!(rb_win_threshold(rate, 100), 5);
-        assert_eq!(rb_win_threshold(rate, 1_000), 50);
-        assert_eq!(rb_win_threshold(rate, 10_000), 500);
-        assert_eq!(rb_win_threshold(rate, 100_000), 5_000);
+    fn zero_total_stake_zero_threshold() {
+        let p = LotteryParams::new(0.05);
+        assert_eq!(p.rb_win_threshold(1, 0), 0);
     }
 
     #[test]
-    fn truncation_takes_floor() {
-        // 7 × 0.05 = 0.35 → truncates to 0.
-        assert_eq!(rb_win_threshold(0.05, 7), 0);
-        // 20 × 0.05 = 1.0 → exactly 1.
-        assert_eq!(rb_win_threshold(0.05, 20), 1);
-        // 21 × 0.05 = 1.05 → truncates to 1.
-        assert_eq!(rb_win_threshold(0.05, 21), 1);
+    fn full_f_full_stake_saturates() {
+        let p = LotteryParams::new(1.0);
+        assert_eq!(p.rb_win_threshold(1, 1), u64::MAX);
     }
 
     #[test]
-    fn integer_form_against_float_form_agree_in_expectation() {
-        // Sanity: the float form `rate × stake / total_stake` and the
-        // integer form `threshold / total_stake` agree to within one
-        // ulp / total_stake at realistic scales.  Pick stake high
-        // enough that the truncation bias is below 0.1%.
-        let rate = 0.05;
-        let stake = 1_000_u64;
-        let total_stake = 1_000_000_u64;
-        let float_p = rate * stake as f64 / total_stake as f64;
-        let int_p = rb_win_threshold(rate, stake) as f64 / total_stake as f64;
-        assert!((float_p - int_p).abs() < 1.0 / total_stake as f64);
+    fn full_stake_yields_f() {
+        // σ = 1 ⇒ φ(1) = 1 − (1 − f) = f.
+        let p = LotteryParams::new(0.05);
+        let observed = rate(&p, 1000, 1000);
+        assert!((observed - 0.05).abs() < 1e-15, "observed = {observed}");
+    }
+
+    #[test]
+    fn tiny_stake_has_nonzero_threshold() {
+        // The bug that prompted this rewrite: previously `stake × f < 1`
+        // truncated the threshold to zero, locking the node out of the
+        // lottery forever.  Spec-faithful φ is strictly positive for any
+        // non-zero stake at non-zero f.
+        let p = LotteryParams::new(0.05);
+        // 100-node cluster, equal stake: 10/1000 with f=0.05.
+        assert!(p.rb_win_threshold(10, 1000) > 0);
+        // Even a single stake unit out of a million still wins eventually.
+        assert!(p.rb_win_threshold(1, 1_000_000) > 0);
+    }
+
+    #[test]
+    fn first_derivative_at_zero_matches_neg_ln_one_minus_f() {
+        // φ'(0) = −ln(1 − f).  Verify by checking that for σ → 0 the
+        // rate φ/σ converges to that constant.
+        let f = 0.05;
+        let p = LotteryParams::new(f);
+        let expected_slope = -(1.0_f64 - f).ln();
+        // Pick σ small enough that the second-order term σ·f²/2 is below
+        // the assertion tolerance.
+        for (stake, total_stake) in [(1u64, 10_000_000u64), (1, 100_000_000)] {
+            let sigma = stake as f64 / total_stake as f64;
+            let observed_slope = rate(&p, stake, total_stake) / sigma;
+            assert!(
+                (observed_slope - expected_slope).abs() < 1e-8,
+                "σ={sigma}: φ/σ={observed_slope}, expected ≈ {expected_slope}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_libm_powf_reference() {
+        // Cross-check against the direct `(1-f).powf(σ)` form for a few
+        // points.  Catches any drift in the expm1-based path.
+        let f = 0.05;
+        let p = LotteryParams::new(f);
+        for (stake, total_stake) in [(1u64, 1_000_000u64), (10, 1_000), (500, 1_000), (1, 1)] {
+            let sigma = stake as f64 / total_stake as f64;
+            let reference = 1.0 - (1.0_f64 - f).powf(sigma);
+            let observed = rate(&p, stake, total_stake);
+            assert!(
+                (observed - reference).abs() < 1e-15_f64.max(reference * 1e-12),
+                "σ={sigma}: observed={observed}, reference={reference}"
+            );
+        }
+    }
+
+    #[test]
+    fn monotone_in_stake() {
+        let p = LotteryParams::new(0.05);
+        let mut prev = 0;
+        for stake in [1u64, 10, 100, 1_000, 10_000, 100_000, 1_000_000] {
+            let t = p.rb_win_threshold(stake, 1_000_000);
+            assert!(t > prev, "stake={stake}: threshold {t} not > prev {prev}");
+            prev = t;
+        }
+    }
+
+    #[test]
+    fn empirical_rate_matches_phi() {
+        // Monte Carlo: draw 100k u64s with a seeded PRNG; observed win
+        // rate should be within 4σ of φ.  At n=100k, p≈0.05, 4σ ≈ 4·√(np(1−p))
+        // ≈ 275 wins, i.e. < 0.3% deviation.
+        use rand::{Rng, SeedableRng};
+        let f = 0.05;
+        let stake = 100u64;
+        let total_stake = 1_000u64;
+        let p = LotteryParams::new(f);
+        let threshold = p.rb_win_threshold(stake, total_stake);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xc4f1_7d05_u64);
+        let n = 100_000;
+        let wins = (0..n).filter(|_| rng.gen::<u64>() < threshold).count();
+        let observed = wins as f64 / n as f64;
+        let expected = 1.0 - (1.0 - f).powf(stake as f64 / total_stake as f64);
+        let stderr = (expected * (1.0 - expected) / n as f64).sqrt();
+        assert!(
+            (observed - expected).abs() < 4.0 * stderr,
+            "observed {observed}, expected {expected} ± {}",
+            4.0 * stderr
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace the linear approximation `(stake * f) as u64` with the exact Praos formula `φ(σ) = 1 − (1 − f)^σ`, quantized to a `[0, 2^64)` `u64` threshold and compared against a uniform `u64` draw.
- Fixes the truncation bug that locked any node with `stake × f < 1` out of the lottery entirely — e.g. an equal-stake 100-node cluster at default `total_stake = 1000, f = 0.05` had every node at threshold zero and never produced an RB.
- Update two `consensus::leios::tests` quorum fixtures (7 → 8 voters) so they clear the ceil-based τ-quorum introduced in `33db4bba0`.

## Why this shape

- φ is evaluated via `exp_m1(σ · ln(1 − f))` so the low-stake regime (where most nodes live) keeps full f64 precision instead of cancelling away most of its bits.
- Quantization to `[0, 2^64)` is the only place precision is lost, and is well below the `1/2^64` resolution of the integer comparison.
- The integer-threshold / integer-draw shape is forward-compatible with a real VRF: when one lands only the draw source changes.

## Smoke test (100-node cluster, equal stake, f = 0.05)

| Metric | Observed | Expected |
| --- | --- | --- |
| RBGenerated (1571 slots) | **78** | 78.5 |
| Cluster rate | **0.0497 / slot** | 0.0500 / slot |
| Distinct producers | **54 / 100** | — |
| TipAdvanced events | 84 855 | — |

Within 0.06σ of the Poisson mean (4σ band [43, 114]). On `main` this config produces zero RBs.

## Test plan

- [x] `cargo test -p shared-consensus lottery::` — 10 unit tests including a 100k-draw empirical-rate Monte Carlo
- [x] `cargo test -p net-node` — refreshed quorum fixtures pass
- [x] 100-node equal-stake cluster smoke test (above) — block rate matches φ within 4σ
- [x] Reviewer: spot-check `quantize_phi` saturation at `φ ≥ 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)