### PR TITLE
Mempool events for displaying txs load in Throughput dashboard

### DIFF
--- a/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
+++ b/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
@@ -127,7 +127,7 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -143,21 +143,6 @@
           "legendFormat": "{{process}} mempool",
           "range": true,
           "refId": "Mempool bytes"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
-          },
-          "direction": "backward",
-          "editorMode": "code",
-          "expr": "rate({service=\"tx-centrifuge\", ns=\"TxCentrifuge.Builder.NewTx\"}[30s]) * 204 / 1000",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Load (assumed 204B per tx)",
-          "queryType": "range",
-          "range": true,
-          "refId": "Load"
         }
       ],
       "title": "Mempool",
@@ -237,7 +222,7 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -250,8 +235,8 @@
           },
           "direction": "backward",
           "editorMode": "code",
-          "expr": "rate({service=\"tx-centrifuge\", ns=\"TxCentrifuge.Builder.NewTx\"}[30s])",
-          "legendFormat": "tx/s",
+          "expr": "rate({type=\"cardano-node\", ns=~\"Mempool.AddedTx\"}[30s])",
+          "legendFormat": "{{process}}",
           "queryType": "range",
           "refId": "A"
         }

--- a/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
+++ b/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
@@ -322,7 +322,7 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },

--- a/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
+++ b/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
@@ -65,6 +65,7 @@
               "mode": "off"
             }
           },
+          "fieldMinMax": false,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -78,38 +79,10 @@
                 "value": 80
               }
             ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Load (assumed 204B per tx)"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "TxkB/s"
-              }
-            ]
           },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "Mempool bytes"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "deckbytes"
-              }
-            ]
-          }
-        ]
+          "unit": "bytes"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -139,8 +112,8 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "cardano_node_metrics_mempoolBytes_int / 1000",
-          "legendFormat": "{{process}} mempool",
+          "expr": "cardano_node_metrics_mempoolBytes_int",
+          "legendFormat": "{{process}}",
           "range": true,
           "refId": "Mempool bytes"
         }
@@ -295,14 +268,10 @@
               {
                 "color": "green",
                 "value": 0
-              },
-              {
-                "color": "red",
-                "value": 200
               }
             ]
           },
-          "unit": "kBs"
+          "unit": "Bps"
         },
         "overrides": []
       },
@@ -334,13 +303,13 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(cardano_node_metrics_cumulativeTxBytes_int{job=\"cardano_node_metrics\"}[300s]) / 1000",
-          "legendFormat": "{{alias}} txkB/s",
+          "expr": "rate(cardano_node_metrics_cumulativeTxBytes_int{job=\"cardano_node_metrics\"}[300s])",
+          "legendFormat": "{{process}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Confirmed tx throughput",
+      "title": "Confirmed tx throughput (tx kB / 300s)",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
DONE
- [x] Use Mempool traces for displaying Tx Load (removed tx-centrifuge logs based display)
- [x] Set All tooltip
- [x] Fix units and simplify expressions

<img width="3223" height="1368" alt="image" src="https://github.com/user-attachments/assets/257d1fc4-d17d-474f-9f0c-bc48ce8536a0" />
