### PR TITLE
Fix missing LeiosElectionInfo handling in sim-rs

### DIFF
--- a/sim-rs/sim-core/src/sim/shared_consensus.rs
+++ b/sim-rs/sim-core/src/sim/shared_consensus.rs
@@ -2071,7 +2071,10 @@ impl SharedConsensus {
                     }
                 }
                 LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::QuorumReached { .. })
-                | LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::ElectionExpired { .. }) => {
+                | LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::ElectionExpired { .. })
+                | LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::LeiosElectionInfo {
+                    ..
+                }) => {
                     // No 1:1 sim telemetry; sim's stat aggregator
                     // derives equivalent signals from `votes_by_eb`
                     // counts on the receive path.


### PR DESCRIPTION
Fixes `sim-rs` build by adding omitted handling of LeiosTelemetryEvent events.