### PR TITLE
Technical debt: limiting votingPanel resource requirements

### DIFF
--- a/net-rs/Cargo.lock
+++ b/net-rs/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -514,9 +514,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -566,7 +566,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -969,7 +969,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -1006,7 +1006,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1505,7 +1505,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2192,18 +2192,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/net-rs/net-cluster/configs/sample-cluster-t22.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-t22.toml
@@ -10,7 +10,7 @@
 # Behaviour invokes T21/T22 threat model, parameter description is given below.
 
 num_nodes = 25
-degree = 3
+degree = 5
 min_latency_ms = 5
 max_latency_ms = 100
 
@@ -29,11 +29,11 @@ tx_rate = 1.0
 kind = "t22"
 # Threshold (average percentage, 0-100) of the committee nodes, which
 # take offered eb messages. EB messages for the remaining nodes will be dropped.
-vote_threshold = 90
+vote_threshold = 75
 
 # Threshold (average percentage, 0-100) of the non-committee nodes
 # (non-voting nodes in Leios), which take offered eb messages.
-non_voting_threshold = 30
+non_voting_threshold = 20
 
 # `True` means that disruptions touch not only eb-offered/eb-txs-offered,
 # but also eb-received/eb-txs-received (in other words, true means more disruptions).

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -500,7 +500,7 @@ async fn get_votes_history(
             if let Some(statuses) = statuses {
                 let eb_known = statuses.eb_received || statuses.eb_generated;
                 count.votes_cast += statuses.vote_cast as u64;
-                count.rb_received += statuses.eb_received as u64;
+                count.rb_received += statuses.rb_received as u64;
                 count.eb_known += eb_known as u64;
                 if statuses.perm_committee_member {
                     count.perm_committee_members += 1;

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -17,9 +17,7 @@ use tokio::sync::{broadcast, mpsc, RwLock};
 use tower_http::cors::CorsLayer;
 use crate::config::{ActiveAttack, AttackRequest, ClusterControlConfig};
 use crate::topology::Topology;
-use crate::types::{
-    self, AggregatedVotesHistory, EventWindow, IngestedEvent, NodeVotes, StatsSnapshot, WINDOW_SIZE
-};
+use crate::types::{self, AggregatedVotesCount, AggregatedVotesHistory, EventWindow, IngestedEvent, NodeVotes, StatsSnapshot, WINDOW_SIZE};
 
 /// Control message sent from the HTTP handlers to the main loop for
 /// the runtime attack-trigger feature.
@@ -488,13 +486,28 @@ async fn get_votes_history(
     // History: from newest [idx=0, slot=last_slot] to oldest [idx=WINDOW_SIZE-1,
     //          slot=last_slot-WINDOW_SIZE+1].
     let mut history = Vec::new();
+    let mut votes_count = Vec::new();
     for slot in ((last_slot+1).saturating_sub(WINDOW_SIZE)..=last_slot).rev() {
         let Some(node_statuses) = votes.events.get(&slot) else {
             history.push("".to_string());
             continue;
         };
+
         let mut str = String::new();
+        let mut count = AggregatedVotesCount::default();
         for node_id in &node_ids {
+            let statuses = node_statuses.get(node_id);
+            if let Some(statuses) = statuses {
+                let eb_known = statuses.eb_received || statuses.eb_generated;
+                count.votes_cast += statuses.vote_cast as u64;
+                count.rb_received += statuses.eb_received as u64;
+                count.eb_known += eb_known as u64;
+                if statuses.perm_committee_member {
+                    count.perm_committee_members += 1;
+                    count.committee_members_know_eb += eb_known as u64;
+                }
+            }
+
             // Priority: Vote > EB > RB > Committee membership.
             // Rationale:
             // 1. Vote cast only if all other events happened; correctness of node
@@ -503,7 +516,7 @@ async fn get_votes_history(
             // 3. Committee info will be shown in empty slots, and committee does not change
             //    often, so viewer will guess it from adjacent columns, no need to specify
             //    this info each time.
-            str.push(match node_statuses.get(node_id) {
+            str.push(match statuses {
                 Some(NodeVotes {vote_cast: true, eb_received: true, rb_received: true, ..}) => '1',
                 Some(NodeVotes {vote_cast: true, eb_generated: true, ..}) => 'G',
                 Some(NodeVotes {eb_received: true, rb_received: true, ..}) => 'E',
@@ -515,12 +528,14 @@ async fn get_votes_history(
             });
         }
         history.push(str);
+        votes_count.push(count);
     };
 
     Json(AggregatedVotesHistory{
         last_slot,
         node_ids,
         votes: history, // TODO: serialize the full history of votes
+        votes_count,
     })
 }
 

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -490,6 +490,7 @@ async fn get_votes_history(
     for slot in ((last_slot+1).saturating_sub(WINDOW_SIZE)..=last_slot).rev() {
         let Some(node_statuses) = votes.events.get(&slot) else {
             history.push("".to_string());
+            votes_count.push(AggregatedVotesCount::default());
             continue;
         };
 

--- a/net-rs/net-cluster/src/types.rs
+++ b/net-rs/net-cluster/src/types.rs
@@ -67,6 +67,15 @@ pub struct NodeVotes {
     pub eb_generated: bool,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AggregatedVotesCount {
+    pub rb_received: u64,
+    pub eb_known: u64,
+    pub committee_members_know_eb: u64,
+    pub votes_cast: u64,
+    pub perm_committee_members: u64,
+}
+
 /// Number of recent slots to keep in the aggregated votes history for the UI.
 pub const WINDOW_SIZE: u64 = 25;
 
@@ -92,6 +101,8 @@ pub struct AggregatedVotesHistory {
     /// '?' - incorrect status (e.g. vote cast without RB received).
     /// In case of multiple statuses for a node, the max is taken: '1','G' > 'E' > 'R' > ' *' > '.'
     pub votes: Vec<String>,
+
+    pub votes_count: Vec<AggregatedVotesCount>
 }
 
 /// An ingested event with extracted metadata for aggregation.

--- a/net-rs/net-ui/src/App.tsx
+++ b/net-rs/net-ui/src/App.tsx
@@ -28,12 +28,18 @@ export default function App() {
   const networkTipCounts = useStore((s) => s.networkTipCounts);
   const selectedNodeId = useStore((s) => s.selectedNodeId);
   const selectedEdge = useStore((s) => s.selectedEdge);
+  const setVotingPanelVisible = useStore((s) => s.setVotingPanelVisible);
   const [eventLogOpen, setEventLogOpen] = useState(true);
   const [chartsOpen, setChartsOpen] = useState(true);
   const [chainTreeOpen, setChainTreeOpen] = useState(true);
   const [controlPanelOpen, setControlPanelOpen] = useState(false);
   const [votingPanelOpen, setVotingPanelOpen] = useState(false);
   const [attackPanelOpen, setAttackPanelOpen] = useState(false);
+
+  // Sync voting panel visibility to store
+  useEffect(() => {
+    setVotingPanelVisible(votingPanelOpen);
+  }, [votingPanelOpen, setVotingPanelVisible]);
 
   useEffect(() => {
     loadTopology();

--- a/net-rs/net-ui/src/components/VotingPanel.tsx
+++ b/net-rs/net-ui/src/components/VotingPanel.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography, Divider } from "@mui/material";
 import { useStore } from "@/store";
 
-type VoteCell = "NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect";
+type VoteCell = "NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty";
 
 function CellIcon({ value }: { value: VoteCell }) {
   if (value === "VoteCast") {
@@ -30,6 +30,9 @@ function CellIcon({ value }: { value: VoteCell }) {
   if (value === "Incorrect") {
     return <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "#ff1010" }} />;
   }
+  if (value === "Empty") {
+    return <Box sx={{ width: 12, height: 12, opacity: 0 }} />;
+  }
   return <Box sx={{ width: 2, height: 2, borderRadius: "50%", bgcolor: "rgba(180,180,180,0.8)" }} />;
 }
 
@@ -37,10 +40,16 @@ export function VotingPanel() {
   const topology = useStore((s) => s.topology);
   const matrix = useStore((s) => s.votingMatrix);
   const slotStart = useStore((s) => s.votingSlotStart);
+  const votingCounts = useStore((s) => s.votingCounts);
+  const overflowRow = useStore((s) => s.voiingMatrixOverflowRow);
 
   const nodes = topology?.nodes ?? [];
-  const rowCount = nodes.length;
+  const totalNodes = nodes.length;
   const colCount = matrix.length;
+  const matrixRowCount = matrix[0]?.length ?? Math.min(nodes.length, 1);
+  const rowCount = overflowRow === -1 ? matrixRowCount : matrixRowCount + 1;
+
+  const formatPct = (v: number | undefined) => ((v ?? -1) ? v : "0");
 
   return (
     <Box sx={{ p: 2, width: 820, maxWidth: "90vw", display: "flex", gap: 3 }}>
@@ -54,23 +63,53 @@ export function VotingPanel() {
           <Box sx={{ color: "text.secondary", fontWeight: 600 }}>Node \\ Slot</Box>
           {Array.from({ length: colCount }, (_, c) => (
             <Box key={`h-${c}`} sx={{ color: "text.secondary", textAlign: "center" }} title={`slot ${slotStart + c}`}>
-              {(slotStart + c) % 1000}
+              {(slotStart + c) % 100}
             </Box>
           ))}
 
           {Array.from({ length: rowCount }, (_, r) => (
             <Box key={`r-${r}`} sx={{ display: "contents" }}>
-              <Box sx={{ pr: 1, color: "text.primary", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={nodes[r].node_id}>
-                {nodes[r].node_id}
+              <Box
+                sx={{ pr: 1, color: "text.primary", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+              >
+                {r === overflowRow ? `${totalNodes - rowCount + 1} nodes hidden` : nodes[r]?.node_id}
               </Box>
               {Array.from({ length: colCount }, (_, c) => {
-                const value = (matrix[c]?.[r] ?? "NoEvent") as VoteCell;
+                const value = (matrix[c]?.[r] ?? "Empty") as VoteCell;
                 return (
                   <Box key={`c-${c}-r-${r}`} sx={{ display: "flex", alignItems: "center", justifyContent: "center", width: 16, height: 16 }}>
                     <CellIcon value={value} />
                   </Box>
                 );
               })}
+            </Box>
+          ))}
+        </Box>
+
+        {/* Separator line */}
+        <Divider sx={{ my: 1, borderColor: "rgba(255,255,255,0.3)" }} />
+
+        {/* Aggregated counts */}
+        <Box sx={{ display: "grid", gridTemplateColumns: `160px repeat(${colCount}, 16px)`, gap: 0.5, alignItems: "center", fontSize: 10 }}>
+          <Box sx={{ color: "text.secondary", fontWeight: 600, whiteSpace: "nowrap" }}>EB known (total), %</Box>
+          {Array.from({ length: colCount }, (_, c) => (
+            <Box key={`eb-${c}`} sx={{ textAlign: "center", color: "#00eeee" }}>
+              {formatPct(votingCounts[c]?.ebReceivedPct)}
+            </Box>
+          ))}
+
+          <Box sx={{ color: "text.secondary", fontWeight: 600, whiteSpace: "nowrap" }}>EB known (committee), %</Box>
+          {Array.from({ length: colCount }, (_, c) => (
+            <Box key={`cmt-${c}`} sx={{ textAlign: "center", color: "#fdd835" }}>
+              {formatPct(votingCounts[c]?.ebKnownToCommitteePct)}
+            </Box>
+          ))}
+
+          {/* Row: Voted % */}
+          <Box sx={{ color: "text.secondary", fontWeight: 600, whiteSpace: "nowrap" }}>Voted (committee), %</Box>
+          {Array.from({ length: colCount }, (_, c) => (
+            <Box key={`v-${c}`} sx={{ textAlign: "center", color: "#66bb6a" }}>
+              {formatPct(votingCounts[c]?.votedPct)}
             </Box>
           ))}
         </Box>

--- a/net-rs/net-ui/src/components/VotingPanel.tsx
+++ b/net-rs/net-ui/src/components/VotingPanel.tsx
@@ -41,7 +41,7 @@ export function VotingPanel() {
   const matrix = useStore((s) => s.votingMatrix);
   const slotStart = useStore((s) => s.votingSlotStart);
   const votingCounts = useStore((s) => s.votingCounts);
-  const overflowRow = useStore((s) => s.voiingMatrixOverflowRow);
+  const overflowRow = useStore((s) => s.votingMatrixOverflowRow);
 
   const nodes = topology?.nodes ?? [];
   const totalNodes = nodes.length;

--- a/net-rs/net-ui/src/store.ts
+++ b/net-rs/net-ui/src/store.ts
@@ -94,9 +94,15 @@ export interface DashboardState {
   loadConfig: () => Promise<void>;
   restartCluster: (config: ClusterControlConfig) => Promise<void>;
 
+  // Voting panel visibility
+  votingPanelVisible: boolean;
+  setVotingPanelVisible: (v: boolean) => void;
+
   // Voting panel data (column-major: [slot][row])
-  votingMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect")[][];
+  votingMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty")[][];
+  voiingMatrixOverflowRow: number;
   votingSlotStart: number;
+  votingCounts: { ebReceivedPct: number; ebKnownToCommitteePct: number; votedPct: number }[];
 
   // Runtime attack trigger
   activeAttack: ActiveAttack | null;
@@ -139,8 +145,12 @@ export const useStore = create<DashboardState>()((set, get) => ({
   networkTipCounts: {},
 
   // Voting panel
+  votingPanelVisible: false,
+  setVotingPanelVisible: (v) => set({ votingPanelVisible: v }),
   votingMatrix: [],
+  voiingMatrixOverflowRow: -1,
   votingSlotStart: 0,
+  votingCounts: [],
 
   pollStats: async () => {
     try {
@@ -234,20 +244,23 @@ export const useStore = create<DashboardState>()((set, get) => ({
 
       const curSnap = { time: now, bandwidth: totalBandwidth, messages: totalMessages, blocks: totalBlocks, forks: curForks };
 
+      const showVotingPanel = get().votingPanelVisible;
+
       const VOTING_SLOTS = 24;
-      const MAX_NODES_VOTING_PANEL = 30;
-      const topoNodes = get().topology?.nodes ?? [];
+      const MAX_NODES_VOTING_PANEL = 20;
+      const topoNodes = showVotingPanel ? (get().topology?.nodes ?? []) : [];
       const nodeCount = topoNodes.length;
 
-      const aggregated_votes = await fetchAggregatedVotesHistory();
-      const votes_history = aggregated_votes.votes;
-      const votingSlotStart = aggregated_votes.last_slot;
+      const aggregated_votes = showVotingPanel ? await fetchAggregatedVotesHistory() : null;
+      const votes_history = aggregated_votes?.votes ?? [];
+      const votingSlotStart = aggregated_votes?.last_slot ?? 0;
+      const votes_count = aggregated_votes?.votes_count ?? [];
       let nodeIds: Record<string, number> = {};
-      for (let i = 0; i < aggregated_votes.node_ids.length; i++) {
-        nodeIds[aggregated_votes.node_ids[i]] = i;
+      for (let i = 0; i < (aggregated_votes?.node_ids ?? []).length; i++) {
+        nodeIds[aggregated_votes?.node_ids[i]] = i;
       }
 
-      const nextMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect")[][] = Array.from(
+      const nextMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty")[][] = Array.from(
         {length: VOTING_SLOTS},
         (_, i) => {
           // Vote events in the string are written from older slots to most recent slot.
@@ -268,9 +281,23 @@ export const useStore = create<DashboardState>()((set, get) => ({
               return "NoEvent" as const;
             });
           }
-          return Array.from({length: nodeCount}, () => "NoEvent" as const);
+
+          return Array.from({length: Math.min(MAX_NODES_VOTING_PANEL, nodeCount)}, () => "NoEvent" as const);
         }
       )
+
+      const nextMatrixOverflowRow = nodeCount > MAX_NODES_VOTING_PANEL ? MAX_NODES_VOTING_PANEL : -1;
+
+      const nextCounts = Array.from({length: VOTING_SLOTS}, (_, i) => {
+        const votes = votes_count[votes_history.length - i - 1] ?? null;
+        if (!votes) return { ebReceivedPct: 0, ebKnownToCommitteePct: 0, votedPct: 0 };
+        const comm = votes.perm_committee_members;
+        return {
+          ebReceivedPct: nodeCount > 0 ? Math.floor((votes.eb_known / nodeCount) * 100) : 0,
+          ebKnownToCommitteePct: comm > 0 ? Math.floor((votes.committee_members_know_eb / comm) * 100) : 0,
+          votedPct: comm > 0 ? Math.floor((votes.votes_cast / comm) * 100) : 0,
+        };
+      });
 
       if (prevSnapshot) {
         const changed =
@@ -325,14 +352,18 @@ export const useStore = create<DashboardState>()((set, get) => ({
             networkChainTree,
             networkTipCounts: tipCounts,
             votingMatrix: nextMatrix,
+            votingMatrixOverflowRow: nextMatrixOverflowRow,
             votingSlotStart,
+            votingCounts: nextCounts,
           }));
         } else {
           // No change — just update latestStats, don't emit a data point
           set({
             latestStats: stats, networkChainTree, networkTipCounts: tipCounts,
             votingMatrix: nextMatrix,
+            voiingMatrixOverflowRow: nextMatrixOverflowRow,
             votingSlotStart,
+            votingCounts: nextCounts,
           });
         }
       } else {
@@ -348,7 +379,9 @@ export const useStore = create<DashboardState>()((set, get) => ({
           networkChainTree,
           networkTipCounts: tipCounts,
           votingMatrix: nextMatrix,
+          voiingMatrixOverflowRow: nextMatrixOverflowRow,
           votingSlotStart,
+          votingCounts: nextCounts,
         });
       }
     } catch (e) {
@@ -613,6 +646,7 @@ export const useStore = create<DashboardState>()((set, get) => ({
           selectedNodeId: null,
           selectedEdge: null,
           votingMatrix: [],
+          voiingMatrixOverflowRow: -1,
           votingSlotStart: 0,
           activeAttack: null,
           attackingIndices: new Set<number>(),

--- a/net-rs/net-ui/src/store.ts
+++ b/net-rs/net-ui/src/store.ts
@@ -100,7 +100,7 @@ export interface DashboardState {
 
   // Voting panel data (column-major: [slot][row])
   votingMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty")[][];
-  voiingMatrixOverflowRow: number;
+  votingMatrixOverflowRow: number;
   votingSlotStart: number;
   votingCounts: { ebReceivedPct: number; ebKnownToCommitteePct: number; votedPct: number }[];
 
@@ -148,7 +148,7 @@ export const useStore = create<DashboardState>()((set, get) => ({
   votingPanelVisible: false,
   setVotingPanelVisible: (v) => set({ votingPanelVisible: v }),
   votingMatrix: [],
-  voiingMatrixOverflowRow: -1,
+  votingMatrixOverflowRow: -1,
   votingSlotStart: 0,
   votingCounts: [],
 
@@ -244,8 +244,9 @@ export const useStore = create<DashboardState>()((set, get) => ({
 
       const curSnap = { time: now, bandwidth: totalBandwidth, messages: totalMessages, blocks: totalBlocks, forks: curForks };
 
-      const showVotingPanel = get().votingPanelVisible;
+      /// Voting panel data preparation: step 1. fetch general info.
 
+      const showVotingPanel = get().votingPanelVisible;
       const VOTING_SLOTS = 24;
       const MAX_NODES_VOTING_PANEL = 20;
       const topoNodes = showVotingPanel ? (get().topology?.nodes ?? []) : [];
@@ -259,6 +260,8 @@ export const useStore = create<DashboardState>()((set, get) => ({
       for (const [i, nodeId] of (aggregated_votes?.node_ids ?? []).entries()) {
         nodeIds[nodeId] = i;
       }
+
+      /// Voting panel matrix preparation: step 2, build voting matrix.
 
       const nextMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty")[][] = Array.from(
         {length: VOTING_SLOTS},
@@ -285,8 +288,9 @@ export const useStore = create<DashboardState>()((set, get) => ({
           return Array.from({length: Math.min(MAX_NODES_VOTING_PANEL, nodeCount)}, () => "NoEvent" as const);
         }
       )
-
       const nextMatrixOverflowRow = nodeCount > MAX_NODES_VOTING_PANEL ? MAX_NODES_VOTING_PANEL : -1;
+
+      /// Voting panel matrix preparation: step 3, counts.
 
       const nextCounts = Array.from({length: VOTING_SLOTS}, (_, i) => {
         const votes = votes_count[votes_history.length - i - 1] ?? null;
@@ -298,6 +302,8 @@ export const useStore = create<DashboardState>()((set, get) => ({
           votedPct: comm > 0 ? Math.floor((votes.votes_cast / comm) * 100) : 0,
         };
       });
+
+      /// Stats
 
       if (prevSnapshot) {
         const changed =
@@ -361,7 +367,7 @@ export const useStore = create<DashboardState>()((set, get) => ({
           set({
             latestStats: stats, networkChainTree, networkTipCounts: tipCounts,
             votingMatrix: nextMatrix,
-            voiingMatrixOverflowRow: nextMatrixOverflowRow,
+            votingMatrixOverflowRow: nextMatrixOverflowRow,
             votingSlotStart,
             votingCounts: nextCounts,
           });
@@ -379,7 +385,7 @@ export const useStore = create<DashboardState>()((set, get) => ({
           networkChainTree,
           networkTipCounts: tipCounts,
           votingMatrix: nextMatrix,
-          voiingMatrixOverflowRow: nextMatrixOverflowRow,
+          votingMatrixOverflowRow: nextMatrixOverflowRow,
           votingSlotStart,
           votingCounts: nextCounts,
         });
@@ -646,7 +652,7 @@ export const useStore = create<DashboardState>()((set, get) => ({
           selectedNodeId: null,
           selectedEdge: null,
           votingMatrix: [],
-          voiingMatrixOverflowRow: -1,
+          votingMatrixOverflowRow: -1,
           votingSlotStart: 0,
           activeAttack: null,
           attackingIndices: new Set<number>(),

--- a/net-rs/net-ui/src/store.ts
+++ b/net-rs/net-ui/src/store.ts
@@ -256,8 +256,8 @@ export const useStore = create<DashboardState>()((set, get) => ({
       const votingSlotStart = aggregated_votes?.last_slot ?? 0;
       const votes_count = aggregated_votes?.votes_count ?? [];
       let nodeIds: Record<string, number> = {};
-      for (let i = 0; i < (aggregated_votes?.node_ids ?? []).length; i++) {
-        nodeIds[aggregated_votes?.node_ids[i]] = i;
+      for (const [i, nodeId] of (aggregated_votes?.node_ids ?? []).entries()) {
+        nodeIds[nodeId] = i;
       }
 
       const nextMatrix: ("NoEvent" | "RBReceived" | "EBReceived" | "EBGenerated" | "VoteCast" | "Committee" | "Incorrect" | "Empty")[][] = Array.from(

--- a/net-rs/net-ui/src/types.ts
+++ b/net-rs/net-ui/src/types.ts
@@ -90,10 +90,19 @@ export interface ClusterControlConfig {
   node_config: Record<string, unknown>;
 }
 
+export interface AggregatedVotesCount {
+  rb_received: number,
+  eb_known: number,
+  committee_members_know_eb: number,
+  votes_cast: number,
+  perm_committee_members: number,
+}
+
 export interface AggregateVotesHistory {
   last_slot: number;
   node_ids: string[];
   votes: string[];
+  votes_count: AggregatedVotesCount[];
 }
 
 // Mirrors shared_consensus::leios::NoVoteReason (kebab-case serde).


### PR DESCRIPTION
Currently voting/block information in net-rs/net-ui/../VotingPanel is not limited by constants, so it creates excessive load and unwanted visualisation effects in case of big networks. 

This PR introduces hard limits for VotingPanel size, while still trying to keep necessary information visible:
1. Counters for votes/blocks added: number of votes/availabe eb's is displayed in VotingPanel for each slot.
2. Number of node lines in VotingPanel is limited by 20.
3. When VotingPanel is disabled, no actual data processing for the panel is done (no requests to server, etc).
