### PR TITLE
Shd/replacing vec with arcs

### DIFF
--- a/net-rs/Cargo.lock
+++ b/net-rs/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blake2b_simd"
@@ -755,9 +755,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru-slab"

--- a/net-rs/Cargo.lock
+++ b/net-rs/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -514,9 +514,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -566,7 +566,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -969,7 +969,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -1006,7 +1006,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1505,7 +1505,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2192,18 +2192,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/net-rs/net-cli/src/serve.rs
+++ b/net-rs/net-cli/src/serve.rs
@@ -4,6 +4,7 @@
 //! Uses the multi-peer coordinator in responder-only mode. The block
 //! generator injects blocks via `NetworkCommand::InjectBlock`.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use rand::rngs::StdRng;
@@ -116,8 +117,8 @@ async fn leios_generator(commands: mpsc::Sender<NetworkCommand>, rate: f64) {
         let mut vote_ids = Vec::new();
         let mut vote_data = Vec::new();
         for v in 0..num_votes {
-            vote_ids.push((slot, vec![v]));
-            vote_data.push(vec![0xA0, v]); // minimal CBOR
+            vote_ids.push((slot, Arc::new(vec![v])));
+            vote_data.push(Arc::new(vec![0xA0, v])); // minimal CBOR
         }
         let _ = commands
             .send(NetworkCommand::InjectLeiosVotes {

--- a/net-rs/net-cli/src/submit.rs
+++ b/net-rs/net-cli/src/submit.rs
@@ -3,6 +3,7 @@
 //! By default submits a single random transaction and exits when it is
 //! accepted. With `--tx-rate`, generates transactions on a Poisson schedule.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use rand::rngs::StdRng;
@@ -51,8 +52,8 @@ fn generate_random_tx(rng: &mut StdRng, min_size: usize, max_size: usize) -> Pen
     enc.bytes(&payload).expect("CBOR encode tx body");
 
     PendingTx {
-        tx_id: TxId(id_buf),
-        body: TxBody(body_buf),
+        tx_id: TxId(Arc::new(id_buf)),
+        body: TxBody(Arc::new(body_buf)),
         size: size as u32,
     }
 }

--- a/net-rs/net-cluster/configs/sample-cluster-t22.toml
+++ b/net-rs/net-cluster/configs/sample-cluster-t22.toml
@@ -10,7 +10,7 @@
 # Behaviour invokes T21/T22 threat model, parameter description is given below.
 
 num_nodes = 25
-degree = 3
+degree = 7
 min_latency_ms = 5
 max_latency_ms = 100
 

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -34,7 +34,7 @@ struct OfferDedup {
     /// `(peer, slot, voter_id)` already forwarded as part of
     /// `LeiosVotesOffered`.  Per-vote because a single offer event
     /// carries a batch.
-    seen_votes: BTreeSet<(PeerId, u64, Vec<u8>)>,
+    seen_votes: BTreeSet<(PeerId, u64, Arc<Vec<u8>>)>,
     max_slot: u64,
     window: u64,
 }
@@ -74,8 +74,8 @@ impl OfferDedup {
     fn fresh_votes(
         &mut self,
         peer: PeerId,
-        votes: Vec<(u64, Vec<u8>)>,
-    ) -> Vec<(u64, Vec<u8>)> {
+        votes: Vec<(u64, Arc<Vec<u8>>)>,
+    ) -> Vec<(u64, Arc<Vec<u8>>)> {
         let mut out = Vec::with_capacity(votes.len());
         for (slot, voter_id) in votes {
             self.update_slot(slot);

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -2442,9 +2442,9 @@ mod tests {
     async fn record_leios_eb_manifest_enables_resolver_backed_serve() {
         use crate::store::leios_store::TxBodyResolver;
 
-        struct StubResolver(std::collections::HashMap<Vec<u8>, Vec<u8>>);
+        struct StubResolver(std::collections::HashMap<Vec<u8>, Arc<Vec<u8>>>);
         impl TxBodyResolver for StubResolver {
-            fn resolve_body(&self, tx_id: &[u8]) -> Option<Vec<u8>> {
+            fn resolve_body(&self, tx_id: &[u8]) -> Option<Arc<Vec<u8>>> {
                 self.0.get(tx_id).cloned()
             }
         }
@@ -2452,7 +2452,7 @@ mod tests {
         let h0 = [0x01u8; 32];
         let h1 = [0x02u8; 32];
         let resolver: Arc<dyn TxBodyResolver> = Arc::new(StubResolver(
-            [(h0.to_vec(), vec![10u8]), (h1.to_vec(), vec![20u8])]
+            [(h0.to_vec(), Arc::new(vec![10u8])), (h1.to_vec(), Arc::new(vec![20u8]))]
                 .into_iter()
                 .collect(),
         ));
@@ -2500,7 +2500,7 @@ mod tests {
                 }
             }
         }
-        assert_eq!(got, Some(vec![vec![10u8], vec![20u8]]));
+        assert_eq!(got, Some(vec![Arc::new(vec![10u8]), Arc::new(vec![20u8])]));
 
         net_cmd_sender
             .send(NetworkCommand::Shutdown)
@@ -2533,7 +2533,7 @@ mod tests {
 
         let hash = [0xA1u8; 32];
         let point = Point::Specific { slot: 7, hash };
-        let txs: Vec<Vec<u8>> = vec![vec![1, 2, 3], vec![4, 5, 6]];
+        let txs: Vec<Arc<Vec<u8>>> = vec![Arc::new(vec![1, 2, 3]), Arc::new(vec![4, 5, 6])];
 
         net_cmd_sender
             .send(NetworkCommand::InjectLeiosBlockTxs {
@@ -2588,9 +2588,9 @@ mod tests {
         // Manifest must be in place before the coordinator can position
         // received bodies. In production net-node records this after
         // decoding the EB body; here we set it directly.
-        let body0 = b"alpha".to_vec();
-        let body1 = b"bravo".to_vec();
-        let body2 = b"charlie".to_vec();
+        let body0 = Arc::new(b"alpha".to_vec());
+        let body1 = Arc::new(b"bravo".to_vec());
+        let body2 = Arc::new(b"charlie".to_vec());
         let h0 = blake2b_256(&body0);
         let h1 = blake2b_256(&body1);
         let h2 = blake2b_256(&body2);
@@ -2670,7 +2670,7 @@ mod tests {
                 PeerId(3),
                 PeerEvent::LeiosBlockTxsFetched {
                     point: point.clone(),
-                    transactions: vec![b"orphan".to_vec()],
+                    transactions: vec![Arc::new(b"orphan".to_vec())],
                 },
             )
             .await;

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -592,7 +592,7 @@ impl Coordinator {
                             .enumerate()
                             .map(|(i, h)| (*h, i as u32))
                             .collect();
-                        let indexed: BTreeMap<u32, Vec<u8>> = transactions
+                        let indexed: BTreeMap<u32, Arc<Vec<u8>>> = transactions
                             .iter()
                             .filter_map(|body| {
                                 let id = blake2b_256(body);

--- a/net-rs/net-core/src/multi_peer/types.rs
+++ b/net-rs/net-core/src/multi_peer/types.rs
@@ -1,7 +1,7 @@
 //! Event and command types for the coordinator ↔ application boundary.
 
 use std::collections::BTreeMap;
-
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::peer::{ConnectionMode, PeerId};
@@ -68,7 +68,7 @@ pub enum NetworkEvent {
     PeersDiscovered { peers: Vec<PeerAddress> },
 
     /// A transaction was received from an inbound peer (via TxSubmission server).
-    TransactionReceived { peer_id: PeerId, body: Vec<u8> },
+    TransactionReceived { peer_id: PeerId, body: Arc<Vec<u8>> },
 
     /// TxSubmission client: a peer requested `count` tx ids (blocking mode).
     TxsRequested { peer_id: PeerId, count: u16 },
@@ -101,7 +101,7 @@ pub enum NetworkEvent {
     /// Leios: fetched transactions for an EB arrived.
     LeiosBlockTxsReceived {
         point: Point,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Arc<Vec<u8>>>,
     },
 
     /// Response to `QueryPeers`: snapshot of all connected peers.
@@ -187,7 +187,7 @@ pub enum NetworkCommand {
     /// (for responder peers to serve via `MsgLeiosBlockTxsRequest`).
     InjectLeiosBlockTxs {
         point: Point,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Arc<Vec<u8>>>,
     },
 
     /// Record the ordered tx-hash list of an EB whose body the receiver

--- a/net-rs/net-core/src/multi_peer/types.rs
+++ b/net-rs/net-core/src/multi_peer/types.rs
@@ -85,7 +85,7 @@ pub enum NetworkEvent {
     /// Leios: votes are available for download from a peer.
     LeiosVotesOffered {
         peer_id: PeerId,
-        votes: Vec<(u64, Vec<u8>)>,
+        votes: Vec<(u64, Arc<Vec<u8>>)>,
     },
 
     /// Leios: a fetched endorser block arrived.
@@ -94,8 +94,8 @@ pub enum NetworkEvent {
     /// Leios: fetched votes arrived.
     /// `vote_ids` are (slot, issuer_id) keys; `vote_data` are the CBOR bodies.
     LeiosVotesReceived {
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     },
 
     /// Leios: fetched transactions for an EB arrived.
@@ -177,7 +177,7 @@ pub enum NetworkCommand {
     /// per peer in the policy's per-peer grouping).
     FetchLeiosVotes {
         peer_id: PeerId,
-        votes: Vec<(u64, Vec<u8>)>,
+        votes: Vec<(u64, Arc<Vec<u8>>)>,
     },
 
     /// Inject a Leios block into the Leios store (for responder peers to serve).
@@ -201,8 +201,8 @@ pub enum NetworkCommand {
 
     /// Inject votes into the Leios store (for responder peers to serve).
     InjectLeiosVotes {
-        votes: Vec<(u64, Vec<u8>)>,
-        data: Vec<Vec<u8>>,
+        votes: Vec<(u64, Arc<Vec<u8>>)>,
+        data: Vec<Arc<Vec<u8>>>,
     },
 
     /// Provide transactions to a specific peer via TxSubmission.

--- a/net-rs/net-core/src/peer/peer_task.rs
+++ b/net-rs/net-core/src/peer/peer_task.rs
@@ -450,7 +450,7 @@ pub(crate) enum LeiosFetchCommand {
         bitmap: std::collections::BTreeMap<u16, u64>,
     },
     Votes {
-        votes: Vec<(u64, Vec<u8>)>,
+        votes: Vec<(u64, Arc<Vec<u8>>)>,
     },
 }
 
@@ -1122,7 +1122,7 @@ mod tests {
             assert!(matches!(msg, LnMsg::MsgLeiosNotificationRequestNext));
             runner
                 .send(&LnMsg::MsgLeiosVotesOffer {
-                    votes: vec![(100, vec![0x01])],
+                    votes: vec![(100, Arc::new(vec![0x01]))],
                 })
                 .await
                 .unwrap();
@@ -1155,7 +1155,7 @@ mod tests {
             let (_id, event2) = event_receiver.recv().await.unwrap();
             match event2 {
                 PeerEvent::LeiosVotesOffered { votes } => {
-                    assert_eq!(votes, vec![(100, vec![0x01])]);
+                    assert_eq!(votes, vec![(100, Arc::new(vec![0x01]))]);
                 }
                 other => panic!("expected LeiosVotesOffered, got {other:?}"),
             }

--- a/net-rs/net-core/src/peer/peer_task.rs
+++ b/net-rs/net-core/src/peer/peer_task.rs
@@ -1296,8 +1296,8 @@ mod tests {
 
         // Send a transaction.
         let tx = PendingTx {
-            tx_id: TxId(vec![0x44, 0x01, 0x02, 0x03, 0x04]), // CBOR bytes(4)
-            body: TxBody(vec![0x45, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E]), // CBOR bytes(5)
+            tx_id: TxId(Arc::new(vec![0x44, 0x01, 0x02, 0x03, 0x04])), // CBOR bytes(4)
+            body: TxBody(Arc::new(vec![0x45, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E])), // CBOR bytes(5)
             size: 5,
         };
         tx_sender.send(tx).await.unwrap();
@@ -1307,7 +1307,7 @@ mod tests {
             let (_id, event) = server_event_rx.recv().await.unwrap();
             match event {
                 PeerEvent::TransactionReceived { body } => {
-                    assert_eq!(body, vec![0x45, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E]);
+                    assert_eq!(*body, vec![0x45, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E]);
                 }
                 other => panic!("expected TransactionReceived, got {other:?}"),
             }

--- a/net-rs/net-core/src/peer/server_handlers.rs
+++ b/net-rs/net-core/src/peer/server_handlers.rs
@@ -661,6 +661,7 @@ mod tests {
     use crate::protocols::leios_fetch::{self, LeiosFetch};
     use crate::protocols::leios_notify::{self, LeiosNotify};
     use crate::types::{BlockBody, Point, WrappedHeader};
+    use std::sync::Arc;
 
     fn make_point(slot: u64) -> Point {
         Point::Specific {
@@ -989,7 +990,7 @@ mod tests {
         let (store, _rx) = LeiosStore::new(100);
         let hash = [0x77u8; 32];
         let point = Point::Specific { slot: 50, hash };
-        let txs: Vec<Vec<u8>> = (0..100u8).map(|i| vec![i, i, i]).collect();
+        let txs: Vec<Arc<Vec<u8>>> = (0..100u8).map(|i| Arc::new(vec![i, i, i])).collect();
         store.inject_block_txs_full(point.clone(), txs);
 
         let server_handle =
@@ -1004,10 +1005,10 @@ mod tests {
 
         // Server returns those four in ascending order.
         assert_eq!(got.len(), 4);
-        assert_eq!(got[0], vec![0, 0, 0]);
-        assert_eq!(got[1], vec![5, 5, 5]);
-        assert_eq!(got[2], vec![64, 64, 64]);
-        assert_eq!(got[3], vec![99, 99, 99]);
+        assert_eq!(*got[0], vec![0, 0, 0]);
+        assert_eq!(*got[1], vec![5, 5, 5]);
+        assert_eq!(*got[2], vec![64, 64, 64]);
+        assert_eq!(*got[3], vec![99, 99, 99]);
 
         let _ = leios_fetch::done(&mut client).await;
         server_handle.await.ok();
@@ -1020,9 +1021,9 @@ mod tests {
         use crate::store::leios_store::TxBodyResolver;
         use std::sync::Arc;
 
-        struct StubResolver(std::collections::HashMap<Vec<u8>, Vec<u8>>);
+        struct StubResolver(std::collections::HashMap<Vec<u8>, Arc<Vec<u8>>>);
         impl TxBodyResolver for StubResolver {
-            fn resolve_body(&self, tx_id: &[u8]) -> Option<Vec<u8>> {
+            fn resolve_body(&self, tx_id: &[u8]) -> Option<Arc<Vec<u8>>> {
                 self.0.get(tx_id).cloned()
             }
         }
@@ -1042,13 +1043,14 @@ mod tests {
         let h2 = [0xA2u8; 32];
         let resolver: Arc<dyn TxBodyResolver> = Arc::new(StubResolver(
             [
-                (h0.to_vec(), vec![0xB0]),
-                (h1.to_vec(), vec![0xB1]),
-                (h2.to_vec(), vec![0xB2]),
+                (h0.to_vec(), Arc::new(vec![0xB0])),
+                (h1.to_vec(), Arc::new(vec![0xB1])),
+                (h2.to_vec(), Arc::new(vec![0xB2])),
             ]
             .into_iter()
             .collect(),
         ));
+
         // Receiver-style store: only the manifest is recorded; bodies
         // come from the resolver.
         let (store, _rx) = LeiosStore::new_with_resolver(100, Some(resolver));
@@ -1064,7 +1066,8 @@ mod tests {
         let got = leios_fetch::fetch_block_txs(&mut client, point, bitmap)
             .await
             .expect("server should respond");
-        assert_eq!(got, vec![vec![0xB0u8], vec![0xB2u8]]);
+        assert_eq!(*got[0], vec![0xB0u8]);
+        assert_eq!(*got[1], vec![0xB2u8]);
 
         let _ = leios_fetch::done(&mut client).await;
         server_handle.await.ok();

--- a/net-rs/net-core/src/peer/server_handlers.rs
+++ b/net-rs/net-core/src/peer/server_handlers.rs
@@ -624,7 +624,9 @@ pub async fn serve_leios_fetch(lf_send: CodecSend, lf_recv: CodecRecv, store: Ar
                     break;
                 };
                 if runner
-                    .send(&LfMsg::MsgLeiosBlockTxs { transactions })
+                    .send(&LfMsg::MsgLeiosBlockTxs {
+                        transactions: transactions.iter().map(|x| x.clone()).collect()
+                    })
                     .await
                     .is_err()
                 {

--- a/net-rs/net-core/src/peer/types.rs
+++ b/net-rs/net-core/src/peer/types.rs
@@ -62,7 +62,7 @@ pub enum PeerEvent {
     LeiosBlockTxsOffered { point: Point },
 
     /// LeiosNotify: votes are available for download.
-    LeiosVotesOffered { votes: Vec<(u64, Vec<u8>)> },
+    LeiosVotesOffered { votes: Vec<(u64, Arc<Vec<u8>>)> },
 
     /// LeiosFetch: a requested endorser block arrived.
     LeiosBlockFetched { point: Point, block: Vec<u8> },
@@ -70,8 +70,8 @@ pub enum PeerEvent {
     /// LeiosFetch: requested votes arrived.
     /// `vote_ids` are (slot, issuer_id) keys; `vote_data` are the CBOR bodies.
     LeiosVotesFetched {
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     },
 
     /// LeiosFetch: requested transactions for an EB arrived.
@@ -106,7 +106,7 @@ pub enum PeerCommand {
     },
 
     /// Fetch votes via LeiosFetch.
-    FetchLeiosVotes { votes: Vec<(u64, Vec<u8>)> },
+    FetchLeiosVotes { votes: Vec<(u64, Arc<Vec<u8>>)> },
 
     /// Provide transactions to this peer via TxSubmission.
     ProvideTxs { txs: Vec<PendingTx> },

--- a/net-rs/net-core/src/peer/types.rs
+++ b/net-rs/net-core/src/peer/types.rs
@@ -47,7 +47,7 @@ pub enum PeerEvent {
     PeersDiscovered { peers: Vec<PeerAddress> },
 
     /// TxSubmission server: received a transaction from a client.
-    TransactionReceived { body: Vec<u8> },
+    TransactionReceived { body: Arc<Vec<u8>> },
 
     /// TxSubmission client: peer requested `count` tx ids (blocking mode).
     TxsRequested { count: u16 },
@@ -77,7 +77,7 @@ pub enum PeerEvent {
     /// LeiosFetch: requested transactions for an EB arrived.
     LeiosBlockTxsFetched {
         point: Point,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Arc<Vec<u8>>>,
     },
 
     /// BlockFetch: peer responded with NoBlocks for a requested range.

--- a/net-rs/net-core/src/protocols/leios_fetch/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/codec.rs
@@ -13,7 +13,7 @@
 //!   msgDone                        = [9]
 
 use std::collections::BTreeMap;
-
+use std::sync::Arc;
 use minicbor::decode::Error as DecodeError;
 use minicbor::encode::Error as EncodeError;
 use minicbor::{Decoder, Encoder};
@@ -50,7 +50,6 @@ impl minicbor::Encode<()> for Message {
             Message::MsgLeiosBlockTxs { transactions } => {
                 e.array(2)?;
                 e.u32(3)?;
-                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
                 encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgLeiosVotesRequest { votes } => {
@@ -88,7 +87,6 @@ impl minicbor::Encode<()> for Message {
                 e.array(3)?;
                 e.u32(7)?;
                 e.bytes(block)?;
-                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
                 encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgLeiosLastBlockAndTxsInRange {
@@ -98,7 +96,6 @@ impl minicbor::Encode<()> for Message {
                 e.array(3)?;
                 e.u32(8)?;
                 e.bytes(block)?;
-                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
                 encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgDone => {
@@ -199,7 +196,7 @@ fn encode_bitmap<W: minicbor::encode::Write>(
 
 fn encode_blob_list<W: minicbor::encode::Write>(
     e: &mut Encoder<W>,
-    blobs: &[Vec<u8>],
+    blobs: &[Arc<Vec<u8>>],
 ) -> Result<(), EncodeError<W::Error>> {
     e.array(blobs.len() as u64)?;
     for blob in blobs {
@@ -282,7 +279,7 @@ fn decode_blob_list(
     max_count: usize,
     max_item_size: usize,
     item_name: &str,
-) -> Result<Vec<Vec<u8>>, DecodeError> {
+) -> Result<Vec<Arc<Vec<u8>>>, DecodeError> {
     let len = d.array()?;
     match len {
         Some(n) => {
@@ -294,7 +291,7 @@ fn decode_blob_list(
             }
             let mut items = Vec::with_capacity(n);
             for _ in 0..n {
-                items.push(decode_bounded_bytes(d, max_item_size, item_name)?);
+                items.push(Arc::new(decode_bounded_bytes(d, max_item_size, item_name)?));
             }
             Ok(items)
         }
@@ -310,7 +307,7 @@ fn decode_blob_list(
                         "{item_name} list exceeds maximum of {max_count}"
                     )));
                 }
-                items.push(decode_bounded_bytes(d, max_item_size, item_name)?);
+                items.push(Arc::new(decode_bounded_bytes(d, max_item_size, item_name)?));
             }
             Ok(items)
         }
@@ -334,7 +331,7 @@ fn decode_bounded_bytes(
 }
 
 /// Decode a list of (slot, voter_id) pairs with bounds checking.
-fn decode_vote_id_list(d: &mut Decoder<'_>) -> Result<Vec<(u64, Vec<u8>)>, DecodeError> {
+fn decode_vote_id_list(d: &mut Decoder<'_>) -> Result<Vec<(u64, Arc<Vec<u8>>)>, DecodeError> {
     let len = d.array()?;
     match len {
         Some(n) => {
@@ -370,7 +367,7 @@ fn decode_vote_id_list(d: &mut Decoder<'_>) -> Result<Vec<(u64, Vec<u8>)>, Decod
 }
 
 /// Decode a single (slot, voter_id) pair.
-fn decode_vote_id_pair(d: &mut Decoder<'_>) -> Result<(u64, Vec<u8>), DecodeError> {
+fn decode_vote_id_pair(d: &mut Decoder<'_>) -> Result<(u64, Arc<Vec<u8>>), DecodeError> {
     let _pair_len = d.array()?;
     let slot = d.u64()?;
     let voter_id = d.bytes()?;
@@ -380,7 +377,7 @@ fn decode_vote_id_pair(d: &mut Decoder<'_>) -> Result<(u64, Vec<u8>), DecodeErro
             voter_id.len()
         )));
     }
-    Ok((slot, voter_id.to_vec()))
+    Ok((slot, Arc::new(voter_id.to_vec())))
 }
 
 #[cfg(test)]
@@ -518,14 +515,14 @@ mod tests {
     #[test]
     fn votes_request_round_trip() {
         let msg = Message::MsgLeiosVotesRequest {
-            votes: vec![(10, vec![0xAA]), (20, vec![0xBB, 0xCC])],
+            votes: vec![(10, Arc::new(vec![0xAA])), (20, Arc::new(vec![0xBB, 0xCC]))],
         };
         let decoded = round_trip(&msg);
         match decoded {
             Message::MsgLeiosVotesRequest { votes } => {
                 assert_eq!(votes.len(), 2);
-                assert_eq!(votes[0], (10, vec![0xAA]));
-                assert_eq!(votes[1], (20, vec![0xBB, 0xCC]));
+                assert_eq!(votes[0], (10, Arc::new(vec![0xAA])));
+                assert_eq!(votes[1], (20, Arc::new(vec![0xBB, 0xCC])));
             }
             other => panic!("expected MsgLeiosVotesRequest, got {other:?}"),
         }
@@ -534,13 +531,13 @@ mod tests {
     #[test]
     fn vote_delivery_round_trip() {
         let msg = Message::MsgLeiosVoteDelivery {
-            votes: vec![vec![0x01, 0x02], vec![0x03, 0x04]],
+            votes: vec![Arc::new(vec![0x01, 0x02]), Arc::new(vec![0x03, 0x04])],
         };
         let decoded = round_trip(&msg);
         match decoded {
             Message::MsgLeiosVoteDelivery { votes } => {
                 assert_eq!(votes.len(), 2);
-                assert_eq!(votes[0], vec![0x01, 0x02]);
+                assert_eq!(votes[0], Arc::new(vec![0x01, 0x02]));
             }
             other => panic!("expected MsgLeiosVoteDelivery, got {other:?}"),
         }

--- a/net-rs/net-core/src/protocols/leios_fetch/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/codec.rs
@@ -50,7 +50,8 @@ impl minicbor::Encode<()> for Message {
             Message::MsgLeiosBlockTxs { transactions } => {
                 e.array(2)?;
                 e.u32(3)?;
-                encode_blob_list(e, transactions)?;
+                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
+                encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgLeiosVotesRequest { votes } => {
                 e.array(2)?;
@@ -87,7 +88,8 @@ impl minicbor::Encode<()> for Message {
                 e.array(3)?;
                 e.u32(7)?;
                 e.bytes(block)?;
-                encode_blob_list(e, transactions)?;
+                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
+                encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgLeiosLastBlockAndTxsInRange {
                 block,
@@ -96,7 +98,8 @@ impl minicbor::Encode<()> for Message {
                 e.array(3)?;
                 e.u32(8)?;
                 e.bytes(block)?;
-                encode_blob_list(e, transactions)?;
+                let transactions = transactions.iter().map(|tx| tx.to_vec()).collect::<Vec<_>>();
+                encode_blob_list(e, transactions.as_slice())?;
             }
             Message::MsgDone => {
                 e.array(1)?;
@@ -129,6 +132,7 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
             3 => {
                 let transactions =
                     decode_blob_list(d, MAX_TRANSACTIONS, MAX_TRANSACTION_SIZE, "transaction")?;
+                let transactions = transactions.into_iter().map(|tx| tx.into()).collect();
                 Ok(Message::MsgLeiosBlockTxs { transactions })
             }
             4 => {
@@ -155,6 +159,7 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
                 let block = decode_block(d)?;
                 let transactions =
                     decode_blob_list(d, MAX_TRANSACTIONS, MAX_TRANSACTION_SIZE, "transaction")?;
+                let transactions = transactions.into_iter().map(|tx| tx.into()).collect();
                 Ok(Message::MsgLeiosNextBlockAndTxsInRange {
                     block,
                     transactions,
@@ -164,6 +169,7 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
                 let block = decode_block(d)?;
                 let transactions =
                     decode_blob_list(d, MAX_TRANSACTIONS, MAX_TRANSACTION_SIZE, "transaction")?;
+                let transactions = transactions.into_iter().map(|tx| tx.into()).collect();
                 Ok(Message::MsgLeiosLastBlockAndTxsInRange {
                     block,
                     transactions,

--- a/net-rs/net-core/src/protocols/leios_fetch/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/codec.rs
@@ -387,6 +387,7 @@ fn decode_vote_id_pair(d: &mut Decoder<'_>) -> Result<(u64, Vec<u8>), DecodeErro
 mod tests {
     use super::*;
     use crate::types::Point;
+    use std::sync::Arc;
 
     fn round_trip(msg: &Message) -> Message {
         let encoded = minicbor::to_vec(msg).unwrap();
@@ -489,14 +490,14 @@ mod tests {
     #[test]
     fn block_txs_round_trip() {
         let msg = Message::MsgLeiosBlockTxs {
-            transactions: vec![vec![0x01, 0x02], vec![0x03]],
+            transactions: vec![Arc::new(vec![0x01, 0x02]), Arc::new(vec![0x03])],
         };
         let decoded = round_trip(&msg);
         match decoded {
             Message::MsgLeiosBlockTxs { transactions } => {
                 assert_eq!(transactions.len(), 2);
-                assert_eq!(transactions[0], vec![0x01, 0x02]);
-                assert_eq!(transactions[1], vec![0x03]);
+                assert_eq!(*transactions[0], vec![0x01, 0x02]);
+                assert_eq!(*transactions[1], vec![0x03]);
             }
             other => panic!("expected MsgLeiosBlockTxs, got {other:?}"),
         }
@@ -574,7 +575,7 @@ mod tests {
     fn next_block_in_range_round_trip() {
         let msg = Message::MsgLeiosNextBlockAndTxsInRange {
             block: vec![0xE1],
-            transactions: vec![vec![0x01]],
+            transactions: vec![Arc::new(vec![0x01])],
         };
         let decoded = round_trip(&msg);
         match decoded {
@@ -583,7 +584,7 @@ mod tests {
                 transactions,
             } => {
                 assert_eq!(block, vec![0xE1]);
-                assert_eq!(transactions, vec![vec![0x01]]);
+                assert_eq!(*transactions[0], vec![0x01]);
             }
             other => panic!("expected MsgLeiosNextBlockAndTxsInRange, got {other:?}"),
         }
@@ -593,7 +594,7 @@ mod tests {
     fn last_block_in_range_round_trip() {
         let msg = Message::MsgLeiosLastBlockAndTxsInRange {
             block: vec![0xE2],
-            transactions: vec![vec![0x02], vec![0x03]],
+            transactions: vec![Arc::new(vec![0x02]), Arc::new(vec![0x03])],
         };
         let decoded = round_trip(&msg);
         match decoded {

--- a/net-rs/net-core/src/protocols/leios_fetch/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/mod.rs
@@ -8,6 +8,7 @@ pub mod bitmap;
 pub mod codec;
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::protocols::{Agency, Protocol, ProtocolError, Runner};
@@ -90,7 +91,7 @@ pub enum Message {
         bitmap: BTreeMap<u16, u64>,
     },
     /// Server delivers transactions. [3, [tx, ...]]
-    MsgLeiosBlockTxs { transactions: Vec<Vec<u8>> },
+    MsgLeiosBlockTxs { transactions: Vec<Arc<Vec<u8>>> },
     /// Client requests votes. [4, [(slot, voter_id), ...]]
     MsgLeiosVotesRequest { votes: Vec<(u64, Vec<u8>)> },
     /// Server delivers votes. [5, [vote, ...]]
@@ -105,12 +106,12 @@ pub enum Message {
     /// Server delivers next block+txs in range (more to follow). [7, block, [tx, ...]]
     MsgLeiosNextBlockAndTxsInRange {
         block: Vec<u8>,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Arc<Vec<u8>>>,
     },
     /// Server delivers last block+txs in range (end of sequence). [8, block, [tx, ...]]
     MsgLeiosLastBlockAndTxsInRange {
         block: Vec<u8>,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Arc<Vec<u8>>>,
     },
     /// Client terminates. [9]
     MsgDone,
@@ -207,7 +208,7 @@ pub async fn fetch_block_txs(
     runner: &mut Runner<LeiosFetch>,
     point: Point,
     bitmap: BTreeMap<u16, u64>,
-) -> Result<Vec<Vec<u8>>, ProtocolError> {
+) -> Result<Vec<Arc<Vec<u8>>>, ProtocolError> {
     runner
         .send(&Message::MsgLeiosBlockTxsRequest { point, bitmap })
         .await?;
@@ -244,7 +245,7 @@ pub async fn fetch_block_range(
     end_slot: u64,
     start_hash: [u8; 32],
     end_hash: [u8; 32],
-) -> Result<Vec<(Vec<u8>, Vec<Vec<u8>>)>, ProtocolError> {
+) -> Result<Vec<(Vec<u8>, Vec<Arc<Vec<u8>>>)>, ProtocolError> {
     runner
         .send(&Message::MsgLeiosBlockRangeRequest {
             start_slot,

--- a/net-rs/net-core/src/protocols/leios_fetch/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/mod.rs
@@ -93,9 +93,9 @@ pub enum Message {
     /// Server delivers transactions. [3, [tx, ...]]
     MsgLeiosBlockTxs { transactions: Vec<Arc<Vec<u8>>> },
     /// Client requests votes. [4, [(slot, voter_id), ...]]
-    MsgLeiosVotesRequest { votes: Vec<(u64, Vec<u8>)> },
+    MsgLeiosVotesRequest { votes: Vec<(u64, Arc<Vec<u8>>)> },
     /// Server delivers votes. [5, [vote, ...]]
-    MsgLeiosVoteDelivery { votes: Vec<Vec<u8>> },
+    MsgLeiosVoteDelivery { votes: Vec<Arc<Vec<u8>>> },
     /// Client requests a certified EB range. [6, start_slot, end_slot, start_hash, end_hash]
     MsgLeiosBlockRangeRequest {
         start_slot: u64,
@@ -224,8 +224,8 @@ pub async fn fetch_block_txs(
 /// Fetch votes from the server.
 pub async fn fetch_votes(
     runner: &mut Runner<LeiosFetch>,
-    votes: Vec<(u64, Vec<u8>)>,
-) -> Result<Vec<Vec<u8>>, ProtocolError> {
+    votes: Vec<(u64, Arc<Vec<u8>>)>,
+) -> Result<Vec<Arc<Vec<u8>>>, ProtocolError> {
     runner
         .send(&Message::MsgLeiosVotesRequest { votes })
         .await?;
@@ -642,15 +642,15 @@ mod tests {
             match msg {
                 Message::MsgLeiosVotesRequest { votes } => {
                     assert_eq!(votes.len(), 2);
-                    assert_eq!(votes[0], (10, vec![0xAA]));
-                    assert_eq!(votes[1], (20, vec![0xBB]));
+                    assert_eq!(votes[0], (10, Arc::new(vec![0xAA])));
+                    assert_eq!(votes[1], (20, Arc::new(vec![0xBB])));
                 }
                 other => panic!("expected MsgLeiosVotesRequest, got {other:?}"),
             }
 
             runner
                 .send(&Message::MsgLeiosVoteDelivery {
-                    votes: vec![vec![0x01, 0x02], vec![0x03, 0x04]],
+                    votes: vec![Arc::new(vec![0x01, 0x02]), Arc::new(vec![0x03, 0x04])],
                 })
                 .await
                 .unwrap();
@@ -662,11 +662,11 @@ mod tests {
         let client = tokio::spawn(async move {
             let mut runner = Runner::<LeiosFetch>::new(Role::Client, cs, cr);
 
-            let vote_ids = vec![(10, vec![0xAA]), (20, vec![0xBB])];
+            let vote_ids = vec![(10, Arc::new(vec![0xAA])), (20, Arc::new(vec![0xBB]))];
             let votes = fetch_votes(&mut runner, vote_ids).await.unwrap();
             assert_eq!(votes.len(), 2);
-            assert_eq!(votes[0], vec![0x01, 0x02]);
-            assert_eq!(votes[1], vec![0x03, 0x04]);
+            assert_eq!(votes[0], Arc::new(vec![0x01, 0x02]));
+            assert_eq!(votes[1], Arc::new(vec![0x03, 0x04]));
 
             done(&mut runner).await.unwrap();
         });

--- a/net-rs/net-core/src/protocols/leios_fetch/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/mod.rs
@@ -601,7 +601,7 @@ mod tests {
 
             runner
                 .send(&Message::MsgLeiosBlockTxs {
-                    transactions: vec![vec![0x01], vec![0x02], vec![0x03]],
+                    transactions: vec![Arc::new(vec![0x01]), Arc::new(vec![0x02]), Arc::new(vec![0x03])],
                 })
                 .await
                 .unwrap();
@@ -701,7 +701,7 @@ mod tests {
             runner
                 .send(&Message::MsgLeiosNextBlockAndTxsInRange {
                     block: vec![0xE1],
-                    transactions: vec![vec![0x01]],
+                    transactions: vec![Arc::new(vec![0x01])],
                 })
                 .await
                 .unwrap();
@@ -709,7 +709,7 @@ mod tests {
             runner
                 .send(&Message::MsgLeiosLastBlockAndTxsInRange {
                     block: vec![0xE2],
-                    transactions: vec![vec![0x02], vec![0x03]],
+                    transactions: vec![Arc::new(vec![0x02]), Arc::new(vec![0x03])],
                 })
                 .await
                 .unwrap();
@@ -727,9 +727,9 @@ mod tests {
 
             assert_eq!(results.len(), 2);
             assert_eq!(results[0].0, vec![0xE1]);
-            assert_eq!(results[0].1, vec![vec![0x01]]);
+            assert_eq!(results[0].1, vec![Arc::new(vec![0x01])]);
             assert_eq!(results[1].0, vec![0xE2]);
-            assert_eq!(results[1].1, vec![vec![0x02], vec![0x03]]);
+            assert_eq!(results[1].1, vec![Arc::new(vec![0x02]), Arc::new(vec![0x03])]);
 
             done(&mut runner).await.unwrap();
         });

--- a/net-rs/net-core/src/protocols/leios_notify/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_notify/codec.rs
@@ -8,6 +8,7 @@
 //!   msgLeiosVotesOffer              = [4, [(slot, voterId), ...]]
 //!   msgDone                         = [5]
 
+use std::sync::Arc;
 use minicbor::decode::Error as DecodeError;
 use minicbor::encode::Error as EncodeError;
 use minicbor::{Decoder, Encoder};
@@ -92,7 +93,7 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
 }
 
 /// Decode a list of (slot, voter_id) pairs with bounds checking.
-fn decode_vote_offers(d: &mut Decoder<'_>) -> Result<Vec<(u64, Vec<u8>)>, DecodeError> {
+fn decode_vote_offers(d: &mut Decoder<'_>) -> Result<Vec<(u64, Arc<Vec<u8>>)>, DecodeError> {
     let len = d.array()?;
     match len {
         Some(n) => {
@@ -128,7 +129,7 @@ fn decode_vote_offers(d: &mut Decoder<'_>) -> Result<Vec<(u64, Vec<u8>)>, Decode
 }
 
 /// Decode a single (slot, voter_id) pair.
-fn decode_vote_offer_pair(d: &mut Decoder<'_>) -> Result<(u64, Vec<u8>), DecodeError> {
+fn decode_vote_offer_pair(d: &mut Decoder<'_>) -> Result<(u64, Arc<Vec<u8>>), DecodeError> {
     let _pair_len = d.array()?;
     let slot = d.u64()?;
     let voter_id = d.bytes()?;
@@ -138,7 +139,7 @@ fn decode_vote_offer_pair(d: &mut Decoder<'_>) -> Result<(u64, Vec<u8>), DecodeE
             voter_id.len()
         )));
     }
-    Ok((slot, voter_id.to_vec()))
+    Ok((slot, Arc::new(voter_id.to_vec())))
 }
 
 #[cfg(test)]
@@ -227,14 +228,14 @@ mod tests {
     #[test]
     fn votes_offer_round_trip() {
         let msg = Message::MsgLeiosVotesOffer {
-            votes: vec![(100, vec![0x01, 0x02, 0x03]), (200, vec![0x04, 0x05])],
+            votes: vec![(100, Arc::new(vec![0x01, 0x02, 0x03])), (200, Arc::new(vec![0x04, 0x05]))],
         };
         let decoded = round_trip(&msg);
         match decoded {
             Message::MsgLeiosVotesOffer { votes } => {
                 assert_eq!(votes.len(), 2);
-                assert_eq!(votes[0], (100, vec![0x01, 0x02, 0x03]));
-                assert_eq!(votes[1], (200, vec![0x04, 0x05]));
+                assert_eq!(votes[0], (100, Arc::new(vec![0x01, 0x02, 0x03])));
+                assert_eq!(votes[1], (200, Arc::new(vec![0x04, 0x05])));
             }
             other => panic!("expected MsgLeiosVotesOffer, got {other:?}"),
         }

--- a/net-rs/net-core/src/protocols/leios_notify/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_notify/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod codec;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::protocols::{Agency, Protocol, ProtocolError, Runner};
@@ -55,7 +56,7 @@ pub enum Message {
     /// Server offers an EB's transactions for download. [3, point]
     MsgLeiosBlockTxsOffer { point: Point },
     /// Server offers votes for download. [4, [(slot, voter_id), ...]]
-    MsgLeiosVotesOffer { votes: Vec<(u64, Vec<u8>)> },
+    MsgLeiosVotesOffer { votes: Vec<(u64, Arc<Vec<u8>>)> },
     /// Client terminates. [5]
     MsgDone,
 }
@@ -121,7 +122,7 @@ pub enum LeiosNotifyEvent {
     /// An EB's transactions are available for download.
     BlockTxsOffer { point: Point },
     /// Votes are available for download.
-    VotesOffer { votes: Vec<(u64, Vec<u8>)> },
+    VotesOffer { votes: Vec<(u64, Arc<Vec<u8>>)> },
 }
 
 /// Request the next notification from the server.
@@ -352,7 +353,7 @@ mod tests {
             assert!(matches!(msg, Message::MsgLeiosNotificationRequestNext));
             runner
                 .send(&Message::MsgLeiosVotesOffer {
-                    votes: vec![(100, vec![0x01, 0x02]), (101, vec![0x03, 0x04])],
+                    votes: vec![(100, Arc::new(vec![0x01, 0x02])), (101, Arc::new(vec![0x03, 0x04]))],
                 })
                 .await
                 .unwrap();
@@ -409,8 +410,8 @@ mod tests {
             match event {
                 LeiosNotifyEvent::VotesOffer { votes } => {
                     assert_eq!(votes.len(), 2);
-                    assert_eq!(votes[0], (100, vec![0x01, 0x02]));
-                    assert_eq!(votes[1], (101, vec![0x03, 0x04]));
+                    assert_eq!(votes[0], (100, Arc::new(vec![0x01, 0x02])));
+                    assert_eq!(votes[1], (101, Arc::new(vec![0x03, 0x04])));
                 }
                 other => panic!("expected VotesOffer, got {other:?}"),
             }

--- a/net-rs/net-core/src/protocols/txsubmission/codec.rs
+++ b/net-rs/net-core/src/protocols/txsubmission/codec.rs
@@ -12,6 +12,7 @@
 //! Inner lists (txIdsAndSizes, txIdList, txList) use indefinite-length
 //! encoding per the Haskell codec.
 
+use std::sync::Arc;
 use minicbor::decode::Error as DecodeError;
 use minicbor::encode::Error as EncodeError;
 use minicbor::{Decoder, Encoder};
@@ -44,7 +45,7 @@ impl<'a> minicbor::Decode<'a, ()> for TxId {
                 raw.len()
             )));
         }
-        Ok(TxId(raw.to_vec()))
+        Ok(TxId(Arc::new(raw.to_vec())))
     }
 }
 
@@ -73,7 +74,7 @@ impl<'a> minicbor::Decode<'a, ()> for TxBody {
                 raw.len()
             )));
         }
-        Ok(TxBody(raw.to_vec()))
+        Ok(TxBody(Arc::new(raw.to_vec())))
     }
 }
 

--- a/net-rs/net-core/src/protocols/txsubmission/codec.rs
+++ b/net-rs/net-core/src/protocols/txsubmission/codec.rs
@@ -265,11 +265,11 @@ mod tests {
     }
 
     fn make_tx_id() -> TxId {
-        TxId(vec![0xaa; 32])
+        TxId(Arc::new(vec![0xaa; 32]))
     }
 
     fn make_tx_body(payload: &[u8]) -> TxBody {
-        TxBody(payload.to_vec())
+        TxBody(Arc::new(payload.to_vec()))
     }
 
     #[test]
@@ -398,7 +398,7 @@ mod tests {
         let raw_hash: Vec<u8> = (0..32).collect();
         let msg = Message::MsgReplyTxIds {
             tx_ids: vec![TxIdAndSize {
-                tx_id: TxId(raw_hash.clone()),
+                tx_id: TxId(Arc::new(raw_hash.clone())),
                 size: 1234,
             }],
         };
@@ -406,7 +406,7 @@ mod tests {
         match decoded {
             Message::MsgReplyTxIds { tx_ids } => {
                 assert_eq!(tx_ids.len(), 1);
-                assert_eq!(tx_ids[0].tx_id.0, raw_hash);
+                assert_eq!(*tx_ids[0].tx_id.0, raw_hash);
                 assert_eq!(tx_ids[0].size, 1234);
             }
             other => panic!("expected MsgReplyTxIds, got {other:?}"),
@@ -420,14 +420,14 @@ mod tests {
         let body_a: Vec<u8> = (0..200).map(|i| (i * 7) as u8).collect();
         let body_b: Vec<u8> = (0..1500).map(|i| (i * 31) as u8).collect();
         let msg = Message::MsgReplyTxs {
-            txs: vec![TxBody(body_a.clone()), TxBody(body_b.clone())],
+            txs: vec![TxBody(Arc::new(body_a.clone())), TxBody(Arc::new(body_b.clone()))],
         };
         let decoded = round_trip(&msg);
         match decoded {
             Message::MsgReplyTxs { txs } => {
                 assert_eq!(txs.len(), 2);
-                assert_eq!(txs[0].0, body_a);
-                assert_eq!(txs[1].0, body_b);
+                assert_eq!(*txs[0].0, body_a);
+                assert_eq!(*txs[1].0, body_b);
             }
             other => panic!("expected MsgReplyTxs, got {other:?}"),
         }

--- a/net-rs/net-core/src/protocols/txsubmission/mod.rs
+++ b/net-rs/net-core/src/protocols/txsubmission/mod.rs
@@ -376,7 +376,7 @@ mod tests {
             TxSubmission::transition(
                 &State::StIdle,
                 &Message::MsgRequestTxs {
-                    tx_ids: vec![TxId(vec![0x42])]
+                    tx_ids: vec![TxId(Arc::new(vec![0x42]))]
                 }
             )
             .unwrap(),
@@ -430,7 +430,7 @@ mod tests {
         assert!(TxSubmission::transition(
             &State::StTxIdsBlocking,
             &Message::MsgRequestTxs {
-                tx_ids: vec![TxId(vec![])]
+                tx_ids: vec![TxId(Arc::new(vec![]))]
             }
         )
         .is_err());
@@ -504,8 +504,8 @@ mod tests {
 
     fn make_test_tx(id_byte: u8, size: usize) -> PendingTx {
         PendingTx {
-            tx_id: TxId(vec![id_byte; 32]),
-            body: TxBody(vec![id_byte; size]),
+            tx_id: TxId(Arc::new(vec![id_byte; 32])),
+            body: TxBody(Arc::new(vec![id_byte; size])),
             size: size as u32,
         }
     }

--- a/net-rs/net-core/src/protocols/txsubmission/mod.rs
+++ b/net-rs/net-core/src/protocols/txsubmission/mod.rs
@@ -7,6 +7,7 @@
 pub mod codec;
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -44,11 +45,11 @@ pub const MAX_TX_SIZE: usize = 2_500_000;
 
 /// Opaque transaction ID stored as raw CBOR bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TxId(pub Vec<u8>);
+pub struct TxId(pub Arc<Vec<u8>>);
 
 /// Opaque transaction body stored as raw CBOR bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TxBody(pub Vec<u8>);
+pub struct TxBody(pub Arc<Vec<u8>>);
 
 /// A transaction ID paired with its serialized size (for flow control).
 #[derive(Debug, Clone)]

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -32,7 +32,7 @@ pub enum LeiosNotification {
     /// An EB's transactions are available for download.
     BlockTxsOffer { point: Point },
     /// Votes are available for download.
-    VotesOffer { votes: Vec<(u64, Vec<u8>)> },
+    VotesOffer { votes: Vec<(u64, Arc<Vec<u8>>)> },
 }
 
 /// Key for block lookups.
@@ -57,7 +57,7 @@ struct LeiosStoreInner {
     /// bodies indirectly without keeping a duplicate copy.
     eb_tx_hashes: HashMap<BlockKey, Vec<[u8; 32]>>,
     /// Votes keyed by (slot, voter_id).
-    votes: HashMap<(u64, Vec<u8>), Vec<u8>>,
+    votes: HashMap<(u64, Arc<Vec<u8>>), Arc<Vec<u8>>>,
     /// Notification queue for the LeiosNotify server.  Front-pruned
     /// alongside the slot-window eviction of the other maps so
     /// long-running connections don't accumulate notifications for
@@ -230,7 +230,7 @@ impl LeiosStore {
     ///
     /// `ids` are `(slot, voter_id)` pairs; `data` are the corresponding
     /// opaque vote blobs (same length).
-    pub fn inject_votes(&self, ids: Vec<(u64, Vec<u8>)>, data: Vec<Vec<u8>>) {
+    pub fn inject_votes(&self, ids: Vec<(u64, Arc<Vec<u8>>)>, data: Vec<Arc<Vec<u8>>>) {
         if ids.is_empty() {
             return;
         }
@@ -325,7 +325,7 @@ impl LeiosStore {
 
     /// Look up votes by their `(slot, voter_id)` identifiers.
     /// Returns one blob per requested id (empty vec if not found).
-    pub fn get_votes(&self, ids: &[(u64, Vec<u8>)]) -> Vec<Vec<u8>> {
+    pub fn get_votes(&self, ids: &[(u64, Arc<Vec<u8>>)]) -> Vec<Arc<Vec<u8>>> {
         let inner = self.inner.lock().unwrap();
         ids.iter()
             .filter_map(|id| inner.votes.get(id).cloned())
@@ -731,8 +731,8 @@ mod tests {
     #[test]
     fn inject_and_get_votes() {
         let (store, _rx) = LeiosStore::new(100);
-        let ids = vec![(100, vec![0x01]), (101, vec![0x02])];
-        let data = vec![vec![0xA0], vec![0xB0]];
+        let ids = vec![(100, Arc::new(vec![0x01])), (101, Arc::new(vec![0x02]))];
+        let data = vec![Arc::new(vec![0xA0]), Arc::new(vec![0xB0])];
 
         store.inject_votes(ids.clone(), data.clone());
 
@@ -740,7 +740,7 @@ mod tests {
         assert_eq!(result, data);
 
         // Unknown vote returns empty.
-        let result = store.get_votes(&[(999, vec![0xFF])]);
+        let result = store.get_votes(&[(999, Arc::new(vec![0xFF]))]);
         assert!(result.is_empty());
     }
 
@@ -751,7 +751,7 @@ mod tests {
         let point = Point::Specific { slot: 1, hash };
 
         store.inject_block(point, vec![0x01]);
-        store.inject_votes(vec![(10, vec![0x02])], vec![vec![0x03]]);
+        store.inject_votes(vec![(10, Arc::new(vec![0x02]))], vec![Arc::new(vec![0x03])]);
 
         let all = store.notifications_after(&mut 0);
         assert_eq!(all.len(), 2);
@@ -777,7 +777,7 @@ mod tests {
 
         // Inject votes/blocks at slot 1, then advance the clock far past
         // the retention window. Old entries must be evicted.
-        store.inject_votes(vec![(1, vec![0xAA])], vec![vec![0x01]]);
+        store.inject_votes(vec![(1, Arc::new(vec![0xAA]))], vec![Arc::new(vec![0x01])]);
         store.inject_block(
             Point::Specific {
                 slot: 1,
@@ -794,7 +794,7 @@ mod tests {
         );
 
         // Pre-eviction sanity.
-        assert_eq!(store.get_votes(&[(1, vec![0xAA])]), vec![vec![0x01]]);
+        assert_eq!(store.get_votes(&[(1, Arc::new(vec![0xAA]))]), vec![Arc::new(vec![0x01])]);
         assert!(store.get_block(1, &[0x11; 32]).is_some());
 
         // Inject something far in the future — past the retention cutoff.
@@ -808,7 +808,7 @@ mod tests {
         );
 
         assert!(
-            store.get_votes(&[(1, vec![0xAA])]).is_empty(),
+            store.get_votes(&[(1, Arc::new(vec![0xAA]))]).is_empty(),
             "old vote should be evicted past retention window"
         );
         assert!(
@@ -846,7 +846,7 @@ mod tests {
             },
             vec![0xB1],
         );
-        store.inject_votes(vec![(1, vec![0xAA])], vec![vec![0x01]]);
+        store.inject_votes(vec![(1, Arc::new(vec![0xAA]))], vec![Arc::new(vec![0x01])]);
         assert_eq!(store.notification_count(), 3);
 
         // Inject a recent block to push max_slot past the retention

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -21,7 +21,7 @@ use crate::types::Point;
 /// locally — typically the host application's mempool answers.
 pub trait TxBodyResolver: Send + Sync {
     /// Return the body for `tx_id`, or `None` if unknown.
-    fn resolve_body(&self, tx_id: &[u8]) -> Option<Vec<u8>>;
+    fn resolve_body(&self, tx_id: &[u8]) -> Option<Arc<Vec<u8>>>;
 }
 
 /// A notification about available Leios data, served by LeiosNotify.
@@ -51,7 +51,7 @@ struct LeiosStoreInner {
     /// shot. `get_block_txs` falls through to manifest+resolver for any
     /// index missing here, so partial holdings still serve subsets to
     /// downstream peers.
-    block_txs: HashMap<BlockKey, BTreeMap<u32, Vec<u8>>>,
+    block_txs: HashMap<BlockKey, BTreeMap<u32, Arc<Vec<u8>>>>,
     /// Per-EB ordered tx hash list. Populated by receivers after decoding
     /// a fetched EB manifest. Pairs with `tx_body_resolver` to serve the
     /// bodies indirectly without keeping a duplicate copy.
@@ -193,7 +193,7 @@ impl LeiosStore {
     ///
     /// The `point` must be `Point::Specific { slot, hash }`. If
     /// `Point::Origin` is passed, the transactions are silently dropped.
-    pub fn inject_block_txs(&self, point: Point, indexed: BTreeMap<u32, Vec<u8>>) {
+    pub fn inject_block_txs(&self, point: Point, indexed: BTreeMap<u32, Arc<Vec<u8>>>) {
         let (slot, hash) = match &point {
             Point::Specific { slot, hash } => (*slot, *hash),
             Point::Origin => return,
@@ -217,8 +217,8 @@ impl LeiosStore {
     /// Convenience for the producer path: inject a complete ordered body
     /// list, indices `0..bodies.len()`. Equivalent to constructing a
     /// `BTreeMap` and calling `inject_block_txs`.
-    pub fn inject_block_txs_full(&self, point: Point, bodies: Vec<Vec<u8>>) {
-        let indexed: BTreeMap<u32, Vec<u8>> = bodies
+    pub fn inject_block_txs_full(&self, point: Point, bodies: Vec<Arc<Vec<u8>>>) {
+        let indexed: BTreeMap<u32, Arc<Vec<u8>>> = bodies
             .into_iter()
             .enumerate()
             .map(|(i, b)| (i as u32, b))
@@ -289,7 +289,7 @@ impl LeiosStore {
         slot: u64,
         hash: &[u8; 32],
         bitmap: &BTreeMap<u16, u64>,
-    ) -> Option<Vec<Vec<u8>>> {
+    ) -> Option<Vec<Arc<Vec<u8>>>> {
         let key = BlockKey { slot, hash: *hash };
         let (block_txs, manifest) = {
             let inner = self.inner.lock().unwrap();
@@ -302,7 +302,7 @@ impl LeiosStore {
             return None;
         }
         let resolver = self.tx_body_resolver.as_ref();
-        let selected: Vec<Vec<u8>> = bitmap::iter_indices(bitmap)
+        let selected: Vec<Arc<Vec<u8>>> = bitmap::iter_indices(bitmap)
             .filter_map(|i| {
                 if let Some(body) = block_txs.as_ref().and_then(|m| m.get(&i).cloned()) {
                     return Some(body);

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -482,7 +482,7 @@ mod tests {
     fn get_block_txs_with_select_all_returns_all() {
         let (store, _rx) = LeiosStore::new(100);
         let hash = [0xCDu8; 32];
-        let txs = vec![vec![10, 20], vec![30, 40]];
+        let txs = vec![Arc::new(vec![10, 20]), Arc::new(vec![30, 40])];
         let point = Point::Specific { slot: 42, hash };
 
         store.inject_block_txs_full(point, txs.clone());
@@ -496,7 +496,7 @@ mod tests {
     fn get_block_txs_empty_bitmap_returns_empty() {
         let (store, _rx) = LeiosStore::new(100);
         let hash = [0xCDu8; 32];
-        let txs = vec![vec![10, 20], vec![30, 40]];
+        let txs = vec![Arc::new(vec![10, 20]), Arc::new(vec![30, 40])];
         let point = Point::Specific { slot: 42, hash };
 
         store.inject_block_txs_full(point, txs);
@@ -509,7 +509,7 @@ mod tests {
     fn get_block_txs_filters_by_bitmap_and_orders_ascending() {
         let (store, _rx) = LeiosStore::new(100);
         let hash = [0xEFu8; 32];
-        let txs: Vec<Vec<u8>> = (0..70u8).map(|i| vec![i]).collect();
+        let txs: Vec<Arc<Vec<u8>>> = (0..70u8).map(|i| Arc::new(vec![i])).collect();
         let point = Point::Specific { slot: 1, hash };
 
         store.inject_block_txs_full(point, txs);
@@ -517,12 +517,12 @@ mod tests {
         // Pick out-of-order indices spanning two segments to check ordering.
         let bitmap = bitmap::from_indices(&[65, 0, 63]);
         let got = store.get_block_txs(1, &hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![0u8], vec![63u8], vec![65u8]]);
+        assert_eq!(got, vec![Arc::new(vec![0u8]), Arc::new(vec![63u8]), Arc::new(vec![65u8])]);
     }
 
-    struct StubResolver(HashMap<Vec<u8>, Vec<u8>>);
+    struct StubResolver(HashMap<Vec<u8>, Arc<Vec<u8>>>);
     impl TxBodyResolver for StubResolver {
-        fn resolve_body(&self, tx_id: &[u8]) -> Option<Vec<u8>> {
+        fn resolve_body(&self, tx_id: &[u8]) -> Option<Arc<Vec<u8>>> {
             self.0.get(tx_id).cloned()
         }
     }
@@ -533,9 +533,9 @@ mod tests {
         let h1 = [0x20u8; 32];
         let h2 = [0x30u8; 32];
         let bodies = HashMap::from([
-            (h0.to_vec(), vec![1u8]),
-            (h1.to_vec(), vec![2u8]),
-            (h2.to_vec(), vec![3u8]),
+            (h0.to_vec(), Arc::new(vec![1u8])),
+            (h1.to_vec(), Arc::new(vec![2u8])),
+            (h2.to_vec(), Arc::new(vec![3u8])),
         ]);
         let resolver: Arc<dyn TxBodyResolver> = Arc::new(StubResolver(bodies));
         let (store, _rx) = LeiosStore::new_with_resolver(100, Some(resolver));
@@ -550,7 +550,7 @@ mod tests {
         // Bitmap selects indices 0 and 2.
         let bitmap = bitmap::from_indices(&[0, 2]);
         let got = store.get_block_txs(5, &eb_hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![1u8], vec![3u8]]);
+        assert_eq!(got, vec![Arc::new(vec![1u8]), Arc::new(vec![3u8])]);
     }
 
     #[test]
@@ -559,7 +559,7 @@ mod tests {
         let h1 = [0x50u8; 32];
         // Only h0 is resolvable.
         let resolver: Arc<dyn TxBodyResolver> =
-            Arc::new(StubResolver(HashMap::from([(h0.to_vec(), vec![0xAA])])));
+            Arc::new(StubResolver(HashMap::from([(h0.to_vec(), Arc::new(vec![0xAA]))])));
         let (store, _rx) = LeiosStore::new_with_resolver(100, Some(resolver));
 
         let eb_hash = [0xCCu8; 32];
@@ -571,7 +571,7 @@ mod tests {
 
         let bitmap = bitmap::from_indices(&[0, 1]);
         let got = store.get_block_txs(7, &eb_hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![0xAA]]);
+        assert_eq!(got, vec![Arc::new(vec![0xAA])]);
     }
 
     #[test]
@@ -585,14 +585,14 @@ mod tests {
             slot: 1,
             hash: eb_hash,
         };
-        store.inject_block_txs_full(point.clone(), vec![vec![100u8], vec![200u8]]);
+        store.inject_block_txs_full(point.clone(), vec![Arc::new(vec![100u8]), Arc::new(vec![200u8])]);
         // Pretend we also have manifest hashes (would normally be set
         // separately; here we make sure the block_txs path wins).
         store.record_eb_manifest(point, vec![[0; 32], [0; 32]]);
 
         let bitmap = bitmap::from_indices(&[0, 1]);
         let got = store.get_block_txs(1, &eb_hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![100u8], vec![200u8]]);
+        assert_eq!(got, vec![Arc::new(vec![100u8]), Arc::new(vec![200u8])]);
     }
 
     #[test]
@@ -607,14 +607,14 @@ mod tests {
     fn get_block_txs_ignores_out_of_range_bits() {
         let (store, _rx) = LeiosStore::new(100);
         let hash = [0xAA; 32];
-        let txs = vec![vec![1u8], vec![2u8]];
+        let txs = vec![Arc::new(vec![1u8]), Arc::new(vec![2u8])];
         let point = Point::Specific { slot: 5, hash };
         store.inject_block_txs_full(point, txs);
 
         // Bit 99 is past the available 2 txs; should be silently dropped.
         let bitmap = bitmap::from_indices(&[0, 99]);
         let got = store.get_block_txs(5, &hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![1u8]]);
+        assert_eq!(got, vec![Arc::new(vec![1u8])]);
     }
 
     #[test]
@@ -625,19 +625,19 @@ mod tests {
 
         // First batch: indices 0 and 2.
         let mut first = BTreeMap::new();
-        first.insert(0u32, vec![0xA0]);
-        first.insert(2u32, vec![0xA2]);
+        first.insert(0u32, Arc::new(vec![0xA0]));
+        first.insert(2u32, Arc::new(vec![0xA2]));
         store.inject_block_txs(point.clone(), first);
 
         // Second batch: indices 1 and 3.
         let mut second = BTreeMap::new();
-        second.insert(1u32, vec![0xA1]);
-        second.insert(3u32, vec![0xA3]);
+        second.insert(1u32, Arc::new(vec![0xA1]));
+        second.insert(3u32, Arc::new(vec![0xA3]));
         store.inject_block_txs(point, second);
 
         let bitmap = bitmap::from_indices(&[0, 1, 2, 3]);
         let got = store.get_block_txs(7, &hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![0xA0], vec![0xA1], vec![0xA2], vec![0xA3]]);
+        assert_eq!(got, vec![Arc::new(vec![0xA0]), Arc::new(vec![0xA1]), Arc::new(vec![0xA2]), Arc::new(vec![0xA3])]);
     }
 
     #[test]
@@ -647,11 +647,11 @@ mod tests {
         let point = Point::Specific { slot: 8, hash };
 
         let mut a = BTreeMap::new();
-        a.insert(0u32, vec![0xB0]);
+        a.insert(0u32, Arc::new(vec![0xB0]));
         store.inject_block_txs(point.clone(), a);
 
         let mut b = BTreeMap::new();
-        b.insert(1u32, vec![0xB1]);
+        b.insert(1u32, Arc::new(vec![0xB1]));
         store.inject_block_txs(point, b);
 
         // One BlockTxsOffer notification, not two.
@@ -670,17 +670,17 @@ mod tests {
         let point = Point::Specific { slot: 9, hash };
 
         let mut a = BTreeMap::new();
-        a.insert(0u32, vec![0xC0]);
+        a.insert(0u32, Arc::new(vec![0xC0]));
         store.inject_block_txs(point.clone(), a);
 
         // Conflicting body for index 0 — first writer wins.
         let mut b = BTreeMap::new();
-        b.insert(0u32, vec![0xFF]);
+        b.insert(0u32, Arc::new(vec![0xFF]));
         store.inject_block_txs(point, b);
 
         let bitmap = bitmap::from_indices(&[0]);
         let got = store.get_block_txs(9, &hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![0xC0]]);
+        assert_eq!(got, vec![Arc::new(vec![0xC0])]);
     }
 
     #[test]
@@ -692,7 +692,7 @@ mod tests {
         let h2 = [0x30u8; 32];
         let resolver: Arc<dyn TxBodyResolver> = Arc::new(StubResolver(HashMap::from([(
             h1.to_vec(),
-            vec![0xD1],
+            Arc::new(vec![0xD1]),
         )])));
         let (store, _rx) = LeiosStore::new_with_resolver(100, Some(resolver));
 
@@ -704,13 +704,13 @@ mod tests {
         store.record_eb_manifest(point.clone(), vec![h0, h1, h2]);
 
         let mut partial = BTreeMap::new();
-        partial.insert(0u32, vec![0xD0]);
-        partial.insert(2u32, vec![0xD2]);
+        partial.insert(0u32, Arc::new(vec![0xD0]));
+        partial.insert(2u32, Arc::new(vec![0xD2]));
         store.inject_block_txs(point, partial);
 
         let bitmap = bitmap::from_indices(&[0, 1, 2]);
         let got = store.get_block_txs(11, &eb_hash, &bitmap).unwrap();
-        assert_eq!(got, vec![vec![0xD0], vec![0xD1], vec![0xD2]]);
+        assert_eq!(got, vec![Arc::new(vec![0xD0]), Arc::new(vec![0xD1]), Arc::new(vec![0xD2])]);
     }
 
     #[test]

--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -288,7 +288,7 @@ impl LeiosConsensus {
 
     /// Vote validation completed; record each vote, fire quorum
     /// telemetry if quorum forms.
-    pub fn on_validated_votes(&mut self, vote_data: &[Vec<u8>]) {
+    pub fn on_validated_votes(&mut self, vote_data: &[Arc<Vec<u8>>]) {
         // Decode wire-format vote bodies up front so we can lend them
         // to the state machine as borrowed `ValidatedVote` views.
         let decoded: Vec<VoteBody> = vote_data
@@ -511,8 +511,8 @@ impl LeiosConsensus {
             );
             let mut id = voter_id.clone();
             id.push(0);
-            votes.push((eb_slot, id));
-            data.push(encoded);
+            votes.push((eb_slot, Arc::new(id)));
+            data.push(Arc::new(encoded));
         }
         if let Some(sig) = npv_signature {
             let body =
@@ -525,8 +525,8 @@ impl LeiosConsensus {
             );
             let mut id = voter_id.clone();
             id.push(1);
-            votes.push((eb_slot, id));
-            data.push(encoded);
+            votes.push((eb_slot, Arc::new(id)));
+            data.push(Arc::new(encoded));
         }
         if !votes.is_empty() {
             self.pending_telemetry.push(NodeEvent::VTBundleGenerated {
@@ -805,11 +805,11 @@ mod tests {
         let (validator, mut outcome_rx) = test_validator();
         let mut leios = test_leios(tx, validator);
 
-        let vote_ids = vec![(10u64, vec![0xAAu8])];
+        let vote_ids = vec![(10u64, Arc::new(vec![0xAAu8]))];
         leios
             .handle_event(&NetworkEvent::LeiosVotesReceived {
                 vote_ids: vote_ids.clone(),
-                vote_data: vec![vec![0x01]],
+                vote_data: vec![Arc::new(vec![0x01])],
             })
             .await;
 
@@ -840,7 +840,7 @@ mod tests {
 
         let eb_hash = point_hash(0);
         let body = crate::production::VoteBody::stub_persistent(0, b"peer-0", 100, &eb_hash);
-        leios.on_validated_votes(&[body.encode(130)]);
+        leios.on_validated_votes(&[Arc::new(body.encode(130))]);
         assert_eq!(leios.election_voter_count(&eb_hash), 1);
         assert!(!leios.election_quorum(&eb_hash));
     }
@@ -859,11 +859,10 @@ mod tests {
         let voters = [
             "test", "peer-0", "peer-1", "peer-2", "peer-3", "peer-4", "peer-5",
         ];
-        let bodies: Vec<Vec<u8>> = voters
+        let bodies: Vec<Arc<Vec<u8>>> = voters
             .iter()
             .map(|v| {
-                crate::production::VoteBody::stub_persistent(0, v.as_bytes(), 100, &eb_hash)
-                    .encode(130)
+                Arc::new(VoteBody::stub_persistent(0, v.as_bytes(), 100, &eb_hash).encode(130))
             })
             .collect();
         leios.on_validated_votes(&bodies);
@@ -887,7 +886,7 @@ mod tests {
 
         // Subsequent votes don't re-fire.
         let body8 = crate::production::VoteBody::stub_persistent(0, b"peer-6", 100, &eb_hash);
-        leios.on_validated_votes(&[body8.encode(130)]);
+        leios.on_validated_votes(&[Arc::new(body8.encode(130))]);
         let drained2 = leios.drain_telemetry();
         assert!(!drained2
             .iter()
@@ -916,7 +915,7 @@ mod tests {
             for v in &voters {
                 let body =
                     crate::production::VoteBody::stub_persistent(slot, v.as_bytes(), 100, &hash);
-                all_bodies.push(body.encode(130));
+                all_bodies.push(Arc::new(body.encode(130)));
             }
         }
         leios.on_validated_votes(&all_bodies);

--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -9,6 +9,7 @@
 //! eligibility signature) and this layer encodes the wire-format body.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use shared_consensus::elections::{Elections, ElectionsConfig};
@@ -215,7 +216,7 @@ impl LeiosConsensus {
         // a receiver has merged via `LeiosFetch BlockTxs`.  Snapshot
         // upfront so we don't hold the mempool lock across the call.
         let known = self.mempool.lock().unwrap().all_known_tx_ids();
-        let tx_known = |h: &[u8; 32]| known.contains(h.as_slice());
+        let tx_known = |h: &[u8; 32]| known.contains(&Arc::new(h.to_vec()));
         let mut fx = self.state.on_slot(slot, &tx_known);
         fx.push(LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::LeiosElectionInfo {
             eb_slot: slot,
@@ -330,9 +331,9 @@ impl LeiosConsensus {
     pub fn match_eb_tx_response(
         &mut self,
         point: &Point,
-        bodies: &[Vec<u8>],
+        bodies: &[Arc<Vec<u8>>],
     ) -> EbTxMatchOutcome {
-        let bodies_with_hashes: Vec<(Vec<u8>, [u8; 32])> = bodies
+        let bodies_with_hashes: Vec<(Arc<Vec<u8>>, [u8; 32])> = bodies
             .iter()
             .map(|body| {
                 let h = blake2b_simd::Params::new().hash_length(32).hash(body);

--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -1010,8 +1010,8 @@ mod tests {
 
     fn push_tx_with_id(mempool: &crate::mempool::SharedMempool, id: [u8; 32]) {
         let tx = PendingTx {
-            tx_id: TxId(id.to_vec()),
-            body: TxBody(vec![]),
+            tx_id: TxId(Arc::new(id.to_vec())),
+            body: TxBody(Arc::new(vec![])),
             size: 0,
         };
         mempool.lock().unwrap().push(tx);
@@ -1146,9 +1146,9 @@ mod tests {
         let mut leios = test_leios_with_mempool(tx, validator, mempool);
 
         // Three bodies, request all three, server returns only the middle one.
-        let body0 = b"alpha".to_vec();
-        let body1 = b"bravo".to_vec();
-        let body2 = b"charlie".to_vec();
+        let body0 = Arc::new(b"alpha".to_vec());
+        let body1 = Arc::new(b"bravo".to_vec());
+        let body2 = Arc::new(b"charlie".to_vec());
         let h0 = body_hash(&body0);
         let h1 = body_hash(&body1);
         let h2 = body_hash(&body2);

--- a/net-rs/net-node/src/consensus/mod.rs
+++ b/net-rs/net-node/src/consensus/mod.rs
@@ -8,6 +8,7 @@
 mod leios;
 mod praos;
 
+use std::sync::Arc;
 use net_core::multi_peer::types::{NetworkCommand, NetworkEvent};
 use net_core::types::{BlockBody, Point, Tip, WrappedHeader};
 use tokio::sync::{mpsc, watch};
@@ -254,7 +255,7 @@ impl Consensus {
     /// EB manifest. Returns the bodies whose hash lies in the manifest,
     /// in manifest-index order, plus how many indices were requested
     /// and which indices remain unfilled.
-    pub fn match_eb_tx_response(&mut self, point: &Point, bodies: &[Vec<u8>]) -> EbTxMatchOutcome {
+    pub fn match_eb_tx_response(&mut self, point: &Point, bodies: &[Arc<Vec<u8>>]) -> EbTxMatchOutcome {
         self.leios.match_eb_tx_response(point, bodies)
     }
 

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -14,6 +14,7 @@ mod validation;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+use std::sync::Arc;
 use clap::Parser;
 use net_core::multi_peer::types::{NetworkCommand, NetworkEvent};
 use tokio::io::AsyncBufReadExt;
@@ -157,7 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
 
     // Transaction validator (validates received txs before mempool entry).
-    let (tx_valid_tx, tx_valid_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
+    let (tx_valid_tx, tx_valid_rx) = tokio::sync::mpsc::channel::<Arc<Vec<u8>>>(1024);
     let _tx_valid_handle = mempool::spawn_tx_validator(
         config.validation.tx_validation_ms,
         config.validation.tx_validation_ms_per_byte,

--- a/net-rs/net-node/src/mempool.rs
+++ b/net-rs/net-node/src/mempool.rs
@@ -450,6 +450,29 @@ mod tests {
         assert_ne!(tx1.tx_id.0, tx2.tx_id.0);
     }
 
+    #[test]
+    fn exp_sample_positive() {
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..100 {
+            let d = exp_sample(&mut rng, 1.0);
+            assert!(d.as_secs_f64() > 0.0);
+        }
+    }
+
+    #[test]
+    fn exp_sample_mean_roughly_correct() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let rate = 2.0;
+        let n = 10_000;
+        let total: f64 = (0..n)
+            .map(|_| exp_sample(&mut rng, rate).as_secs_f64())
+            .sum();
+        let mean = total / n as f64;
+        assert!((0.4..=0.6).contains(&mean), "mean={mean}, expected ~0.5");
+    }
+
+    // -- Wrapper translation tests (algorithmic behaviour lives in shared-consensus) --
+
     #[tokio::test]
     async fn mempool_resolver_serves_body_through_trait() {
         use net_core::store::leios_store::TxBodyResolver;
@@ -488,7 +511,10 @@ mod tests {
         let pool_locked = pool.lock().unwrap();
         assert_eq!(pool_locked.len(), 1);
         let expected = tx_from_received_bytes(body);
-        assert_eq!(pool_locked.get_body_by_id(&expected.tx_id.0), Some(expected.body.0));
+        assert_eq!(
+            pool_locked.get_body_by_id(&expected.tx_id.0),
+            Some(expected.body.0)
+        );
     }
 
     #[test]

--- a/net-rs/net-node/src/mempool.rs
+++ b/net-rs/net-node/src/mempool.rs
@@ -44,7 +44,7 @@ fn from_con_tx(tx: shared_consensus::mempool::PendingTx) -> PendingTx {
 /// Pad/truncate a `Vec<u8>` tx-id into the wrapper's 32-byte hash form.
 /// shared-consensus's `TxId = Vec<u8>` is hash-scheme-agnostic; net-rs's wire
 /// format pins it at Blake2b-256.
-fn to_hash_32(id: Vec<u8>) -> [u8; 32] {
+fn to_hash_32(id: Arc<Vec<u8>>) -> [u8; 32] {
     let mut h = [0u8; 32];
     let n = id.len().min(32);
     h[..n].copy_from_slice(&id[..n]);
@@ -180,8 +180,8 @@ impl Mempool {
     }
 
 
-    pub fn get_body_by_id(&self, id: &[u8]) -> Option<Vec<u8>> {
-        self.state.get_body_by_id(id)
+    pub fn get_body_by_id(&self, id: &[u8]) -> Option<Arc<Vec<u8>>> {
+        self.state.get_body_by_id(Arc::new(id.to_vec()))
     }
 
     /// Run the CIP-0164 overflow rule.  Returns the body path the next
@@ -239,7 +239,7 @@ impl Mempool {
     /// `peek_unannounced_for_peer` iterates, so no admit-fanout
     /// notification fires here — peers fetch these via LeiosFetch
     /// BlockTxs, not TxSubmission.
-    pub fn merge_eb_body(&mut self, body: Vec<u8>) {
+    pub fn merge_eb_body(&mut self, body: Arc<Vec<u8>>) {
         let tx = tx_from_received_bytes(body);
         self.state.merge_eb_body(tx.tx_id.0, tx.body.0, tx.size);
     }
@@ -256,8 +256,8 @@ impl Mempool {
     /// Snapshot of every locally available tx id — free pool plus
     /// EB-pinned bodies.  Used by the CIP-0164 `MissingTX` voting
     /// predicate.
-    pub fn all_known_tx_ids(&self) -> HashSet<Vec<u8>> {
-        let mut ids: HashSet<Vec<u8>> = self.state.txs.iter().map(|t| t.tx_id.clone()).collect();
+    pub fn all_known_tx_ids(&self) -> HashSet<Arc<Vec<u8>>> {
+        let mut ids: HashSet<Arc<Vec<u8>>> = self.state.txs.iter().map(|t| t.tx_id.clone()).collect();
         ids.extend(self.state.eb_pinned.keys().cloned());
         ids
     }
@@ -280,18 +280,18 @@ impl MempoolTxBodyResolver {
 }
 
 impl net_core::store::leios_store::TxBodyResolver for MempoolTxBodyResolver {
-    fn resolve_body(&self, tx_id: &[u8]) -> Option<Vec<u8>> {
+    fn resolve_body(&self, tx_id: &[u8]) -> Option<Arc<Vec<u8>>> {
         self.0.lock().unwrap().get_body_by_id(tx_id)
     }
 }
 
 /// Build a `PendingTx` from raw bytes received from a peer.
 /// The tx_id is derived by hashing the body with Blake2b-256.
-pub fn tx_from_received_bytes(body: Vec<u8>) -> PendingTx {
+pub fn tx_from_received_bytes(body: Arc<Vec<u8>>) -> PendingTx {
     let hash = blake2b_simd::Params::new().hash_length(32).hash(&body);
     let size = body.len() as u32;
     PendingTx {
-        tx_id: TxId(hash.as_bytes().to_vec()),
+        tx_id: TxId(Arc::new(hash.as_bytes().to_vec())),
         body: TxBody(body),
         size,
     }
@@ -366,7 +366,7 @@ pub fn spawn_tx_validator(
     tx_validation_ms: f64,
     tx_validation_ms_per_byte: f64,
     mempool: SharedMempool,
-    mut rx: mpsc::Receiver<Vec<u8>>,
+    mut rx: mpsc::Receiver<Arc<Vec<u8>>>,
 ) -> tokio::task::JoinHandle<()> {
     let sem = Arc::new(tokio::sync::Semaphore::new(256));
     tokio::spawn(async move {
@@ -394,7 +394,7 @@ pub fn spawn_tx_validator(
 fn make_fake_tx(rng: &mut StdRng, size: usize) -> PendingTx {
     let mut body_buf = vec![0u8; size];
     rng.fill(&mut body_buf[..]);
-    tx_from_received_bytes(body_buf)
+    tx_from_received_bytes(Arc::new(body_buf))
 }
 
 /// Sample an exponential inter-arrival time: `-ln(U) / lambda`.
@@ -409,8 +409,8 @@ mod tests {
 
     fn make_tx_with_id(id: u8, size: usize) -> PendingTx {
         PendingTx {
-            tx_id: TxId(vec![id; 32]),
-            body: TxBody(vec![0; size]),
+            tx_id: TxId(Arc::new(vec![id; 32])),
+            body: TxBody(Arc::new(vec![0; size])),
             size: size as u32,
         }
     }
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn tx_from_received_bytes_deterministic() {
-        let body = vec![0xAA; 100];
+        let body = Arc::new(vec![0xAA; 100]);
         let tx1 = tx_from_received_bytes(body.clone());
         let tx2 = tx_from_received_bytes(body);
         assert_eq!(tx1.tx_id.0, tx2.tx_id.0);
@@ -445,33 +445,10 @@ mod tests {
 
     #[test]
     fn tx_from_received_bytes_different_inputs() {
-        let tx1 = tx_from_received_bytes(vec![0xAA; 100]);
-        let tx2 = tx_from_received_bytes(vec![0xBB; 100]);
+        let tx1 = tx_from_received_bytes(Arc::new(vec![0xAA; 100]));
+        let tx2 = tx_from_received_bytes(Arc::new(vec![0xBB; 100]));
         assert_ne!(tx1.tx_id.0, tx2.tx_id.0);
     }
-
-    #[test]
-    fn exp_sample_positive() {
-        let mut rng = StdRng::seed_from_u64(42);
-        for _ in 0..100 {
-            let d = exp_sample(&mut rng, 1.0);
-            assert!(d.as_secs_f64() > 0.0);
-        }
-    }
-
-    #[test]
-    fn exp_sample_mean_roughly_correct() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let rate = 2.0;
-        let n = 10_000;
-        let total: f64 = (0..n)
-            .map(|_| exp_sample(&mut rng, rate).as_secs_f64())
-            .sum();
-        let mean = total / n as f64;
-        assert!((0.4..=0.6).contains(&mean), "mean={mean}, expected ~0.5");
-    }
-
-    // -- Wrapper translation tests (algorithmic behaviour lives in shared-consensus) --
 
     #[tokio::test]
     async fn mempool_resolver_serves_body_through_trait() {
@@ -480,23 +457,26 @@ mod tests {
         {
             let mut p = pool.lock().unwrap();
             p.push(PendingTx {
-                tx_id: TxId(vec![0xCC; 32]),
-                body: TxBody(vec![0xDE, 0xAD]),
+                tx_id: TxId(Arc::new(vec![0xCC; 32])),
+                body: TxBody(Arc::new(vec![0xDE, 0xAD])),
                 size: 2,
             });
         }
         let resolver = MempoolTxBodyResolver::new(pool);
-        assert_eq!(resolver.resolve_body(&[0xCC; 32]), Some(vec![0xDE, 0xAD]));
+        assert_eq!(
+            resolver.resolve_body(&[0xCC; 32]),
+            Some(Arc::new(vec![0xDE, 0xAD]))
+        );
         assert_eq!(resolver.resolve_body(&[0x99; 32]), None);
     }
 
     #[tokio::test]
     async fn validator_pushes_received_body_into_mempool_with_hash_id() {
         let pool = new_mempool(100);
-        let (tx, rx) = mpsc::channel::<Vec<u8>>(8);
+        let (tx, rx) = mpsc::channel::<Arc<Vec<u8>>>(8);
         let _h = spawn_tx_validator(0.0, 0.0, pool.clone(), rx);
 
-        let body = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let body = Arc::new(vec![0xDE, 0xAD, 0xBE, 0xEF]);
         tx.send(body.clone()).await.unwrap();
 
         for _ in 0..50 {
@@ -508,10 +488,7 @@ mod tests {
         let pool_locked = pool.lock().unwrap();
         assert_eq!(pool_locked.len(), 1);
         let expected = tx_from_received_bytes(body);
-        assert_eq!(
-            pool_locked.get_body_by_id(&expected.tx_id.0),
-            Some(expected.body.0)
-        );
+        assert_eq!(pool_locked.get_body_by_id(&expected.tx_id.0), Some(expected.body.0));
     }
 
     #[test]

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -567,6 +567,7 @@ pub fn blake2b_256(bytes: &[u8]) -> [u8; 32] {
 mod tests {
     use super::*;
     use net_core::protocols::txsubmission::{PendingTx, TxBody, TxId};
+    use std::sync::Arc;
 
     fn base_config() -> ProductionConfig {
         ProductionConfig {
@@ -635,8 +636,8 @@ mod tests {
 
     fn make_test_tx(id: u8, size: usize) -> PendingTx {
         PendingTx {
-            tx_id: TxId(vec![id; 32]),
-            body: TxBody(vec![id; size]),
+            tx_id: TxId(Arc::new(vec![id; 32])),
+            body: TxBody(Arc::new(vec![id; size])),
             size: size as u32,
         }
     }

--- a/net-rs/net-node/src/validation.rs
+++ b/net-rs/net-node/src/validation.rs
@@ -13,6 +13,7 @@
 //! and tracks the current tip so `rollback` is meaningful.
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -83,8 +84,8 @@ pub enum LedgerCommand {
     ValidateEb { point: Point },
     /// Validate a vote bundle (fake delay, then succeed).
     ValidateVotes {
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     },
 }
 
@@ -104,8 +105,8 @@ pub enum LedgerOutcome {
     /// Vote validation completed.
     VotesValidated {
         #[allow(dead_code)] // kept for future telemetry/diagnostics
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     },
 }
 
@@ -487,8 +488,8 @@ mod tests {
         let rx = test_dyn_config(0.0, 0.0, 0.0);
         let (validator, mut outcome_rx) = Validator::new(rx);
 
-        let vote_ids = vec![(10u64, vec![0xAAu8]), (20u64, vec![0xBBu8])];
-        let vote_data = vec![vec![0x01], vec![0x02]];
+        let vote_ids = vec![(10u64, Arc::new(vec![0xAAu8])), (20u64, Arc::new(vec![0xBBu8]))];
+        let vote_data = vec![Arc::new(vec![0x01]), Arc::new(vec![0x02])];
         validator
             .submit(LedgerCommand::ValidateVotes {
                 vote_ids: vote_ids.clone(),

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -216,7 +216,7 @@ pub trait Behaviour: Send + Sync {
         &mut self,
         _state: &LeiosState,
         _peer: PeerId,
-        _vote_ids: &[(u64, Vec<u8>)],
+        _vote_ids: &[(u64, Arc<Vec<u8>>)],
     ) -> BehaviourOutcome<LeiosEffect> {
         BehaviourOutcome::Continue
     }
@@ -233,8 +233,8 @@ pub trait Behaviour: Send + Sync {
     fn on_votes_received(
         &mut self,
         _state: &LeiosState,
-        _vote_ids: &[(u64, Vec<u8>)],
-        _vote_data: &[Vec<u8>],
+        _vote_ids: &[(u64, Arc<Vec<u8>>)],
+        _vote_data: &[Arc<Vec<u8>>],
     ) -> BehaviourOutcome<LeiosEffect> {
         BehaviourOutcome::Continue
     }
@@ -483,7 +483,7 @@ impl Behaviour for CompositeBehaviour {
         &mut self,
         state: &LeiosState,
         peer: PeerId,
-        vote_ids: &[(u64, Vec<u8>)],
+        vote_ids: &[(u64, Arc<Vec<u8>>)],
     ) -> BehaviourOutcome<LeiosEffect> {
         for c in self.children.iter_mut() {
             let out = c.on_votes_offered(state, peer, vote_ids);
@@ -512,8 +512,8 @@ impl Behaviour for CompositeBehaviour {
     fn on_votes_received(
         &mut self,
         state: &LeiosState,
-        vote_ids: &[(u64, Vec<u8>)],
-        vote_data: &[Vec<u8>],
+        vote_ids: &[(u64, Arc<Vec<u8>>)],
+        vote_data: &[Arc<Vec<u8>>],
     ) -> BehaviourOutcome<LeiosEffect> {
         for c in self.children.iter_mut() {
             let out = c.on_votes_received(state, vote_ids, vote_data);

--- a/shared-rs/consensus/src/fetch.rs
+++ b/shared-rs/consensus/src/fetch.rs
@@ -26,7 +26,7 @@ use crate::types::Point;
 /// Vote identity used by the candidate tracker and the vote-fetch
 /// policy — `(slot, voter_id)`, matching the wire-format tuple a vote
 /// announcement carries.
-pub type VoteId = (u64, Vec<u8>);
+pub type VoteId = (u64, Arc<Vec<u8>>);
 
 /// Resolve the offer-set for a single [`VoteId`].  Borrowed by
 /// [`VoteFetchPolicy::pick`] so the policy can inspect a per-vote
@@ -202,7 +202,7 @@ impl VoteFetchPolicy for LowestRttFirst {
         candidates_for: &VoteCandidateLookup<'_>,
         rtt: &dyn PeerRtt,
     ) -> BTreeMap<PeerId, Vec<VoteId>> {
-        let mut grouped: BTreeMap<PeerId, Vec<(u64, Vec<u8>)>> = BTreeMap::new();
+        let mut grouped: BTreeMap<PeerId, Vec<(u64, Arc<Vec<u8>>)>> = BTreeMap::new();
         for vote in votes {
             let candidates = candidates_for(vote);
             if let Some(picked) = LowestRttFirst::pick_one(&candidates, rtt).first() {
@@ -273,7 +273,7 @@ impl VoteFetchPolicy for BroadcastN {
         candidates_for: &VoteCandidateLookup<'_>,
         rtt: &dyn PeerRtt,
     ) -> BTreeMap<PeerId, Vec<VoteId>> {
-        let mut grouped: BTreeMap<PeerId, Vec<(u64, Vec<u8>)>> = BTreeMap::new();
+        let mut grouped: BTreeMap<PeerId, Vec<(u64, Arc<Vec<u8>>)>> = BTreeMap::new();
         for vote in votes {
             let candidates = candidates_for(vote);
             for picked in self.pick_n(&candidates, rtt) {
@@ -636,10 +636,10 @@ mod tests {
     fn vote_fetch_groups_by_lowest_rtt_per_vote() {
         let policy = LowestRttFirst;
         let rtt = rtts(&[(1, 50), (2, 10)]);
-        let votes = vec![(10u64, b"voter-a".to_vec()), (10u64, b"voter-b".to_vec())];
+        let votes = vec![(10u64, Arc::new(b"voter-a".to_vec())), (10u64, Arc::new(b"voter-b".to_vec()))];
         let candidates_for = |v: &VoteId| {
             // voter-a is offered by both peers; voter-b only by pid(1).
-            if v.1 == b"voter-a" {
+            if *v.1 == b"voter-a" {
                 vec![pid(1), pid(2)]
             } else {
                 vec![pid(1)]
@@ -649,11 +649,11 @@ mod tests {
         // pid(2) (lower RTT) gets voter-a; pid(1) (only candidate) gets voter-b.
         assert_eq!(
             grouped.get(&pid(2)).cloned().unwrap_or_default(),
-            vec![(10u64, b"voter-a".to_vec())]
+            vec![(10u64, Arc::new(b"voter-a".to_vec()))]
         );
         assert_eq!(
             grouped.get(&pid(1)).cloned().unwrap_or_default(),
-            vec![(10u64, b"voter-b".to_vec())]
+            vec![(10u64, Arc::new(b"voter-b".to_vec()))]
         );
     }
 
@@ -699,12 +699,12 @@ mod tests {
         t.note_block_offered(pt(1, 1), pid(1));
         t.note_eb_offered(pt(2, 2), pid(1));
         t.note_eb_txs_offered(pt(3, 3), pid(1));
-        t.note_vote_offered((4, b"v".to_vec()), pid(1));
+        t.note_vote_offered((4, Arc::new(b"v".to_vec())), pid(1));
         t.forget_peer(pid(1));
         assert!(t.block_candidates(&pt(1, 1)).is_empty());
         assert!(t.eb_candidates(&pt(2, 2)).is_empty());
         assert!(t.eb_txs_candidates(&pt(3, 3)).is_empty());
-        assert!(t.vote_candidates(&(4, b"v".to_vec())).is_empty());
+        assert!(t.vote_candidates(&(4, Arc::new(b"v".to_vec()))).is_empty());
     }
 
     #[test]
@@ -712,13 +712,13 @@ mod tests {
         let mut t = CandidateTracker::new();
         t.note_eb_offered(pt(5, 1), pid(1));
         t.note_eb_offered(pt(15, 1), pid(2));
-        t.note_vote_offered((5, b"a".to_vec()), pid(1));
-        t.note_vote_offered((15, b"b".to_vec()), pid(2));
+        t.note_vote_offered((5, Arc::new(b"a".to_vec())), pid(1));
+        t.note_vote_offered((15, Arc::new(b"b".to_vec())), pid(2));
         t.prune_below_slot(10);
         assert!(t.eb_candidates(&pt(5, 1)).is_empty());
         assert_eq!(t.eb_candidates(&pt(15, 1)), vec![pid(2)]);
-        assert!(t.vote_candidates(&(5, b"a".to_vec())).is_empty());
-        assert_eq!(t.vote_candidates(&(15, b"b".to_vec())), vec![pid(2)]);
+        assert!(t.vote_candidates(&(5, Arc::new(b"a".to_vec()))).is_empty());
+        assert_eq!(t.vote_candidates(&(15, Arc::new(b"b".to_vec()))), vec![pid(2)]);
     }
 
     // -- PeerRttCache -------------------------------------------------------

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -1304,6 +1304,7 @@ fn indices_to_bitmap(indices: &[u32]) -> BTreeMap<u16, u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn pipeline() -> PipelineConfig {
         PipelineConfig {
@@ -1575,14 +1576,18 @@ mod tests {
         state.eb_tx_hashes.insert(h(1), (10, vec![ha, hb, hc]));
         // Body order arrives as [b, a, c] but should come out [a, b, c].
         let bodies = vec![
-            (b"body-b".to_vec(), hb),
-            (b"body-a".to_vec(), ha),
-            (b"body-c".to_vec(), hc),
+            (Arc::new(b"body-b".to_vec()), hb),
+            (Arc::new(b"body-a".to_vec()), ha),
+            (Arc::new(b"body-c".to_vec()), hc),
         ];
         let outcome = state.match_eb_tx_response(&point(10, 1), &bodies);
         assert_eq!(
             outcome.matched_bodies,
-            vec![b"body-a".to_vec(), b"body-b".to_vec(), b"body-c".to_vec()]
+            vec![
+                Arc::new(b"body-a".to_vec()),
+                Arc::new(b"body-b".to_vec()),
+                Arc::new(b"body-c".to_vec())
+            ]
         );
     }
 
@@ -1592,9 +1597,12 @@ mod tests {
         let ha = h(0xA0);
         state.eb_tx_hashes.insert(h(1), (10, vec![ha]));
         let bogus = h(0xFF);
-        let bodies = vec![(b"body-a".to_vec(), ha), (b"bogus".to_vec(), bogus)];
+        let bodies = vec![
+            (Arc::new(b"body-a".to_vec()), ha),
+            (Arc::new(b"bogus".to_vec()), bogus),
+        ];
         let outcome = state.match_eb_tx_response(&point(10, 1), &bodies);
-        assert_eq!(outcome.matched_bodies, vec![b"body-a".to_vec()]);
+        assert_eq!(outcome.matched_bodies, vec![Arc::new(b"body-a".to_vec())]);
     }
 
     #[test]
@@ -1745,9 +1753,11 @@ mod tests {
         requested.insert(0u16, 0b11u64);
         state.pending_eb_tx_fetches.insert(h(1), (10, requested));
         // Only body for index 0 (ha) arrives.
-        let outcome =
-            state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
-        assert_eq!(outcome.matched_bodies, vec![b"body-a".to_vec()]);
+        let outcome = state.match_eb_tx_response(
+            &point(10, 1),
+            &[(Arc::new(b"body-a".to_vec()), ha)],
+        );
+        assert_eq!(outcome.matched_bodies, vec![Arc::new(b"body-a".to_vec())]);
         assert_eq!(outcome.requested, 2);
         // Index 1 still missing.
         let mut expected_remaining = BTreeMap::new();
@@ -1768,8 +1778,10 @@ mod tests {
         let mut requested = BTreeMap::new();
         requested.insert(0u16, 0b1u64);
         state.pending_eb_tx_fetches.insert(h(1), (10, requested));
-        let outcome =
-            state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
+        let outcome = state.match_eb_tx_response(
+            &point(10, 1),
+            &[(Arc::new(b"body-a".to_vec()), ha)],
+        );
         assert!(outcome.remaining_bitmap.is_empty());
         assert!(!state.pending_eb_tx_fetches.contains_key(&h(1)));
     }
@@ -1779,9 +1791,9 @@ mod tests {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
         let outcome = state.match_eb_tx_response(
             &point(10, 1),
-            &[(b"some-body".to_vec(), h(0xAA))],
+            &[(Arc::new(b"some-body".to_vec()), h(0xAA))],
         );
-        assert_eq!(outcome.matched_bodies, vec![b"some-body".to_vec()]);
+        assert_eq!(outcome.matched_bodies, vec![Arc::new(b"some-body".to_vec())]);
         assert_eq!(outcome.requested, 0);
         assert!(outcome.remaining_bitmap.is_empty());
     }
@@ -2065,8 +2077,8 @@ mod tests {
 
         let mut mempool = crate::mempool::MempoolState::new(4096);
         // Local mempool has txs 0 (h(1)) and 2 (h(3)); 1 (h(2)) and 3 (h(4)) are missing.
-        mempool.admit_validated(h(1).to_vec(), vec![0u8; 16], 16);
-        mempool.admit_validated(h(3).to_vec(), vec![0u8; 16], 16);
+        mempool.admit_validated(Arc::new(h(1).to_vec()), Arc::new(vec![0u8; 16]), 16);
+        mempool.admit_validated(Arc::new(h(3).to_vec()), Arc::new(vec![0u8; 16]), 16);
 
         let bitmap = state.missing_eb_tx_bitmap(&h(0xAB), &mempool);
         let indices: Vec<u32> = crate::bitmap::iter_indices(&bitmap).collect();
@@ -2080,8 +2092,8 @@ mod tests {
         state.eb_tx_hashes.insert(h(0xCD), (50, manifest));
 
         let mut mempool = crate::mempool::MempoolState::new(4096);
-        mempool.admit_validated(h(5).to_vec(), vec![0u8; 8], 8);
-        mempool.admit_validated(h(6).to_vec(), vec![0u8; 8], 8);
+        mempool.admit_validated(Arc::new(h(5).to_vec()), Arc::new(vec![0u8; 8]), 8);
+        mempool.admit_validated(Arc::new(h(6).to_vec()), Arc::new(vec![0u8; 8]), 8);
 
         let bitmap = state.missing_eb_tx_bitmap(&h(0xCD), &mempool);
         assert!(bitmap.is_empty());

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -191,7 +191,7 @@ pub enum LeiosEffect {
     /// [`VoteFetchPolicy`] into one batch per peer.  The wrapper
     /// dispatches each (`peer`, `votes`) tuple as a separate fetch.
     FetchLeiosVotes {
-        per_peer: BTreeMap<PeerId, Vec<(u64, Vec<u8>)>>,
+        per_peer: BTreeMap<PeerId, Vec<(u64, Arc<Vec<u8>>)>>,
     },
     /// Record the EB-tx manifest in the network-side store so this
     /// node can serve EB-tx requests back to peers.
@@ -230,8 +230,8 @@ pub enum LeiosEffect {
     ValidateEb { point: Point },
     /// Submit fetched vote bodies for ledger validation.
     ValidateVotes {
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     },
 
     /// Telemetry event the I/O layer should forward to its sink.
@@ -950,8 +950,8 @@ impl LeiosState {
     /// Received vote bodies; submit to the validator.
     pub fn on_votes_received(
         &mut self,
-        vote_ids: Vec<(u64, Vec<u8>)>,
-        vote_data: Vec<Vec<u8>>,
+        vote_ids: Vec<(u64, Arc<Vec<u8>>)>,
+        vote_data: Vec<Arc<Vec<u8>>>,
     ) -> Vec<LeiosEffect> {
         let appended: Vec<LeiosEffect> = match self
             .invoke_hook(|b, s| b.on_votes_received(s, &vote_ids, &vote_data))
@@ -1655,7 +1655,7 @@ mod tests {
     #[test]
     fn on_votes_offered_emits_fetch() {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
-        let votes = vec![(10u64, vec![0u8; 8])];
+        let votes = vec![(10u64, Arc::new(vec![0u8; 8]))];
         let peer = PeerId(1);
         let fx = state.on_votes_offered(peer, votes.clone());
         assert_eq!(fx.len(), 1);
@@ -1680,8 +1680,8 @@ mod tests {
     #[test]
     fn on_votes_received_emits_validate_votes() {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
-        let ids = vec![(10u64, vec![0u8; 8])];
-        let bodies = vec![vec![0xAB]];
+        let ids = vec![(10u64, Arc::new(vec![0u8; 8]))];
+        let bodies = vec![Arc::new(vec![0xAB])];
         let fx = state.on_votes_received(ids.clone(), bodies.clone());
         assert_eq!(fx.len(), 1);
         match &fx[0] {
@@ -1934,10 +1934,10 @@ mod tests {
         state.candidates.note_eb_txs_offered(point(8, 0xDD), peer);
         state
             .candidates
-            .note_vote_offered((5, b"voter".to_vec()), peer);
+            .note_vote_offered((5, Arc::new(b"voter".to_vec())), peer);
         state
             .candidates
-            .note_vote_offered((8, b"voter".to_vec()), peer);
+            .note_vote_offered((8, Arc::new(b"voter".to_vec())), peer);
 
         state.set_chain_tip_context(ChainTipContext {
             tip_rb_slot: Some(8),
@@ -1950,7 +1950,7 @@ mod tests {
         assert!(
             state
                 .candidates
-                .vote_candidates(&(5, b"voter".to_vec()))
+                .vote_candidates(&(5, Arc::new(b"voter".to_vec())))
                 .is_empty()
         );
         assert_eq!(state.candidates.eb_candidates(&point(8, 0xBB)), vec![peer]);
@@ -1959,7 +1959,7 @@ mod tests {
             vec![peer]
         );
         assert_eq!(
-            state.candidates.vote_candidates(&(8, b"voter".to_vec())),
+            state.candidates.vote_candidates(&(8, Arc::new(b"voter".to_vec()))),
             vec![peer]
         );
     }

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -271,7 +271,7 @@ pub enum LeiosTelemetryEvent {
 pub struct EbTxMatchOutcome {
     /// Bodies whose blake2b-256 hash maps to a requested manifest
     /// index, in ascending manifest-index order.
-    pub matched_bodies: Vec<Vec<u8>>,
+    pub matched_bodies: Vec<Arc<Vec<u8>>>,
     /// Number of indices that the original request bitmap selected.
     /// Zero means "manifest not cached at request time" (fallback path).
     pub requested: usize,
@@ -490,7 +490,7 @@ impl LeiosState {
             .iter()
             .enumerate()
             .filter_map(|(i, h)| {
-                let tx_id: crate::mempool::TxId = h.to_vec();
+                let tx_id: crate::mempool::TxId = Arc::new(h.to_vec());
                 if mempool.has_tx(&tx_id) {
                     None
                 } else {
@@ -1091,7 +1091,7 @@ impl LeiosState {
     pub fn match_eb_tx_response(
         &mut self,
         point: &Point,
-        bodies_with_hashes: &[(Vec<u8>, [u8; 32])],
+        bodies_with_hashes: &[(Arc<Vec<u8>>, [u8; 32])],
     ) -> EbTxMatchOutcome {
         // A response means the in-flight fetch for this point is done;
         // clear the candidate tracker's pending guard so a retry (which
@@ -1124,13 +1124,13 @@ impl LeiosState {
             .map(|(i, h)| (h, i))
             .collect();
         // Match each body, sorting by manifest index.
-        let mut matched: BTreeMap<usize, Vec<u8>> = BTreeMap::new();
+        let mut matched: BTreeMap<usize, Arc<Vec<u8>>> = BTreeMap::new();
         for (body, body_hash) in bodies_with_hashes {
             if let Some(&idx) = manifest_index.get(body_hash) {
                 matched.entry(idx).or_insert_with(|| body.clone());
             }
         }
-        let matched_bodies: Vec<Vec<u8>> = matched.values().cloned().collect();
+        let matched_bodies: Vec<Arc<Vec<u8>>> = matched.values().cloned().collect();
 
         // Compute `requested` and `remaining_bitmap`.
         let (requested, remaining_bitmap) =

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -54,13 +54,13 @@ pub struct EbKey {
 /// Opaque transaction identifier.  Conventionally Blake2b-256 of the
 /// body, but this crate doesn't enforce that — the wrapper picks the hash
 /// scheme and supplies it on every entry path.
-pub type TxId = Vec<u8>;
+pub type TxId = Arc<Vec<u8>>;
 
 /// A transaction body the mempool is holding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingTx {
     pub tx_id: TxId,
-    pub body: Vec<u8>,
+    pub body: Arc<Vec<u8>>,
     pub size: u32,
 }
 
@@ -75,7 +75,7 @@ pub enum MempoolEffect {
     /// validator returns, the wrapper calls
     /// [`MempoolState::on_tx_validated`] or
     /// [`MempoolState::on_tx_validation_failed`].
-    ValidateTx { tx_id: TxId, body: Vec<u8> },
+    ValidateTx { tx_id: TxId, body: Arc<Vec<u8>> },
     /// A tx was dropped before reaching the mempool (overflow,
     /// validation failure) or evicted from it.  Telemetry only — the
     /// wrapper forwards this to its events sink.
@@ -142,7 +142,7 @@ pub struct MempoolState {
     /// Bodies currently with the validator.  Cleared on
     /// `on_tx_validated` (body moves to `txs`) or
     /// `on_tx_validation_failed` (body dropped).
-    pub pending_validation: BTreeMap<TxId, Vec<u8>>,
+    pub pending_validation: BTreeMap<TxId, Arc<Vec<u8>>>,
     /// Per-EB ordered tx-hash list — the "EB Body" in CIP-0164 terms.
     /// Producers populate this from `produce_eb`; receivers from
     /// `record_eb_manifest` after decoding a fetched EB body.
@@ -211,7 +211,7 @@ impl MempoolState {
     /// `AlreadyKnown` and discards.  Otherwise records the body and
     /// emits `ValidateTx`; the wrapper validates and reports back via
     /// [`Self::on_tx_validated`] or [`Self::on_tx_validation_failed`].
-    pub fn on_tx_received(&mut self, tx_id: TxId, body: Vec<u8>) -> Vec<MempoolEffect> {
+    pub fn on_tx_received(&mut self, tx_id: TxId, body: Arc<Vec<u8>>) -> Vec<MempoolEffect> {
         let appended: Vec<MempoolEffect> =
             match self.invoke_hook(|b, s| b.on_tx_received(s, &tx_id, &body)) {
                 BehaviourOutcome::Continue => Vec::new(),
@@ -274,7 +274,7 @@ impl MempoolState {
     pub fn admit_validated(
         &mut self,
         tx_id: TxId,
-        body: Vec<u8>,
+        body: Arc<Vec<u8>>,
         size: u32,
     ) -> Vec<MempoolEffect> {
         if self.contains(&tx_id) {
@@ -347,7 +347,7 @@ impl MempoolState {
     /// mempool sizes this prototype targets keep it acceptable.  Used
     /// by the LeiosFetch BlockTxs server (via the `TxBodyResolver`
     /// trait in the consumer's wrapper) to resolve manifest entries.
-    pub fn get_body_by_id(&self, id: &[u8]) -> Option<Vec<u8>> {
+    pub fn get_body_by_id(&self, id: Arc<Vec<u8>>) -> Option<Arc<Vec<u8>>> {
         if let Some(body) = self
             .txs
             .iter()
@@ -356,7 +356,7 @@ impl MempoolState {
         {
             return Some(body);
         }
-        self.eb_pinned.get(id).map(|tx| tx.body.clone())
+        self.eb_pinned.get(&id).map(|tx| tx.body.clone())
     }
 
     /// Return up to `max_count` txs not yet advertised to `peer_id`,
@@ -587,7 +587,7 @@ impl MempoolState {
     /// wrapper hashes incoming bodies and matches against the manifest
     /// before calling here.  No-op if the tx is already known via
     /// `txs` or `eb_pinned`.
-    pub fn merge_eb_body(&mut self, tx_id: TxId, body: Vec<u8>, size: u32) {
+    pub fn merge_eb_body(&mut self, tx_id: TxId, body: Arc<Vec<u8>>, size: u32) {
         if self.contains(&tx_id) || self.eb_pinned.contains_key(&tx_id) {
             return;
         }
@@ -618,16 +618,16 @@ impl MempoolState {
     /// returns bodies for every requested index whose body is locally
     /// resolvable.  Out-of-range indices and indices whose body is
     /// missing are silently dropped (partial response).
-    pub fn get_eb_bodies<I>(&self, eb_key: &EbKey, indices: I) -> Option<Vec<Vec<u8>>>
+    pub fn get_eb_bodies<I>(&self, eb_key: &EbKey, indices: I) -> Option<Vec<Arc<Vec<u8>>>>
     where
         I: IntoIterator<Item = u32>,
     {
         let manifest = self.eb_manifests.get(eb_key)?;
-        let bodies: Vec<Vec<u8>> = indices
+        let bodies: Vec<Arc<Vec<u8>>> = indices
             .into_iter()
             .filter_map(|i| {
                 let tx_id = manifest.get(i as usize)?;
-                self.get_body_by_id(tx_id)
+                self.get_body_by_id(tx_id.clone())
             })
             .collect();
         Some(bodies)
@@ -688,7 +688,7 @@ impl MempoolState {
     fn admit_internal(
         &mut self,
         tx_id: TxId,
-        body: Vec<u8>,
+        body: Arc<Vec<u8>>,
         size: u32,
     ) -> Vec<MempoolEffect> {
         let mut fx = Vec::new();
@@ -760,8 +760,8 @@ mod tests {
         PeerId(n)
     }
 
-    fn tx(id: u8, size: u32) -> (TxId, Vec<u8>, u32) {
-        (vec![id; 32], vec![0u8; size as usize], size)
+    fn tx(id: u8, size: u32) -> (TxId, Arc<Vec<u8>>, u32) {
+        (Arc::new(vec![id; 32]), Arc::new(vec![0u8; size as usize]), size)
     }
 
     fn admit(state: &mut MempoolState, id: u8, size: u32) -> Vec<MempoolEffect> {
@@ -877,7 +877,7 @@ mod tests {
                 tx_id,
                 reason: TxRejectReason::QueueFull,
             } => {
-                assert_eq!(*tx_id, vec![1u8; 32]);
+                assert_eq!(*tx_id, Arc::new(vec![1u8; 32]));
             }
             other => panic!("expected TxRejected QueueFull, got {other:?}"),
         }
@@ -893,10 +893,10 @@ mod tests {
         admit(&mut s, 1, 100);
         admit(&mut s, 2, 200);
         admit(&mut s, 3, 300);
-        let included = vec![vec![1u8; 32], vec![3u8; 32]];
+        let included = vec![Arc::new(vec![1u8; 32]), Arc::new(vec![3u8; 32])];
         s.on_block_applied(&included);
         assert_eq!(s.len(), 1);
-        assert_eq!(s.txs.front().unwrap().tx_id, vec![2u8; 32]);
+        assert_eq!(s.txs.front().unwrap().tx_id, Arc::new(vec![2u8; 32]));
         assert_eq!(s.total_bytes(), 200);
     }
 

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -755,13 +755,18 @@ fn hex_short(id: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn pid(n: u64) -> PeerId {
         PeerId(n)
     }
 
     fn tx(id: u8, size: u32) -> (TxId, Arc<Vec<u8>>, u32) {
-        (Arc::new(vec![id; 32]), Arc::new(vec![0u8; size as usize]), size)
+        (
+            Arc::new(vec![id; 32]),
+            Arc::new(vec![0u8; size as usize]),
+            size,
+        )
     }
 
     fn admit(state: &mut MempoolState, id: u8, size: u32) -> Vec<MempoolEffect> {
@@ -912,7 +917,7 @@ mod tests {
     fn on_block_applied_unknown_ids_is_noop() {
         let mut s = MempoolState::new(10);
         admit(&mut s, 1, 100);
-        s.on_block_applied(&[vec![99u8; 32]]);
+        s.on_block_applied(&[Arc::new(vec![99u8; 32])]);
         assert_eq!(s.len(), 1);
     }
 
@@ -986,7 +991,7 @@ mod tests {
         admit(&mut s, 2, 100);
         let next = s.peek_unannounced_for_peer(peer, 10);
         assert_eq!(next.len(), 1);
-        assert_eq!(next[0].tx_id, vec![2u8; 32]);
+        assert_eq!(next[0].tx_id, Arc::new(vec![2u8; 32]));
     }
 
     #[test]
@@ -998,8 +1003,8 @@ mod tests {
         let _ = s.peek_unannounced_for_peer(peer, 10);
         admit(&mut s, 3, 100);
         let advertised = s.peer_advertised.get(&peer).unwrap();
-        assert!(!advertised.contains(&vec![1u8; 32]));
-        assert!(advertised.contains(&vec![2u8; 32]));
+        assert!(!advertised.contains(&Arc::new(vec![1u8; 32])));
+        assert!(advertised.contains(&Arc::new(vec![2u8; 32])));
     }
 
     #[test]
@@ -1024,10 +1029,10 @@ mod tests {
         admit(&mut s, 2, 100);
         let peer = pid(0);
         let _ = s.peek_unannounced_for_peer(peer, 10);
-        s.on_block_applied(&[vec![1u8; 32]]);
+        s.on_block_applied(&[Arc::new(vec![1u8; 32])]);
         let advertised = s.peer_advertised.get(&peer).unwrap();
-        assert!(!advertised.contains(&vec![1u8; 32]));
-        assert!(advertised.contains(&vec![2u8; 32]));
+        assert!(!advertised.contains(&Arc::new(vec![1u8; 32])));
+        assert!(advertised.contains(&Arc::new(vec![2u8; 32])));
     }
 
     #[test]
@@ -1100,11 +1105,18 @@ mod tests {
         let eb = eb_key(50, 0xEE);
         let (manifest, evictions) = s.produce_eb(eb, 3);
 
-        assert_eq!(manifest, vec![vec![1u8; 32], vec![2u8; 32], vec![3u8; 32]]);
+        assert_eq!(
+            manifest,
+            vec![
+                Arc::new(vec![1u8; 32]),
+                Arc::new(vec![2u8; 32]),
+                Arc::new(vec![3u8; 32])
+            ]
+        );
         assert!(evictions.is_empty(), "no older EBs to evict yet");
         assert!(s.is_empty(), "txs are drained");
         assert_eq!(s.total_bytes(), 0);
-        assert!(s.eb_pinned.contains_key(&vec![1u8; 32]));
+        assert!(s.eb_pinned.contains_key(&Arc::new(vec![1u8; 32])));
         assert_eq!(s.get_eb_manifest(&eb), Some(manifest.as_slice()));
     }
 
@@ -1116,12 +1128,12 @@ mod tests {
         let eb = eb_key(10, 0x11);
         let _ = s.produce_eb(eb, 2);
         // Both still locally available, just under different roofs.
-        assert!(s.has_tx(&vec![1u8; 32]));
-        assert!(s.has_tx(&vec![2u8; 32]));
-        assert!(!s.has_tx(&vec![99u8; 32]));
+        assert!(s.has_tx(&Arc::new(vec![1u8; 32])));
+        assert!(s.has_tx(&Arc::new(vec![2u8; 32])));
+        assert!(!s.has_tx(&Arc::new(vec![99u8; 32])));
         // After draining into an EB, a new tx in the free pool is also has_tx-true.
         admit(&mut s, 3, 100);
-        assert!(s.has_tx(&vec![3u8; 32]));
+        assert!(s.has_tx(&Arc::new(vec![3u8; 32])));
     }
 
     #[test]
@@ -1131,12 +1143,12 @@ mod tests {
         s.admit_validated(id1.clone(), body1.clone(), sz1);
         s.produce_eb(eb_key(5, 0x55), 1);
         // Now id1 is in eb_pinned, not txs.
-        assert_eq!(s.get_body_by_id(&id1), Some(body1));
+        assert_eq!(s.get_body_by_id(id1), Some(body1));
         // A fresh free tx resolves from `txs`.
         let (id2, body2, sz2) = tx(2, 60);
         s.admit_validated(id2.clone(), body2.clone(), sz2);
-        assert_eq!(s.get_body_by_id(&id2), Some(body2));
-        assert_eq!(s.get_body_by_id(&[99u8; 32]), None);
+        assert_eq!(s.get_body_by_id(id2), Some(body2));
+        assert_eq!(s.get_body_by_id(Arc::new(vec![99u8; 32])), None);
     }
 
     #[test]
@@ -1144,8 +1156,8 @@ mod tests {
         // Receiver-side flow: see the EB header → fetch body → decode
         // manifest → record. Bodies arrive later via merge_eb_body.
         let mut s = MempoolState::new(10);
-        let id_a = vec![0xAAu8; 32];
-        let id_b = vec![0xBBu8; 32];
+        let id_a = Arc::new(vec![0xAAu8; 32]);
+        let id_b = Arc::new(vec![0xBBu8; 32]);
         let eb = eb_key(20, 0x77);
         s.record_eb_manifest(eb, vec![id_a.clone(), id_b.clone()]);
 
@@ -1153,29 +1165,29 @@ mod tests {
         assert_eq!(s.missing_eb_indices(&eb), vec![0, 1]);
 
         // Merge the second body first (out-of-order delivery is fine).
-        s.merge_eb_body(id_b.clone(), vec![0xB0], 1);
+        s.merge_eb_body(id_b.clone(), Arc::new(vec![0xB0]), 1);
         assert_eq!(s.missing_eb_indices(&eb), vec![0]);
         assert!(s.has_tx(&id_b));
 
         // Then the first.
-        s.merge_eb_body(id_a.clone(), vec![0xA0], 1);
+        s.merge_eb_body(id_a.clone(), Arc::new(vec![0xA0]), 1);
         assert!(s.missing_eb_indices(&eb).is_empty());
     }
 
     #[test]
     fn get_eb_bodies_returns_partial_subset_in_index_order() {
         let mut s = MempoolState::new(10);
-        let ids: Vec<TxId> = (0..5).map(|i| vec![i as u8; 32]).collect();
+        let ids: Vec<TxId> = (0..5).map(|i| Arc::new(vec![i as u8; 32])).collect();
         let eb = eb_key(30, 0x33);
         s.record_eb_manifest(eb, ids.clone());
         // Only bodies for indices 1 and 3 are locally available.
-        s.merge_eb_body(ids[1].clone(), vec![0x11], 1);
-        s.merge_eb_body(ids[3].clone(), vec![0x33], 1);
+        s.merge_eb_body(ids[1].clone(), Arc::new(vec![0x11]), 1);
+        s.merge_eb_body(ids[3].clone(), Arc::new(vec![0x33]), 1);
 
         // Server gets a bitmap request for [0, 1, 2, 3, 4]; returns only the
         // bodies it has, in ascending index order.
         let got = s.get_eb_bodies(&eb, 0..5).unwrap();
-        assert_eq!(got, vec![vec![0x11], vec![0x33]]);
+        assert_eq!(got, vec![Arc::new(vec![0x11]), Arc::new(vec![0x33])]);
     }
 
     #[test]
@@ -1188,12 +1200,12 @@ mod tests {
     #[test]
     fn merge_eb_body_idempotent_against_existing() {
         let mut s = MempoolState::new(10);
-        let id = vec![0xCCu8; 32];
+        let id = Arc::new(vec![0xCCu8; 32]);
         s.record_eb_manifest(eb_key(40, 0x40), vec![id.clone()]);
-        s.merge_eb_body(id.clone(), vec![0xCC], 1);
+        s.merge_eb_body(id.clone(), Arc::new(vec![0xCC]), 1);
         // Second call with a different (faked) body must not overwrite.
-        s.merge_eb_body(id.clone(), vec![0xFF], 1);
-        assert_eq!(s.get_body_by_id(&id), Some(vec![0xCC]));
+        s.merge_eb_body(id.clone(), Arc::new(vec![0xFF]), 1);
+        assert_eq!(s.get_body_by_id(id), Some(Arc::new(vec![0xCC])));
     }
 
     #[test]
@@ -1212,15 +1224,15 @@ mod tests {
         // Tight window so the test stays small.
         let mut s = MempoolState::new_with_eb_retention(100, 5);
         let old_eb = eb_key(1, 0x01);
-        let evicted_id = vec![0xAAu8; 32];
+        let evicted_id = Arc::new(vec![0xAAu8; 32]);
         let evictions_initial = s.record_eb_manifest(old_eb, vec![evicted_id.clone()]);
         assert!(evictions_initial.is_empty(), "no evictions on first record");
-        s.merge_eb_body(evicted_id.clone(), vec![0xAA], 1);
+        s.merge_eb_body(evicted_id.clone(), Arc::new(vec![0xAA]), 1);
         assert!(s.has_tx(&evicted_id));
         assert!(s.get_eb_manifest(&old_eb).is_some());
 
         // Push max_eb_slot far past the window.
-        let evictions = s.record_eb_manifest(eb_key(100, 0x02), vec![vec![0xBBu8; 32]]);
+        let evictions = s.record_eb_manifest(eb_key(100, 0x02), vec![Arc::new(vec![0xBBu8; 32])]);
 
         // Old EB and its body are evicted; new EB stays.
         assert!(s.get_eb_manifest(&old_eb).is_none());
@@ -1242,9 +1254,9 @@ mod tests {
     fn produce_eb_emits_evictions_for_aged_pins() {
         let mut s = MempoolState::new_with_eb_retention(100, 5);
         // Old EB with a pinned body.
-        let old_id = vec![0xAAu8; 32];
+        let old_id = Arc::new(vec![0xAAu8; 32]);
         let _ = s.record_eb_manifest(eb_key(1, 0x01), vec![old_id.clone()]);
-        s.merge_eb_body(old_id.clone(), vec![0xAA], 1);
+        s.merge_eb_body(old_id.clone(), Arc::new(vec![0xAA]), 1);
 
         // Produce a new EB far past the retention window — the
         // producer-side path also evicts the aged closure.
@@ -1265,10 +1277,10 @@ mod tests {
         // Same tx referenced by two EBs — pruning one shouldn't drop
         // the body if the other still references it.
         let mut s = MempoolState::new_with_eb_retention(100, 5);
-        let id = vec![0xCCu8; 32];
+        let id = Arc::new(vec![0xCCu8; 32]);
         s.record_eb_manifest(eb_key(1, 0x01), vec![id.clone()]);
         s.record_eb_manifest(eb_key(95, 0x02), vec![id.clone()]);
-        s.merge_eb_body(id.clone(), vec![0xCC], 1);
+        s.merge_eb_body(id.clone(), Arc::new(vec![0xCC]), 1);
         // Bump max so the slot=1 EB falls out of the window but slot=95 stays.
         s.record_eb_manifest(eb_key(99, 0x03), vec![]);
         assert!(s.get_eb_manifest(&eb_key(1, 0x01)).is_none());

--- a/shared-rs/consensus/src/production.rs
+++ b/shared-rs/consensus/src/production.rs
@@ -145,11 +145,12 @@ mod tests {
     use crate::mempool::{EbKey, MempoolState};
     use crate::pipeline::PipelineConfig;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     fn pending(id: u8, size: u32) -> PendingTx {
         PendingTx {
-            tx_id: vec![id; 32],
-            body: vec![0u8; size as usize],
+            tx_id: Arc::new(vec![id; 32]),
+            body: Arc::new(vec![0u8; size as usize]),
             size,
         }
     }
@@ -221,11 +222,11 @@ mod tests {
         populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200)]);
         let body = BodyPath::decide(&mut state, 500, EB_CAP, &leios, false);
         assert_eq!(body.inline.len(), 2);
-        assert_eq!(body.inline[0].tx_id, vec![1u8; 32]);
-        assert_eq!(body.inline[1].tx_id, vec![2u8; 32]);
+        assert_eq!(body.inline[0].tx_id, Arc::new(vec![1u8; 32]));
+        assert_eq!(body.inline[1].tx_id, Arc::new(vec![2u8; 32]));
         assert_eq!(body.manifest.len(), 2);
-        assert_eq!(body.manifest[0], vec![3u8; 32]);
-        assert_eq!(body.manifest[1], vec![4u8; 32]);
+        assert_eq!(body.manifest[0], Arc::new(vec![3u8; 32]));
+        assert_eq!(body.manifest[1], Arc::new(vec![4u8; 32]));
         // Inline txs drained; manifest txs still in the free pool
         // pending the wrapper's produce_eb commit.
         assert_eq!(state.txs.len(), 2);
@@ -252,8 +253,8 @@ mod tests {
         // drain_up_to(500) takes [250] (next would be 501 > 500 with
         // non-empty result).  Residual = [251] → manifest.
         assert_eq!(body.inline.len(), 1);
-        assert_eq!(body.inline[0].tx_id, vec![1u8; 32]);
-        assert_eq!(body.manifest, vec![vec![2u8; 32]]);
+        assert_eq!(body.inline[0].tx_id, Arc::new(vec![1u8; 32]));
+        assert_eq!(body.manifest, vec![Arc::new(vec![2u8; 32])]);
     }
 
     #[test]
@@ -297,8 +298,8 @@ mod tests {
         let body = BodyPath::decide(&mut state, 500, 500, &leios, false);
         assert_eq!(body.inline.len(), 2);
         assert_eq!(body.manifest.len(), 2);
-        assert_eq!(body.manifest[0], vec![3u8; 32]);
-        assert_eq!(body.manifest[1], vec![4u8; 32]);
+        assert_eq!(body.manifest[0], Arc::new(vec![3u8; 32]));
+        assert_eq!(body.manifest[1], Arc::new(vec![4u8; 32]));
         // Residual txs 3..7 still in mempool; produce_eb drains the
         // manifest prefix.
         assert_eq!(state.txs.len(), 5);
@@ -325,7 +326,7 @@ mod tests {
         let body = BodyPath::decide(&mut state, 500, 500, &leios, false);
         assert_eq!(body.inline.len(), 1);
         assert_eq!(body.manifest.len(), 1);
-        assert_eq!(body.manifest[0], vec![2u8; 32]);
+        assert_eq!(body.manifest[0], Arc::new(vec![2u8; 32]));
     }
 
     #[test]


### PR DESCRIPTION
An attempt to additionally reduce memory consumption of net-node.

Main idea: as profiling shows, Mempool is the main memory user. The structures of Mempool have multiple occurrences of TxId's and transaction bodies, each of them is a Vec<u8> (many of them copied multiple times). Enclosing those vec's with Arc's may reduce memory footprint.

Estimated improvement:
1. ~30% for block-producing node (eb_pinned vs. txs deque sizes).
2. Smaller memory consumption peaks.