### PR TITLE
praos: deep-rollback recovery + multi-peer fork reconciliation (with chaos behaviours)

### DIFF
--- a/net-rs/Cargo.lock
+++ b/net-rs/Cargo.lock
@@ -836,9 +836,11 @@ dependencies = [
  "clap",
  "figment",
  "futures-util",
+ "indexmap",
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shared-consensus",
  "tempfile",
  "tokio",
@@ -1292,6 +1294,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1718,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/net-rs/net-cluster/src/aggregator.rs
+++ b/net-rs/net-cluster/src/aggregator.rs
@@ -44,7 +44,7 @@ pub async fn run(
                             accumulated_before_flush = 0;
                         }
                         else {
-                            accumulated_before_flush += len.clone();
+                            accumulated_before_flush += len;
                         }
                     }
                     None => {

--- a/net-rs/net-cluster/src/aggregator.rs
+++ b/net-rs/net-cluster/src/aggregator.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::sync::{mpsc, RwLock};
 use crate::types::{EventWindow, IngestedEvent};
+use tokio::sync::{mpsc, RwLock};
 
 /// Run the aggregator as a tokio task.
 ///

--- a/net-rs/net-cluster/src/main.rs
+++ b/net-rs/net-cluster/src/main.rs
@@ -129,8 +129,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         tokio::sync::mpsc::channel::<config::ClusterControlConfig>(1);
     let (update_tx, mut update_rx) =
         tokio::sync::mpsc::channel::<std::collections::HashMap<String, serde_json::Value>>(16);
-    let (attack_tx, mut attack_rx) =
-        tokio::sync::mpsc::channel::<server::AttackCommand>(4);
+    let (attack_tx, mut attack_rx) = tokio::sync::mpsc::channel::<server::AttackCommand>(4);
     let initial_stakes: Vec<u64> = topo.nodes.iter().map(|n| n.stake).collect();
     let (server_state, _server_handle) = server::start(
         current_config.aggregator_port,
@@ -375,7 +374,9 @@ fn build_topology(
     total_stake: u64,
 ) -> Result<topology::Topology, Box<dyn std::error::Error + Send + Sync>> {
     match current_config.topology_source {
-        config::TopologySource::Random => Ok(topology::generate_random(current_config, total_stake)),
+        config::TopologySource::Random => {
+            Ok(topology::generate_random(current_config, total_stake))
+        }
         config::TopologySource::Yaml => {
             let yaml = &current_config.topology_yaml;
             topology::load_from_yaml(

--- a/net-rs/net-cluster/src/process.rs
+++ b/net-rs/net-cluster/src/process.rs
@@ -184,11 +184,7 @@ impl ProcessManager {
     /// pipe are silently skipped.  Used by the runtime attack-trigger
     /// path, where the orchestrator targets a specific subset of nodes
     /// rather than broadcasting.
-    pub async fn send_config_update_to(
-        &mut self,
-        indices: &[usize],
-        json: &serde_json::Value,
-    ) {
+    pub async fn send_config_update_to(&mut self, indices: &[usize], json: &serde_json::Value) {
         let mut line = serde_json::to_string(json).unwrap_or_default();
         line.push('\n');
         let bytes = line.as_bytes();

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -173,6 +173,7 @@ impl AggregatedVotes {
 /// Returns the `Arc<ServerState>` (shared with the aggregator) and a
 /// `JoinHandle` for the server task. The server must be started before
 /// spawning net-node children so they can connect immediately.
+#[allow(clippy::too_many_arguments)]
 pub async fn start(
     port: u16,
     event_tx: mpsc::Sender<Vec<IngestedEvent>>,

--- a/net-rs/net-cluster/src/server.rs
+++ b/net-rs/net-cluster/src/server.rs
@@ -7,6 +7,12 @@ use std::collections::{BTreeSet, HashMap};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::config::{ActiveAttack, AttackRequest, ClusterControlConfig};
+use crate::topology::Topology;
+use crate::types::{
+    self, AggregatedVotesCount, AggregatedVotesHistory, EventWindow, IngestedEvent, NodeVotes,
+    StatsSnapshot, WINDOW_SIZE,
+};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -15,9 +21,6 @@ use axum::Json;
 use futures_util::stream::Stream;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tower_http::cors::CorsLayer;
-use crate::config::{ActiveAttack, AttackRequest, ClusterControlConfig};
-use crate::topology::Topology;
-use crate::types::{self, AggregatedVotesCount, AggregatedVotesHistory, EventWindow, IngestedEvent, NodeVotes, StatsSnapshot, WINDOW_SIZE};
 
 /// Control message sent from the HTTP handlers to the main loop for
 /// the runtime attack-trigger feature.
@@ -128,9 +131,9 @@ impl AggregatedVotes {
                     }
                 }
                 Some("LeiosElectionInfo") => {
-                    let pers_committee = msg.and_then(
-                        |m| m.get("pers_committee_member")).and_then(|c| c.as_bool()
-                    );
+                    let pers_committee = msg
+                        .and_then(|m| m.get("pers_committee_member"))
+                        .and_then(|c| c.as_bool());
                     // No event happens, so no slot update needed.
                     self.update_for_slot_node(node_id, slot, |mask| {
                         mask.perm_committee_member = pers_committee.is_some_and(|x| x);
@@ -256,17 +259,32 @@ fn log_interesting_event(event: &IngestedEvent) {
         Some("RBReceived") => {
             let slot = msg.and_then(|m| m.get("slot")).and_then(|s| s.as_u64());
             let len = msg.and_then(|m| m.get("len")).and_then(|l| l.as_u64());
-            tracing::info!("{}: received block (slot {:?}, len {:?})", event.node_id, slot, len);
+            tracing::info!(
+                "{}: received block (slot {:?}, len {:?})",
+                event.node_id,
+                slot,
+                len
+            );
         }
         Some("EBReceived") => {
             let slot = msg.and_then(|m| m.get("slot")).and_then(|s| s.as_u64());
             let len = msg.and_then(|m| m.get("len")).and_then(|l| l.as_u64());
-            tracing::info!("{}: received EB (slot {:?}, len {:?})", event.node_id, slot, len);
+            tracing::info!(
+                "{}: received EB (slot {:?}, len {:?})",
+                event.node_id,
+                slot,
+                len
+            );
         }
         Some("EBTxsReceived") => {
             let slot = msg.and_then(|m| m.get("slot")).and_then(|s| s.as_u64());
             let len = msg.and_then(|m| m.get("len")).and_then(|c| c.as_u64());
-            tracing::info!("{}: received EB txs (slot {:?}, count {:?})", event.node_id, slot, len);
+            tracing::info!(
+                "{}: received EB txs (slot {:?}, count {:?})",
+                event.node_id,
+                slot,
+                len
+            );
         }
         _ => {}
     }
@@ -285,7 +303,11 @@ async fn receive_events(
 
     for event in &events {
         log_interesting_event(event);
-        state.aggregate_votes.write().await.update_aggregated_event(event);
+        state
+            .aggregate_votes
+            .write()
+            .await
+            .update_aggregated_event(event);
     }
 
     {
@@ -473,11 +495,15 @@ async fn get_node_stats(
     }
 }
 
-async fn get_votes_history(
-    State(state): State<Arc<ServerState>>,
-) -> Json<AggregatedVotesHistory> {
-    let node_ids: Vec<String> = state.topology.read().await
-        .nodes.iter().map(|t| t.node_id.clone()).collect();
+async fn get_votes_history(State(state): State<Arc<ServerState>>) -> Json<AggregatedVotesHistory> {
+    let node_ids: Vec<String> = state
+        .topology
+        .read()
+        .await
+        .nodes
+        .iter()
+        .map(|t| t.node_id.clone())
+        .collect();
 
     let votes = state.aggregate_votes.read().await;
 
@@ -487,7 +513,7 @@ async fn get_votes_history(
     //          slot=last_slot-WINDOW_SIZE+1].
     let mut history = Vec::new();
     let mut votes_count = Vec::new();
-    for slot in ((last_slot+1).saturating_sub(WINDOW_SIZE)..=last_slot).rev() {
+    for slot in ((last_slot + 1).saturating_sub(WINDOW_SIZE)..=last_slot).rev() {
         let Some(node_statuses) = votes.events.get(&slot) else {
             history.push("".to_string());
             votes_count.push(AggregatedVotesCount::default());
@@ -518,21 +544,46 @@ async fn get_votes_history(
             //    often, so viewer will guess it from adjacent columns, no need to specify
             //    this info each time.
             str.push(match statuses {
-                Some(NodeVotes {vote_cast: true, eb_received: true, rb_received: true, ..}) => '1',
-                Some(NodeVotes {vote_cast: true, eb_generated: true, ..}) => 'G',
-                Some(NodeVotes {eb_received: true, rb_received: true, ..}) => 'E',
-                Some(NodeVotes {rb_received: true, ..}) => 'R',
-                Some(NodeVotes {perm_committee_member: true, eb_received: false, vote_cast: false, ..}) => '*',
-                Some(NodeVotes {perm_committee_member: false, eb_received: false, vote_cast: false, ..}) => '.',
+                Some(NodeVotes {
+                    vote_cast: true,
+                    eb_received: true,
+                    rb_received: true,
+                    ..
+                }) => '1',
+                Some(NodeVotes {
+                    vote_cast: true,
+                    eb_generated: true,
+                    ..
+                }) => 'G',
+                Some(NodeVotes {
+                    eb_received: true,
+                    rb_received: true,
+                    ..
+                }) => 'E',
+                Some(NodeVotes {
+                    rb_received: true, ..
+                }) => 'R',
+                Some(NodeVotes {
+                    perm_committee_member: true,
+                    eb_received: false,
+                    vote_cast: false,
+                    ..
+                }) => '*',
+                Some(NodeVotes {
+                    perm_committee_member: false,
+                    eb_received: false,
+                    vote_cast: false,
+                    ..
+                }) => '.',
                 None => '.',
-                _ => '?'
+                _ => '?',
             });
         }
         history.push(str);
         votes_count.push(count);
-    };
+    }
 
-    Json(AggregatedVotesHistory{
+    Json(AggregatedVotesHistory {
         last_slot,
         node_ids,
         votes: history, // TODO: serialize the full history of votes
@@ -896,22 +947,28 @@ mod tests {
             let mut node_map = HashMap::new();
             if slot % 2 == 0 {
                 // Committee-only slot (no real events)
-                node_map.insert("node-0".to_string(), NodeVotes {
-                    perm_committee_member: true,
-                    rb_received: false,
-                    eb_received: false,
-                    eb_generated: false,
-                    vote_cast: false,
-                });
+                node_map.insert(
+                    "node-0".to_string(),
+                    NodeVotes {
+                        perm_committee_member: true,
+                        rb_received: false,
+                        eb_received: false,
+                        eb_generated: false,
+                        vote_cast: false,
+                    },
+                );
             } else {
                 // Slot with real events
-                node_map.insert("node-0".to_string(), NodeVotes {
-                    perm_committee_member: true,
-                    rb_received: true,
-                    eb_received: slot >= 21,
-                    eb_generated: false,
-                    vote_cast: slot >= 31,
-                });
+                node_map.insert(
+                    "node-0".to_string(),
+                    NodeVotes {
+                        perm_committee_member: true,
+                        rb_received: true,
+                        eb_received: slot >= 21,
+                        eb_generated: false,
+                        vote_cast: slot >= 31,
+                    },
+                );
             }
             votes.events.insert(slot, node_map);
         }
@@ -928,7 +985,7 @@ mod tests {
             // All elder odd slots should have been removed
             if !votes.slots.contains(&slot) {
                 assert!(slot < *votes.slots.first().unwrap());
-                assert!(votes.events.iter().all(|(k,_v)| slot < *k));
+                assert!(votes.events.iter().all(|(k, _v)| slot < *k));
             }
         }
 

--- a/net-rs/net-cluster/src/types.rs
+++ b/net-rs/net-cluster/src/types.rs
@@ -102,7 +102,7 @@ pub struct AggregatedVotesHistory {
     /// In case of multiple statuses for a node, the max is taken: '1','G' > 'E' > 'R' > ' *' > '.'
     pub votes: Vec<String>,
 
-    pub votes_count: Vec<AggregatedVotesCount>
+    pub votes_count: Vec<AggregatedVotesCount>,
 }
 
 /// An ingested event with extracted metadata for aggregation.

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -854,6 +854,31 @@ impl Coordinator {
                 self.emit_event(NetworkEvent::PeerSnapshot { peers });
             }
 
+            NetworkCommand::DropInboundPeers => {
+                // Drop every accepted (inbound) peer — those carrying an
+                // ip_guard.  Send `Disconnect` (not a task abort, which
+                // leaves the mux/bearer up): the peer task exits its loop
+                // and tears the connection down, so the remote outbound
+                // side observes EOF, reconnects, and re-intersects.
+                // Outbound peers are left untouched; the disconnect event
+                // then runs the normal `remove_peer` cleanup.
+                let inbound: Vec<PeerId> = self
+                    .peers
+                    .iter()
+                    .filter(|(_, p)| p.ip_guard.is_some())
+                    .map(|(id, _)| *id)
+                    .collect();
+                if !inbound.is_empty() {
+                    tracing::info!(
+                        count = inbound.len(),
+                        "DropInboundPeers: resetting accepted peer connections"
+                    );
+                    for peer_id in inbound {
+                        self.send_peer_command(peer_id, PeerCommand::Disconnect);
+                    }
+                }
+            }
+
             NetworkCommand::Shutdown => {
                 // Disconnect all peers.
                 let peer_ids: Vec<PeerId> = self.peers.keys().copied().collect();

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -142,6 +142,12 @@ const PEER_EVENTS_CAPACITY: usize = 32768;
 /// way to TCP. Kept proportional (~1.5%) to NETWORK_EVENTS_CAPACITY.
 const MIN_EMIT_HEADROOM: usize = 1024;
 
+/// First re-intersection backoff for an address (the first attempt is
+/// always allowed; rapid repeats grow from here).
+const REINTERSECT_BACKOFF_BASE: Duration = Duration::from_secs(1);
+/// Cap on the per-address re-intersection backoff.
+const REINTERSECT_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
 /// Per-peer state tracked by the coordinator.
 struct PeerState {
     address: String,
@@ -193,6 +199,12 @@ struct Coordinator {
     pending_fetches: HashMap<Point, PeerId>,
     /// Peers waiting to be reconnected (address, next attempt time, current backoff).
     reconnect_queue: Vec<(String, Instant, Duration)>,
+    /// Per-address re-intersection throttle: `(next_allowed, backoff)`.
+    /// A peer on an unreconcilable fork re-intersects in a tight loop;
+    /// `ReIntersect` is rate-limited per *address* (stable across the
+    /// reconnect handovers that change `PeerId`) with exponential backoff
+    /// so the node backs off gracefully instead of spinning.
+    reintersect_throttle: HashMap<String, (Instant, Duration)>,
 
     /// Shared chain state for responder peers.
     chain_store: Arc<ChainStore>,
@@ -239,6 +251,7 @@ impl Coordinator {
         Self {
             config,
             peers: HashMap::new(),
+            reintersect_throttle: HashMap::new(),
             next_peer_id: 0,
             peer_events,
             peer_event_sender,
@@ -757,7 +770,44 @@ impl Coordinator {
             }
 
             NetworkCommand::ReIntersect { peer_id } => {
-                self.send_peer_command(peer_id, PeerCommand::ReIntersect);
+                // Throttle re-intersection per address with exponential
+                // backoff: a peer stuck on an unreconcilable fork (or a
+                // churning reconnect handover) re-intersects in a tight
+                // loop. Keyed by address (stable across the reconnects that
+                // change PeerId), so the node backs off gracefully instead
+                // of spinning. The first attempt for an address always
+                // passes; rapid repeats grow the backoff to a cap; a quiet
+                // peer resets.
+                let now = Instant::now();
+                let address = self.peers.get(&peer_id).map(|p| p.address.clone());
+                let allow = match &address {
+                    None => true, // unknown peer — let it through
+                    Some(addr) => match self.reintersect_throttle.get(addr).copied() {
+                        Some((next_allowed, _)) if now < next_allowed => false,
+                        Some((next_allowed, backoff)) => {
+                            let next_backoff = if now > next_allowed + backoff {
+                                REINTERSECT_BACKOFF_BASE // went quiet → reset
+                            } else {
+                                (backoff * 2).min(REINTERSECT_BACKOFF_MAX)
+                            };
+                            self.reintersect_throttle
+                                .insert(addr.clone(), (now + next_backoff, next_backoff));
+                            true
+                        }
+                        None => {
+                            self.reintersect_throttle.insert(
+                                addr.clone(),
+                                (now + REINTERSECT_BACKOFF_BASE, REINTERSECT_BACKOFF_BASE),
+                            );
+                            true
+                        }
+                    },
+                };
+                if allow {
+                    self.send_peer_command(peer_id, PeerCommand::ReIntersect);
+                } else if let Some(addr) = &address {
+                    tracing::debug!(%peer_id, address = %addr, "re-intersect throttled (peer churning on a fork)");
+                }
             }
 
             NetworkCommand::DiscoverPeers => {

--- a/net-rs/net-core/src/multi_peer/coordinator.rs
+++ b/net-rs/net-core/src/multi_peer/coordinator.rs
@@ -632,9 +632,7 @@ impl Coordinator {
                 // Position bodies by content hash → manifest index so a
                 // partial response from the upstream peer still lands
                 // at the right slots in our sparse holdings.
-                if let (Some(store), Point::Specific { slot, hash }) =
-                    (&self.leios_store, &point)
-                {
+                if let (Some(store), Point::Specific { slot, hash }) = (&self.leios_store, &point) {
                     if let Some(manifest) = store.get_eb_manifest(*slot, hash) {
                         let by_hash: HashMap<[u8; 32], u32> = manifest
                             .iter()
@@ -841,10 +839,7 @@ impl Coordinator {
                 point,
                 bitmap,
             } => {
-                self.send_peer_command(
-                    peer_id,
-                    PeerCommand::FetchLeiosBlockTxs { point, bitmap },
-                );
+                self.send_peer_command(peer_id, PeerCommand::FetchLeiosBlockTxs { point, bitmap });
             }
 
             NetworkCommand::InjectLeiosBlock { point, block } => {

--- a/net-rs/net-core/src/multi_peer/types.rs
+++ b/net-rs/net-core/src/multi_peer/types.rs
@@ -197,6 +197,13 @@ pub enum NetworkCommand {
     /// Request a snapshot of all connected peers (for telemetry).
     QueryPeers,
 
+    /// Drop all currently-accepted (inbound) peer connections.  The
+    /// remote (outbound) side observes the disconnect and reconnects,
+    /// re-running ChainSync intersection from scratch.  Used by the
+    /// `DropInboundPeers` behaviour to mimic a relay that resets
+    /// inbound connections (the reconnect-handover trigger).
+    DropInboundPeers,
+
     /// Shut down all peers and stop the coordinator.
     Shutdown,
 }

--- a/net-rs/net-core/src/multi_peer/types.rs
+++ b/net-rs/net-core/src/multi_peer/types.rs
@@ -86,10 +86,7 @@ pub enum NetworkEvent {
     LeiosBlockReceived { point: Point, block: Vec<u8> },
 
     /// Leios: votes delivered inline by a peer (no fetch round-trip).
-    LeiosVotesReceived {
-        peer_id: PeerId,
-        votes: Vec<Vote>,
-    },
+    LeiosVotesReceived { peer_id: PeerId, votes: Vec<Vote> },
 
     /// Leios: fetched transactions for an EB arrived.
     LeiosBlockTxsReceived {

--- a/net-rs/net-core/src/mux/mod.rs
+++ b/net-rs/net-core/src/mux/mod.rs
@@ -251,6 +251,12 @@ impl<S: scheduler::Scheduler> Mux<S> {
         // Spawn a supervisor that aborts the surviving task when one fails.
         let muxer_abort = muxer_handle.abort_handle();
         let demuxer_abort = demuxer_handle.abort_handle();
+        // Keep clones so an external `abort()` can tear down the muxer and
+        // demuxer directly — they own the bearer's read/write halves, so
+        // aborting only the supervisor would leave the socket open (the
+        // remote then only notices via keepalive timeout).
+        let muxer_abort_ext = muxer_abort.clone();
+        let demuxer_abort_ext = demuxer_abort.clone();
 
         let (error_tx, error_rx) = tokio::sync::watch::channel(None);
 
@@ -285,6 +291,8 @@ impl<S: scheduler::Scheduler> Mux<S> {
 
         RunningMux {
             supervisor,
+            muxer_abort: muxer_abort_ext,
+            demuxer_abort: demuxer_abort_ext,
             error_rx,
             stats,
         }
@@ -296,6 +304,11 @@ impl<S: scheduler::Scheduler> Mux<S> {
 /// via `wait()` or `error()`.
 pub struct RunningMux {
     supervisor: JoinHandle<()>,
+    /// Abort handles for the muxer (egress/writer) and demuxer
+    /// (ingress/reader) tasks — they own the bearer's halves, so
+    /// `abort()` must cancel them to actually close the socket.
+    muxer_abort: tokio::task::AbortHandle,
+    demuxer_abort: tokio::task::AbortHandle,
     error_rx: tokio::sync::watch::Receiver<Option<String>>,
     /// Per-connection byte counters (shared with muxer/demuxer tasks).
     pub stats: Arc<MuxStats>,
@@ -317,8 +330,12 @@ impl RunningMux {
         self.error_rx.borrow().clone()
     }
 
-    /// Abort the mux (both tasks).
+    /// Abort the mux. Cancels the muxer and demuxer (which own the
+    /// bearer's write/read halves, so the socket is closed and the
+    /// remote sees EOF promptly) as well as the supervisor.
     pub fn abort(&self) {
+        self.muxer_abort.abort();
+        self.demuxer_abort.abort();
         self.supervisor.abort();
     }
 }

--- a/net-rs/net-core/src/peer/peer_task.rs
+++ b/net-rs/net-core/src/peer/peer_task.rs
@@ -571,8 +571,7 @@ pub(crate) fn spawn_leios_fetch(
                 }
                 LeiosFetchCommand::BlockTxs { point, bitmap } => {
                     let (slot, eb_hash) = eb_fields(&point);
-                    let requested: Vec<u32> =
-                        leios_fetch::bitmap::iter_indices(&bitmap).collect();
+                    let requested: Vec<u32> = leios_fetch::bitmap::iter_indices(&bitmap).collect();
                     tracing::info!(
                         %peer_id, slot, eb_hash,
                         requested = requested.len(),

--- a/net-rs/net-core/src/peer/server_handlers.rs
+++ b/net-rs/net-core/src/peer/server_handlers.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use shared_consensus::behaviour::{
-    BehaviourHandle, Outbound, OutboundDecision, OwnedOutbound,
-};
+use shared_consensus::behaviour::{BehaviourHandle, Outbound, OutboundDecision, OwnedOutbound};
 
 use crate::types::{BlockBody, Point, Tip, WrappedHeader};
 
@@ -534,7 +532,6 @@ fn notification_to_ln_msg(n: &crate::store::leios_store::LeiosNotification) -> L
 /// Sends notifications about available Leios data as the store is populated.
 /// Uses `LeiosStore::subscribe()` to wake when new items are injected.
 pub async fn serve_leios_notify(ln_send: CodecSend, ln_recv: CodecRecv, store: Arc<LeiosStore>) {
-
     let mut runner = Runner::<LeiosNotify>::new(Role::Server, ln_send, ln_recv);
     let mut read_index: usize = 0;
     let mut subscription = store.subscribe();

--- a/net-rs/net-core/src/protocols/leios_fetch/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/codec.rs
@@ -18,9 +18,7 @@ use minicbor::decode::Error as DecodeError;
 use minicbor::encode::Error as EncodeError;
 use minicbor::{Decoder, Encoder};
 
-use super::{
-    Message, MAX_BITMAP_ENTRIES, MAX_BLOCK_SIZE, MAX_TRANSACTIONS, MAX_TRANSACTION_SIZE,
-};
+use super::{Message, MAX_BITMAP_ENTRIES, MAX_BLOCK_SIZE, MAX_TRANSACTIONS, MAX_TRANSACTION_SIZE};
 use crate::types::Point;
 
 impl minicbor::Encode<()> for Message {
@@ -372,7 +370,13 @@ mod tests {
                 bitmap,
                 transactions,
             } => {
-                assert_eq!(point, Point::Specific { slot: 7, hash: test_hash() });
+                assert_eq!(
+                    point,
+                    Point::Specific {
+                        slot: 7,
+                        hash: test_hash()
+                    }
+                );
                 assert_eq!(bitmap[&0], 0x3);
                 assert_eq!(transactions, vec![tx(1), tx(2)]);
             }

--- a/net-rs/net-core/src/protocols/leios_fetch/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/mod.rs
@@ -255,7 +255,10 @@ mod tests {
             LeiosFetch::transition(
                 &State::StBlockTxs,
                 &Message::MsgLeiosBlockTxs {
-                    point: Point::Specific { slot: 1, hash: [0; 32] },
+                    point: Point::Specific {
+                        slot: 1,
+                        hash: [0; 32]
+                    },
                     bitmap: BTreeMap::new(),
                     transactions: vec![],
                 }
@@ -293,7 +296,10 @@ mod tests {
         assert!(LeiosFetch::transition(
             &State::StBlock,
             &Message::MsgLeiosBlockTxs {
-                point: Point::Specific { slot: 1, hash: [0; 32] },
+                point: Point::Specific {
+                    slot: 1,
+                    hash: [0; 32]
+                },
                 bitmap: BTreeMap::new(),
                 transactions: vec![],
             }

--- a/net-rs/net-core/src/protocols/leios_notify/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_notify/codec.rs
@@ -108,9 +108,9 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
         // Tolerate (and skip) any trailing elements beyond the fields we
         // read — keeps us forward-compatible with added fields.
         let consumed = match tag {
-            0 | 5 => 1,                 // tag only
-            1 | 3 | 4 => 2,             // tag + payload
-            2 => 3,                     // tag + point + eb_size
+            0 | 5 => 1,     // tag only
+            1 | 3 | 4 => 2, // tag + payload
+            2 => 3,         // tag + point + eb_size
             _ => unreachable!(),
         };
         skip_trailing(d, len, consumed)?;
@@ -122,11 +122,7 @@ impl<'a> minicbor::Decode<'a, ()> for Message {
 /// given we have already consumed `consumed` of them.  Handles both
 /// definite-length arrays (skip `len - consumed`) and indefinite-length
 /// arrays (skip until the break marker).
-fn skip_trailing(
-    d: &mut Decoder<'_>,
-    len: Option<u64>,
-    consumed: u64,
-) -> Result<(), DecodeError> {
+fn skip_trailing(d: &mut Decoder<'_>, len: Option<u64>, consumed: u64) -> Result<(), DecodeError> {
     match len {
         Some(n) => {
             for _ in consumed..n {

--- a/net-rs/net-core/src/protocols/leios_notify/mod.rs
+++ b/net-rs/net-core/src/protocols/leios_notify/mod.rs
@@ -218,11 +218,8 @@ mod tests {
             State::StIdle
         );
         assert_eq!(
-            LeiosNotify::transition(
-                &State::StBusy,
-                &Message::MsgLeiosVotes { votes: vec![] }
-            )
-            .unwrap(),
+            LeiosNotify::transition(&State::StBusy, &Message::MsgLeiosVotes { votes: vec![] })
+                .unwrap(),
             State::StIdle
         );
     }

--- a/net-rs/net-core/src/store/leios_store.rs
+++ b/net-rs/net-core/src/store/leios_store.rs
@@ -533,11 +533,12 @@ impl LeiosStore {
 /// evicted from the slot-window-pruned maps and can never be served.
 fn notification_evictable(n: &LeiosNotification, cutoff: u64) -> bool {
     match n {
-        LeiosNotification::BlockOffer { point }
-        | LeiosNotification::BlockTxsOffer { point } => match point {
-            Point::Specific { slot, .. } => *slot < cutoff,
-            Point::Origin => true,
-        },
+        LeiosNotification::BlockOffer { point } | LeiosNotification::BlockTxsOffer { point } => {
+            match point {
+                Point::Specific { slot, .. } => *slot < cutoff,
+                Point::Origin => true,
+            }
+        }
         LeiosNotification::Votes { votes } => votes.iter().all(|v| v.slot < cutoff),
     }
 }
@@ -784,10 +785,8 @@ mod tests {
         let h0 = [0x10u8; 32];
         let h1 = [0x20u8; 32];
         let h2 = [0x30u8; 32];
-        let resolver: Arc<dyn TxBodyResolver> = Arc::new(StubResolver(HashMap::from([(
-            h1.to_vec(),
-            vec![0xD1],
-        )])));
+        let resolver: Arc<dyn TxBodyResolver> =
+            Arc::new(StubResolver(HashMap::from([(h1.to_vec(), vec![0xD1])])));
         let (store, _rx) = LeiosStore::new_with_resolver(100, Some(resolver));
 
         let eb_hash = [0xDDu8; 32];
@@ -1101,7 +1100,10 @@ mod tests {
         // fast-forwarded rather than reading a stale local index.
         let mut cursor = 0usize;
         let entries = store.notifications_after(&mut cursor);
-        assert!(cursor >= pushed - MAX_NOTIFICATIONS, "cursor fast-forwarded past pruned front");
+        assert!(
+            cursor >= pushed - MAX_NOTIFICATIONS,
+            "cursor fast-forwarded past pruned front"
+        );
         assert_eq!(entries.len(), stats.notifications);
     }
 

--- a/net-rs/net-core/src/types/block.rs
+++ b/net-rs/net-core/src/types/block.rs
@@ -169,8 +169,7 @@ impl BlockBody {
             Some(n) => n,
             None => return Err(DecodeError::message("indefinite tx_bodies array")),
         };
-        u32::try_from(tx_count)
-            .map_err(|_| DecodeError::message("tx_bodies length exceeds u32"))
+        u32::try_from(tx_count).map_err(|_| DecodeError::message("tx_bodies length exceeds u32"))
     }
 
     /// Extract the header from this block in ChainSync wire format:

--- a/net-rs/net-node/configs/follow-dev-relay.toml
+++ b/net-rs/net-node/configs/follow-dev-relay.toml
@@ -1,0 +1,33 @@
+# Passive stake-0 follower for the Leios dev relay
+# (leios-node.play.dev.cardano.org:3001, network magic 164).
+#
+# Overlay on top of leios-dev.toml:
+#   cargo run --release -p net-node -- \
+#       --config configs/leios-dev.toml \
+#       --config configs/follow-dev-relay.toml
+
+node_id = "dev-relay-follower"
+seed = 1
+
+[production]
+stake = 0
+
+[transactions]
+tx_rate = 0.0
+
+[telemetry]
+stats_interval_secs = 10
+
+[[telemetry.stats_sinks]]
+type = "log"
+
+# Suppress EB-tx fetch — the relay RSTs on MsgLeiosBlockTxsRequest
+# (upstream CDDL/behaviour gap, cardano-scaling/cardano-blueprint#68).
+# Without this, every EB sighting triggers a doomed fetch and tears
+# down the bearer.  Mempool tx diffusion still works as the organic
+# fallback.
+[fetch_policy.eb_txs]
+kind = "no_fetch"
+
+[[peers]]
+address = "leios-node.play.dev.cardano.org:3001"

--- a/net-rs/net-node/configs/follow-dev-relay.toml
+++ b/net-rs/net-node/configs/follow-dev-relay.toml
@@ -1,10 +1,10 @@
 # Passive stake-0 follower for the Leios dev relay
 # (leios-node.play.dev.cardano.org:3001, network magic 164).
 #
-# Overlay on top of leios-dev.toml:
+# Overlay on top of leios-dev.toml; run from the net-rs/ workspace root:
 #   cargo run --release -p net-node -- \
-#       --config configs/leios-dev.toml \
-#       --config configs/follow-dev-relay.toml
+#       --config net-node/configs/leios-dev.toml \
+#       --config net-node/configs/follow-dev-relay.toml
 
 node_id = "dev-relay-follower"
 seed = 1

--- a/net-rs/net-node/configs/leios-dev.toml
+++ b/net-rs/net-node/configs/leios-dev.toml
@@ -1,0 +1,36 @@
+# Base configuration for the public Leios prototype dev network
+# (leios-node.play.dev.cardano.org), network magic 164.
+#
+# Mirrors the parameters in testnet/config/shelley-genesis.json
+# (systemStart 2026-05-29T00:00:00Z = 1780012800 unix, slotLength 1s)
+# and pairs with an overlay config that adds the peer + identity.
+
+network_magic = 164
+slot_duration_ms = 1000
+genesis_time_unix = 1780012800
+leios_enabled = true
+scheduler = "priority-wfq"
+security_param_k = 2160
+
+[production]
+total_stake = 1000
+rb_generation_probability = 0.05
+vote_generation_probability = 0.8
+stage_length_slots = 20
+
+[production.committee_selection]
+type = "StakeCentile"
+top_centile_of_stake = 0.99
+
+[transactions]
+tx_rate = 0.0
+tx_size_min = 250
+tx_size_max = 16384
+
+[validation]
+rb_head_validation_ms = 1.0
+rb_body_validation_ms_constant = 0.3539
+rb_body_validation_ms_per_byte = 0.0000215
+tx_validation_ms = 0.6201
+eb_validation_ms = 2.0
+vote_validation_ms = 1.0

--- a/net-rs/net-node/src/config.rs
+++ b/net-rs/net-node/src/config.rs
@@ -122,7 +122,9 @@ pub enum FetchPolicyKind {
 
 impl FetchPolicyKind {
     /// Build a [`BlockFetchPolicy`] handle from this config.
-    pub fn into_block_policy(self) -> Box<dyn shared_consensus::fetch::BlockFetchPolicy + Send + Sync> {
+    pub fn into_block_policy(
+        self,
+    ) -> Box<dyn shared_consensus::fetch::BlockFetchPolicy + Send + Sync> {
         use shared_consensus::fetch::{BroadcastN, LowestRttFirst, NoFetch};
         match self {
             FetchPolicyKind::LowestRtt => Box::new(LowestRttFirst),
@@ -146,7 +148,9 @@ impl FetchPolicyKind {
     }
 
     /// Build an [`EbTxsFetchPolicy`] handle from this config.
-    pub fn into_eb_txs_policy(self) -> Box<dyn shared_consensus::fetch::EbTxsFetchPolicy + Send + Sync> {
+    pub fn into_eb_txs_policy(
+        self,
+    ) -> Box<dyn shared_consensus::fetch::EbTxsFetchPolicy + Send + Sync> {
         use shared_consensus::fetch::{BroadcastN, LowestRttFirst, NoFetch};
         match self {
             FetchPolicyKind::LowestRtt => Box::new(LowestRttFirst),
@@ -156,7 +160,6 @@ impl FetchPolicyKind {
             FetchPolicyKind::NoFetch => Box::new(NoFetch),
         }
     }
-
 }
 
 /// Per-traffic-class fetch-policy selection.  Each class is set

--- a/net-rs/net-node/src/consensus/leios/mod.rs
+++ b/net-rs/net-node/src/consensus/leios/mod.rs
@@ -11,17 +11,17 @@
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use shared_consensus::elections::{Elections, ElectionsConfig};
-use shared_consensus::leios::{
-    ChainTipContext, LeiosEffect, LeiosState, LeiosTelemetryEvent, VotingConfig,
-};
-pub use shared_consensus::leios::EbTxMatchOutcome;
-pub use shared_consensus::pipeline::PipelineConfig;
-use shared_consensus::committee;
 use net_core::multi_peer::types::{NetworkCommand, NetworkEvent};
 use net_core::types::{Point, Vote};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use shared_consensus::committee;
+use shared_consensus::elections::{Elections, ElectionsConfig};
+pub use shared_consensus::leios::EbTxMatchOutcome;
+use shared_consensus::leios::{
+    ChainTipContext, LeiosEffect, LeiosState, LeiosTelemetryEvent, VotingConfig,
+};
+pub use shared_consensus::pipeline::PipelineConfig;
 use tokio::sync::{mpsc, watch};
 use tracing::info;
 
@@ -67,8 +67,11 @@ impl LeiosConsensus {
         dyn_config: watch::Receiver<DynamicConfig>,
     ) -> Self {
         let total_stake: u64 = stake_registry_entries.iter().map(|e| e.stake).sum();
-        let persistent_committee =
-            committee::build_committee(&committee_selection, stake_registry_entries, committee_seed);
+        let persistent_committee = committee::build_committee(
+            &committee_selection,
+            stake_registry_entries,
+            committee_seed,
+        );
         let expected_total_weight = committee::expected_total_weight(
             &committee_selection,
             &persistent_committee,
@@ -208,10 +211,12 @@ impl LeiosConsensus {
         let known = self.mempool.lock().unwrap().all_known_tx_ids();
         let tx_known = |h: &[u8; 32]| known.contains(h.as_slice());
         let mut fx = self.state.on_slot(slot, &tx_known);
-        fx.push(LeiosEffect::EmitTelemetry(LeiosTelemetryEvent::LeiosElectionInfo {
-            eb_slot: slot,
-            perm_committee: self.state.voting_config.persistent_seats > 0,
-        }));
+        fx.push(LeiosEffect::EmitTelemetry(
+            LeiosTelemetryEvent::LeiosElectionInfo {
+                eb_slot: slot,
+                perm_committee: self.state.voting_config.persistent_seats > 0,
+            },
+        ));
         self.dispatch(fx).await;
     }
 
@@ -219,10 +224,9 @@ impl LeiosConsensus {
     pub async fn handle_event(&mut self, event: &NetworkEvent) -> bool {
         let now = Instant::now();
         let (consumed, fx): (bool, Vec<LeiosEffect>) = match event {
-            NetworkEvent::LeiosBlockOffered { peer_id, point } => (
-                true,
-                self.state.on_eb_offered(point.clone(), *peer_id, now),
-            ),
+            NetworkEvent::LeiosBlockOffered { peer_id, point } => {
+                (true, self.state.on_eb_offered(point.clone(), *peer_id, now))
+            }
             NetworkEvent::LeiosBlockTxsOffered { peer_id, point } => {
                 let bitmap = self.bitmap_for_missing_txs(point);
                 (
@@ -273,11 +277,7 @@ impl LeiosConsensus {
     /// Verify a `LeiosBlockTxsReceived` response against the cached
     /// manifest.  Bodies are blake2b-hashed here (the wire-format body
     /// hash) before being matched, since shared-consensus is format-agnostic.
-    pub fn match_eb_tx_response(
-        &mut self,
-        point: &Point,
-        bodies: &[Vec<u8>],
-    ) -> EbTxMatchOutcome {
+    pub fn match_eb_tx_response(&mut self, point: &Point, bodies: &[Vec<u8>]) -> EbTxMatchOutcome {
         let bodies_with_hashes: Vec<(Vec<u8>, [u8; 32])> = bodies
             .iter()
             .map(|body| {
@@ -403,7 +403,7 @@ impl LeiosConsensus {
                             node: node_id,
                             slot: eb_slot,
                             pers_committee_member: perm_committee,
-                        }
+                        },
                     };
                     self.pending_telemetry.push(node_event);
                 }
@@ -470,7 +470,6 @@ impl LeiosConsensus {
         self.state.elections.voter_count(hash)
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -633,9 +632,9 @@ mod tests {
         assert!(
             leios
                 .handle_event(&NetworkEvent::LeiosBlockOffered {
-                peer_id: net_core::peer::PeerId(1),
-                point: p.clone(),
-            })
+                    peer_id: net_core::peer::PeerId(1),
+                    point: p.clone(),
+                })
                 .await
         );
 
@@ -1139,5 +1138,4 @@ mod tests {
         assert_eq!(outcome2.requested, 2);
         assert!(outcome2.remaining_bitmap.is_empty());
     }
-
 }

--- a/net-rs/net-node/src/consensus/mod.rs
+++ b/net-rs/net-node/src/consensus/mod.rs
@@ -168,6 +168,20 @@ impl Consensus {
         self.leios.state_mut().ask_rb_production_strategy(praos, slot)
     }
 
+    /// Consult the behaviour for a deliberate self-reorg this slot and,
+    /// if requested, roll the adopted chain back and diffuse the
+    /// rollback to peers.  Returns the depth rolled back, or `None` when
+    /// the behaviour is honest or the chain is too short.  Honest nodes
+    /// pay only one cheap `None`-returning hook call per slot.
+    pub async fn maybe_force_reorg(&mut self, slot: u64) -> Option<u64> {
+        let depth = self.leios.state_mut().ask_praos_reorg(slot)?;
+        if self.praos.force_rollback(depth).await {
+            Some(depth)
+        } else {
+            None
+        }
+    }
+
     /// Notify the Leios layer of a new slot tick.
     pub async fn on_slot(&mut self, slot: u64) {
         // Bump Praos's slot first so subsequent header-arrival paths

--- a/net-rs/net-node/src/consensus/mod.rs
+++ b/net-rs/net-node/src/consensus/mod.rs
@@ -182,6 +182,14 @@ impl Consensus {
         }
     }
 
+    /// Consult the behaviour for whether to reset accepted (inbound)
+    /// peer connections this slot.  The caller issues
+    /// `NetworkCommand::DropInboundPeers` when this returns true.  Honest
+    /// nodes pay one cheap `false`-returning hook call per slot.
+    pub fn should_drop_inbound_peers(&mut self, slot: u64) -> bool {
+        self.leios.state_mut().ask_drop_inbound_peers(slot)
+    }
+
     /// Notify the Leios layer of a new slot tick.
     pub async fn on_slot(&mut self, slot: u64) {
         // Bump Praos's slot first so subsequent header-arrival paths

--- a/net-rs/net-node/src/consensus/mod.rs
+++ b/net-rs/net-node/src/consensus/mod.rs
@@ -12,12 +12,12 @@ use net_core::multi_peer::types::{NetworkCommand, NetworkEvent};
 use net_core::types::{BlockBody, Point, Tip, WrappedHeader};
 use tokio::sync::{mpsc, watch};
 
-use shared_consensus::chain_tree::ChainTreeEntry;
-use shared_consensus::fetch::PeerRttCache;
-use shared_consensus::leios::ChainTipContext;
 use crate::config::{CommitteeSelection, DynamicConfig, FetchPolicyConfig, StakeEntry};
 use crate::telemetry::NodeEvent;
 use crate::validation::{LedgerOutcome, Validator};
+use shared_consensus::chain_tree::ChainTreeEntry;
+use shared_consensus::fetch::PeerRttCache;
+use shared_consensus::leios::ChainTipContext;
 
 pub use leios::{EbTxMatchOutcome, LeiosConsensus, PipelineConfig};
 pub use praos::PraosConsensus;
@@ -97,9 +97,8 @@ impl Consensus {
         leios.set_rtt(rtt);
         leios.set_eb_policy(fetch_policy.eb.into_eb_policy());
         leios.set_eb_txs_policy(fetch_policy.eb_txs.into_eb_txs_policy());
-        let behaviour_seed = rng_seed.unwrap_or_else(|| {
-            shared_consensus::behaviour::seed_from_node_id(praos.node_id_str())
-        });
+        let behaviour_seed = rng_seed
+            .unwrap_or_else(|| shared_consensus::behaviour::seed_from_node_id(praos.node_id_str()));
         // Install the shared behaviour handle on every state machine so
         // a stateful behaviour (equivocation variant store, peer
         // partition map, …) sees events from every layer and the
@@ -131,7 +130,11 @@ impl Consensus {
         spec: &shared_consensus::behaviour::BehaviourSpec,
         _mempool: &crate::mempool::SharedMempool,
     ) {
-        tracing::info!(?spec, behaviour_seed = self.behaviour_seed, "swapping per-node behaviour");
+        tracing::info!(
+            ?spec,
+            behaviour_seed = self.behaviour_seed,
+            "swapping per-node behaviour"
+        );
         shared_consensus::behaviour::swap_handle(&self.behaviour_handle, spec, self.behaviour_seed);
     }
 
@@ -165,7 +168,9 @@ impl Consensus {
         // alongside.  Borrow split is done by passing `praos.state()`
         // before mutably borrowing the leios layer.
         let praos = self.praos.state();
-        self.leios.state_mut().ask_rb_production_strategy(praos, slot)
+        self.leios
+            .state_mut()
+            .ask_rb_production_strategy(praos, slot)
     }
 
     /// Consult the behaviour for a deliberate self-reorg this slot and,
@@ -307,12 +312,8 @@ impl Consensus {
                 // for the parent's announced EB needs that EB recorded
                 // in `LeiosState` until its body validates locally.
                 // `BodyPath::decide` reads this for the next own RB.
-                if let Some((eb_slot, eb_hash)) =
-                    self.praos.parent_announced_eb_for_cert(point)
-                {
-                    self.leios
-                        .state
-                        .on_chain_endorsement(eb_slot, eb_hash);
+                if let Some((eb_slot, eb_hash)) = self.praos.parent_announced_eb_for_cert(point) {
+                    self.leios.state.on_chain_endorsement(eb_slot, eb_hash);
                 }
                 self.praos.on_validation_outcome(outcome).await
             }

--- a/net-rs/net-node/src/consensus/praos/mod.rs
+++ b/net-rs/net-node/src/consensus/praos/mod.rs
@@ -107,6 +107,17 @@ impl PraosConsensus {
         &self.state
     }
 
+    /// Deliberate self-reorg (the `DeepReorg` behaviour): roll the
+    /// adopted chain back `depth` blocks, abandon the suffix, and diffuse
+    /// the resulting `InjectRollback` so downstream followers see a deep
+    /// rollback.  Returns true if a rollback was actually emitted.
+    pub async fn force_rollback(&mut self, depth: u64) -> bool {
+        let fx = self.state.force_rollback(depth);
+        let emitted = !fx.is_empty();
+        self.dispatch(fx).await;
+        emitted
+    }
+
     /// Drain effects to the I/O sinks.  Network-side effects go to
     /// `commands`; validator effects go to `validator.submit`.  Header
     /// and body bytes are rehydrated into the wire types here; the

--- a/net-rs/net-node/src/consensus/praos/mod.rs
+++ b/net-rs/net-node/src/consensus/praos/mod.rs
@@ -328,12 +328,8 @@ impl PraosConsensus {
     pub async fn on_validation_outcome(&mut self, outcome: LedgerOutcome) -> bool {
         let now = Instant::now();
         let (rolled_back, fx) = match outcome {
-            LedgerOutcome::Applied { point } => {
-                (false, self.state.on_block_applied(point, now))
-            }
-            LedgerOutcome::RolledBack { target } => {
-                (true, self.state.on_block_rolled_back(target))
-            }
+            LedgerOutcome::Applied { point } => (false, self.state.on_block_applied(point, now)),
+            LedgerOutcome::RolledBack { target } => (true, self.state.on_block_rolled_back(target)),
             LedgerOutcome::ApplyFailed { point, error } => {
                 self.state.on_block_apply_failed(point, error);
                 (false, Vec::new())
@@ -360,10 +356,9 @@ impl PraosConsensus {
 
     #[allow(dead_code)]
     pub fn local_tip(&self) -> Option<Tip> {
-        self.state.local_tip().map(|(point, block_no)| Tip {
-            point,
-            block_no,
-        })
+        self.state
+            .local_tip()
+            .map(|(point, block_no)| Tip { point, block_no })
     }
 
     pub fn chain_tree_snapshot(
@@ -411,10 +406,7 @@ impl PraosConsensus {
     /// For an RB at `point` carrying a CIP-0164 cert, return the
     /// parent RB's (slot, announced_eb_hash).  Used by the facade to
     /// drive `LeiosState::on_chain_endorsement` at apply time.
-    pub fn parent_announced_eb_for_cert(
-        &self,
-        point: &Point,
-    ) -> Option<(u64, [u8; 32])> {
+    pub fn parent_announced_eb_for_cert(&self, point: &Point) -> Option<(u64, [u8; 32])> {
         self.state.parent_announced_eb_for_cert(point)
     }
 }
@@ -423,12 +415,7 @@ impl PraosConsensus {
 // directly to exercise inner state without going through async I/O.
 #[cfg(test)]
 impl PraosConsensus {
-    pub(super) fn record_peer_tip(
-        &mut self,
-        peer_id: PeerId,
-        tip: &Tip,
-        header: &WrappedHeader,
-    ) {
+    pub(super) fn record_peer_tip(&mut self, peer_id: PeerId, tip: &Tip, header: &WrappedHeader) {
         let info = match header.parsed.as_ref() {
             Some(i) => i,
             None => return,
@@ -501,9 +488,9 @@ mod tests {
 
     use crate::validation::{LedgerOutcome, Validator};
 
-    use shared_consensus::peer_chain::PeerChainEntry;
-    use shared_consensus::praos::{IN_FLIGHT_TTL, SelectionDecision};
     use super::*;
+    use shared_consensus::peer_chain::PeerChainEntry;
+    use shared_consensus::praos::{SelectionDecision, IN_FLIGHT_TTL};
 
     /// Placeholder peer id for tests that don't care which peer announced
     /// the tip — consensus is expected to ignore the value during phase 2.
@@ -686,7 +673,11 @@ mod tests {
             })
             .await;
 
-        let chain = consensus.state.peer_chains.get(&peer).expect("chain exists");
+        let chain = consensus
+            .state
+            .peer_chains
+            .get(&peer)
+            .expect("chain exists");
         assert_eq!(chain.len(), 2);
         assert_eq!(chain.tip().unwrap().block_no, 2);
         assert_eq!(chain.tip().unwrap().prev_hash, Some(hash1));
@@ -1114,15 +1105,36 @@ mod tests {
         let h2 = [2u8; 32];
         let h3 = [3u8; 32];
         // Insert blocks 1, 2, 3 with prev_hash links, 1 has prev=None.
-        consensus
-            .state.chain_tree
-            .insert(h1, Point::Specific { slot: 1, hash: h1 }, 1, 1, None, 0, None, false);
-        consensus
-            .state.chain_tree
-            .insert(h2, Point::Specific { slot: 2, hash: h2 }, 2, 2, Some(h1), 0, None, false);
-        consensus
-            .state.chain_tree
-            .insert(h3, Point::Specific { slot: 3, hash: h3 }, 3, 3, Some(h2), 0, None, false);
+        consensus.state.chain_tree.insert(
+            h1,
+            Point::Specific { slot: 1, hash: h1 },
+            1,
+            1,
+            None,
+            0,
+            None,
+            false,
+        );
+        consensus.state.chain_tree.insert(
+            h2,
+            Point::Specific { slot: 2, hash: h2 },
+            2,
+            2,
+            Some(h1),
+            0,
+            None,
+            false,
+        );
+        consensus.state.chain_tree.insert(
+            h3,
+            Point::Specific { slot: 3, hash: h3 },
+            3,
+            3,
+            Some(h2),
+            0,
+            None,
+            false,
+        );
 
         let walk = consensus.walk_ancestors_hybrid(h3);
         assert_eq!(walk.chain, vec![h3, h2, h1]);
@@ -1168,7 +1180,8 @@ mod tests {
             false,
         );
         consensus
-            .state.block_cache
+            .state
+            .block_cache
             .insert(h_mid, cached(Some(h_anchor), 11, 11, h_mid));
 
         // Walk should cross from chain_tree (h_tip) into block_cache
@@ -1222,11 +1235,21 @@ mod tests {
         let h2 = [2u8; 32];
 
         // h1 goes into chain_tree as a valid genesis child.
-        consensus
-            .state.chain_tree
-            .insert(h1, Point::Specific { slot: 1, hash: h1 }, 1, 1, None, 0, None, false);
+        consensus.state.chain_tree.insert(
+            h1,
+            Point::Specific { slot: 1, hash: h1 },
+            1,
+            1,
+            None,
+            0,
+            None,
+            false,
+        );
         // h2 goes ONLY into block_cache.
-        consensus.state.block_cache.insert(h2, cached(Some(h1), 2, 2, h2));
+        consensus
+            .state
+            .block_cache
+            .insert(h2, cached(Some(h1), 2, 2, h2));
 
         let walk = consensus.walk_ancestors_hybrid(h2);
         assert_eq!(walk.chain, vec![h2, h1]);
@@ -1737,7 +1760,8 @@ mod tests {
         // adopted_tip should now be block 6.
         assert_eq!(
             consensus
-                .state.chain_tree
+                .state
+                .chain_tree
                 .block_number(&consensus.state.adopted_tip_hash.unwrap()),
             Some(6),
             "adopted tip should be 6 after fork switch"
@@ -2083,7 +2107,12 @@ mod tests {
         // Set the anchor to block 3 in our adopted chain (a known common
         // ancestor). The anchor hash must be in our chain_tree.
         let block3_hash = consensus.state.chain_tree.ancestors(adopted_hash)[2]; // [5, 4, 3]
-        let block3_point = consensus.state.chain_tree.point(&block3_hash).unwrap().clone();
+        let block3_point = consensus
+            .state
+            .chain_tree
+            .point(&block3_hash)
+            .unwrap()
+            .clone();
         consensus.record_peer_intersection(peer, &block3_point);
 
         // Peer announces blocks 64..68 with different hashes (different
@@ -2337,7 +2366,8 @@ mod tests {
         };
         consensus.record_peer_intersection(peer, &intersection);
         consensus
-            .state.peer_chains
+            .state
+            .peer_chains
             .get_mut(&peer)
             .unwrap()
             .append(PeerChainEntry {

--- a/net-rs/net-node/src/consensus/praos/mod.rs
+++ b/net-rs/net-node/src/consensus/praos/mod.rs
@@ -2347,30 +2347,14 @@ mod tests {
                 prev_hash: Some(hash5p),
             });
 
-        // select_chain_once should detect the non-contiguous candidate
-        // (block 6' is in chain_tree but blocks 4' and 5' are missing)
-        // and return WaitingForBlocks anchored at block 3 — the driver
-        // then fetches `[block3 → block6']` as a contiguous range.
-        // Must NOT return Switched (replay would walk a stale ancestry
-        // through the adopted chain) or OrphanCandidate (a re-intersect
-        // would loop because the intersection is already correct).
+        // select_chain_once should detect the fork mismatch (block 6' is
+        // in chain_tree but its ancestors don't reach block 3) and return
+        // OrphanCandidate so the driver can re-intersect.
         let decision = consensus.select_chain_once(&HashSet::new());
         match decision {
-            SelectionDecision::WaitingForBlocks {
-                ancestor,
-                anchor_point,
-                missing,
-                tip_block_no,
-                ..
-            } => {
-                assert_eq!(ancestor, hashes[2], "anchor should be block 3");
-                assert_eq!(
-                    anchor_point,
-                    Some(intersection.clone()),
-                    "anchor_point should pin the BlockFetch range to block 3"
-                );
-                assert_eq!(missing, vec![tip6p.point.clone()]);
-                assert_eq!(tip_block_no, 6);
+            SelectionDecision::OrphanCandidate { .. } => { /* correct */ }
+            SelectionDecision::Switched { .. } => {
+                panic!("should NOT return Switched when there's a fork mismatch in chain_tree");
             }
             other => {
                 panic!("unexpected decision: {other:?}");

--- a/net-rs/net-node/src/consensus/praos/mod.rs
+++ b/net-rs/net-node/src/consensus/praos/mod.rs
@@ -2347,14 +2347,30 @@ mod tests {
                 prev_hash: Some(hash5p),
             });
 
-        // select_chain_once should detect the fork mismatch (block 6' is
-        // in chain_tree but its ancestors don't reach block 3) and return
-        // OrphanCandidate so the driver can re-intersect.
+        // select_chain_once should detect the non-contiguous candidate
+        // (block 6' is in chain_tree but blocks 4' and 5' are missing)
+        // and return WaitingForBlocks anchored at block 3 — the driver
+        // then fetches `[block3 → block6']` as a contiguous range.
+        // Must NOT return Switched (replay would walk a stale ancestry
+        // through the adopted chain) or OrphanCandidate (a re-intersect
+        // would loop because the intersection is already correct).
         let decision = consensus.select_chain_once(&HashSet::new());
         match decision {
-            SelectionDecision::OrphanCandidate { .. } => { /* correct */ }
-            SelectionDecision::Switched { .. } => {
-                panic!("should NOT return Switched when there's a fork mismatch in chain_tree");
+            SelectionDecision::WaitingForBlocks {
+                ancestor,
+                anchor_point,
+                missing,
+                tip_block_no,
+                ..
+            } => {
+                assert_eq!(ancestor, hashes[2], "anchor should be block 3");
+                assert_eq!(
+                    anchor_point,
+                    Some(intersection.clone()),
+                    "anchor_point should pin the BlockFetch range to block 3"
+                );
+                assert_eq!(missing, vec![tip6p.point.clone()]);
+                assert_eq!(tip_block_no, 6);
             }
             other => {
                 panic!("unexpected decision: {other:?}");

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -243,6 +243,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     store.tick_slot(slot);
                 }
 
+                // Behaviour-driven self-reorg (e.g. DeepReorg): re-anchor
+                // the adopted chain before production so the producer forks
+                // and downstream followers see a deep rollback. No-op for
+                // honest nodes.
+                if let Some(depth) = consensus.maybe_force_reorg(slot).await {
+                    info!(node_id = %node_id, slot, depth, "behaviour: forced deep self-reorg");
+                }
+
                 // Leios: advance pipeline phases and trigger voting.
                 if leios {
                     consensus.on_slot(slot).await;

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -553,7 +553,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 let _ = commands.send(NetworkCommand::QueryPeers).await;
                 if state_size_log_every_n_ticks > 0 {
                     state_size_tick = state_size_tick.wrapping_add(1);
-                    if state_size_tick % state_size_log_every_n_ticks == 0 {
+                    if state_size_tick.is_multiple_of(state_size_log_every_n_ticks) {
                         consensus.log_state_sizes();
                         mempool.lock().expect("mempool mutex poisoned").as_inner()
                             .log_state_sizes(&node_id);

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -87,7 +87,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .behaviour
         .clone()
         .unwrap_or(shared_consensus::behaviour::BehaviourSpec::Honest);
-    info!(?behaviour_spec, behaviour_seed, "materialising per-node behaviour");
+    info!(
+        ?behaviour_spec,
+        behaviour_seed, "materialising per-node behaviour"
+    );
     let behaviour_handle =
         shared_consensus::behaviour::build_handle(&behaviour_spec, behaviour_seed);
 
@@ -676,11 +679,13 @@ async fn record_network_event(
                 .await;
         }
         NetworkEvent::LeiosBlockTxsReceived { transactions, .. } => {
-            telem.record(NodeEvent::EBTxsReceived {
-                node: node_id.into(),
-                slot: telem.current_slot,
-                len: transactions.len()
-            }).await
+            telem
+                .record(NodeEvent::EBTxsReceived {
+                    node: node_id.into(),
+                    slot: telem.current_slot,
+                    len: transactions.len(),
+                })
+                .await
         }
         NetworkEvent::LeiosVotesReceived { ref votes, .. } => {
             telem

--- a/net-rs/net-node/src/main.rs
+++ b/net-rs/net-node/src/main.rs
@@ -250,6 +250,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 if let Some(depth) = consensus.maybe_force_reorg(slot).await {
                     info!(node_id = %node_id, slot, depth, "behaviour: forced deep self-reorg");
                 }
+                // Behaviour-driven inbound reset (DropInboundPeers): RST
+                // accepted peers so they reconnect and re-intersect.
+                if consensus.should_drop_inbound_peers(slot) {
+                    let _ = commands.send(NetworkCommand::DropInboundPeers).await;
+                    info!(node_id = %node_id, slot, "behaviour: dropping inbound peers");
+                }
 
                 // Leios: advance pipeline phases and trigger voting.
                 if leios {

--- a/net-rs/net-node/src/mempool.rs
+++ b/net-rs/net-node/src/mempool.rs
@@ -18,9 +18,9 @@ use rand::{Rng, SeedableRng};
 use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 
-use shared_consensus::mempool::{EbKey, MempoolState};
 use net_core::peer::PeerId;
 use net_core::protocols::txsubmission::{PendingTx, TxBody, TxId};
+use shared_consensus::mempool::{EbKey, MempoolState};
 
 use crate::config::{DynamicConfig, TxConfig};
 
@@ -139,15 +139,18 @@ impl Mempool {
     /// admits do not signal — nothing new to fan out.
     pub fn push(&mut self, tx: PendingTx) {
         use shared_consensus::mempool::{MempoolEffect, TxRejectReason};
-        let effects = self.state.admit_validated(
-            tx.tx_id.0.clone(),
-            tx.body.0.clone(),
-            tx.size,
-        );
-        let admitted = !effects.iter().any(|e| matches!(
-            e,
-            MempoolEffect::TxRejected { reason: TxRejectReason::AlreadyKnown, .. }
-        ));
+        let effects = self
+            .state
+            .admit_validated(tx.tx_id.0.clone(), tx.body.0.clone(), tx.size);
+        let admitted = !effects.iter().any(|e| {
+            matches!(
+                e,
+                MempoolEffect::TxRejected {
+                    reason: TxRejectReason::AlreadyKnown,
+                    ..
+                }
+            )
+        });
         if admitted {
             if let Err(mpsc::error::TrySendError::Full(_)) = self.admit_tx.try_send(tx) {
                 // Fanout channel full — peer will pick the tx up via
@@ -178,7 +181,6 @@ impl Mempool {
     pub fn forget_peer(&mut self, peer_id: PeerId) {
         self.state.forget_peer(to_con_pid(peer_id));
     }
-
 
     pub fn get_body_by_id(&self, id: &[u8]) -> Option<Vec<u8>> {
         self.state.get_body_by_id(id)

--- a/net-rs/net-node/src/network.rs
+++ b/net-rs/net-node/src/network.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use net_core::multi_peer::types::NetworkCommand;
-use net_core::multi_peer::{spawn_coordinator, CoordinatorConfig, CoordinatorHandle, PeerRttObserver};
+use net_core::multi_peer::{
+    spawn_coordinator, CoordinatorConfig, CoordinatorHandle, PeerRttObserver,
+};
 use net_core::mux::scheduler::SchedulerType;
 use net_core::store::leios_store::TxBodyResolver;
 

--- a/net-rs/net-node/src/production.rs
+++ b/net-rs/net-node/src/production.rs
@@ -8,9 +8,9 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tokio::sync::watch;
 
-use shared_consensus::mempool::EbKey;
 use net_core::protocols::txsubmission::PendingTx;
 use net_core::types::{BlockBody, Point, WrappedHeader};
+use shared_consensus::mempool::EbKey;
 
 use crate::config::{DynamicConfig, ProductionConfig};
 
@@ -528,7 +528,8 @@ mod tests {
         let mempool = empty_mempool();
         assert!(producer.is_active());
         for slot in 0..100 {
-            let result = producer.try_produce_block(slot, None, slot + 1, false, &mempool, &empty_leios());
+            let result =
+                producer.try_produce_block(slot, None, slot + 1, false, &mempool, &empty_leios());
             assert!(result.is_some(), "should produce at slot {slot}");
             match result.unwrap().point {
                 Point::Specific { slot: s, .. } => assert_eq!(s, slot),
@@ -840,5 +841,4 @@ mod tests {
             .count();
         assert_eq!(wins_after, 100);
     }
-
 }

--- a/net-rs/net-node/src/telemetry.rs
+++ b/net-rs/net-node/src/telemetry.rs
@@ -12,10 +12,10 @@ use net_core::store::leios_store::LeiosStoreStats;
 use serde::Serialize;
 use tracing::info;
 
+use crate::config::{EventSinkConfig, StatsSinkConfig, TelemetryConfig};
 use shared_consensus::chain_tree::ChainTreeEntry;
 use shared_consensus::leios::LeiosStateSizes;
 use shared_consensus::praos::PraosStateSizes;
-use crate::config::{EventSinkConfig, StatsSinkConfig, TelemetryConfig};
 
 // ---------------------------------------------------------------------------
 // Event types (sim-rs compatible JSONL format)

--- a/net-rs/net-node/src/validation.rs
+++ b/net-rs/net-node/src/validation.rs
@@ -459,5 +459,4 @@ mod tests {
             other => panic!("expected EbValidated, got {other:?}"),
         }
     }
-
 }

--- a/shared-rs/consensus/src/aggregation.rs
+++ b/shared-rs/consensus/src/aggregation.rs
@@ -56,17 +56,15 @@ pub fn record_vote(
         None => {
             let elapsed = current_slot.saturating_sub(eb_slot);
             let phase = pipeline.phase_for_elapsed(elapsed);
-            elections
-                .entry(*eb_hash)
-                .or_insert(EbElection {
-                    announced_slot: eb_slot,
-                    phase,
-                    seen_slot: current_slot,
-                    voted: false,
-                    voter_weights: BTreeMap::new(),
-                    quorum_reached: false,
-                    body_validated_locally: false,
-                })
+            elections.entry(*eb_hash).or_insert(EbElection {
+                announced_slot: eb_slot,
+                phase,
+                seen_slot: current_slot,
+                voted: false,
+                voter_weights: BTreeMap::new(),
+                quorum_reached: false,
+                body_validated_locally: false,
+            })
         }
     };
 

--- a/shared-rs/consensus/src/behaviour/behaviours/deep_reorg.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/deep_reorg.rs
@@ -1,0 +1,70 @@
+//! `DeepReorg` — deliberately triggers a deep self-reorg on a producing
+//! node.  Every `every_slots` slots it asks the I/O wrapper to roll the
+//! adopted chain back `depth` blocks (via
+//! [`crate::praos::PraosState::force_rollback`]) and fork, so downstream
+//! followers must recover from a deep `RollBackward` that orphans their
+//! adopted tip.  Not an honest behaviour — a chain-chaos / resilience
+//! testing tool (and the harness for the deep-rollback recovery work).
+
+use crate::behaviour::Behaviour;
+
+#[derive(Debug, Clone)]
+pub struct DeepReorg {
+    /// Fire a reorg whenever `slot % every_slots == 0` (clamped to >= 1).
+    every_slots: u64,
+    /// How many blocks to roll the adopted chain back each time.
+    depth: u64,
+    /// Last slot a reorg fired, so a slot ticked more than once doesn't
+    /// fire twice.  Starts at `u64::MAX` (no slot has fired).
+    last_fired: u64,
+}
+
+impl DeepReorg {
+    pub fn new(every_slots: u64, depth: u64) -> Self {
+        Self {
+            every_slots: every_slots.max(1),
+            depth,
+            last_fired: u64::MAX,
+        }
+    }
+}
+
+impl Behaviour for DeepReorg {
+    fn name(&self) -> &'static str {
+        "deep-reorg"
+    }
+
+    fn praos_reorg(&mut self, slot: u64) -> Option<u64> {
+        if self.depth == 0 || slot == 0 {
+            return None;
+        }
+        if slot % self.every_slots == 0 && slot != self.last_fired {
+            self.last_fired = slot;
+            return Some(self.depth);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fires_every_n_slots_once_each() {
+        let mut b = DeepReorg::new(10, 40);
+        assert_eq!(b.praos_reorg(0), None); // genesis never fires
+        assert_eq!(b.praos_reorg(9), None);
+        assert_eq!(b.praos_reorg(10), Some(40));
+        assert_eq!(b.praos_reorg(10), None, "same slot doesn't re-fire");
+        assert_eq!(b.praos_reorg(11), None);
+        assert_eq!(b.praos_reorg(20), Some(40));
+    }
+
+    #[test]
+    fn zero_depth_is_inert() {
+        let mut b = DeepReorg::new(10, 0);
+        assert_eq!(b.praos_reorg(10), None);
+        assert_eq!(b.praos_reorg(20), None);
+    }
+}

--- a/shared-rs/consensus/src/behaviour/behaviours/deep_reorg.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/deep_reorg.rs
@@ -38,7 +38,7 @@ impl Behaviour for DeepReorg {
         if self.depth == 0 || slot == 0 {
             return None;
         }
-        if slot % self.every_slots == 0 && slot != self.last_fired {
+        if slot.is_multiple_of(self.every_slots) && slot != self.last_fired {
             self.last_fired = slot;
             return Some(self.depth);
         }

--- a/shared-rs/consensus/src/behaviour/behaviours/drop_inbound.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/drop_inbound.rs
@@ -32,7 +32,14 @@ impl Behaviour for DropInboundPeers {
         if self.probability <= 0.0 || slot == 0 {
             return false;
         }
-        // Deterministic per-(seed, slot) draw in [0, 1): replays
+        // Bypass the draw at the top end: `u64 / u64::MAX as f64` can hit
+        // exactly 1.0 (the denominator rounds to 2^64 in f64), and the
+        // `<` test would then refuse to drop on the rare hash that maxes
+        // out — violating "always drop at probability=1.0".
+        if self.probability >= 1.0 {
+            return true;
+        }
+        // Deterministic per-(seed, slot) draw in [0, 1]: replays
         // identically from a seed (no clock / OS entropy).
         let mut h = blake2b_simd::Params::new().hash_length(8).to_state();
         h.update(&self.seed.to_le_bytes());

--- a/shared-rs/consensus/src/behaviour/behaviours/drop_inbound.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/drop_inbound.rs
@@ -1,0 +1,74 @@
+//! `DropInboundPeers` — randomly resets accepted (inbound) peer
+//! connections on a serving node, so the remote reconnects and re-runs
+//! ChainSync intersection from scratch.  Mimics a relay that RSTs
+//! inbound connections; the reconnect-handover trigger for
+//! deep-rollback recovery testing (compose with `DeepReorg` so the
+//! reconnect re-intersects against a reorged chain).
+
+use crate::behaviour::Behaviour;
+
+#[derive(Debug, Clone)]
+pub struct DropInboundPeers {
+    seed: u64,
+    /// Per-slot probability of resetting inbound peers, clamped to [0,1].
+    probability: f64,
+}
+
+impl DropInboundPeers {
+    pub fn new(seed: u64, probability: f64) -> Self {
+        Self {
+            seed,
+            probability: probability.clamp(0.0, 1.0),
+        }
+    }
+}
+
+impl Behaviour for DropInboundPeers {
+    fn name(&self) -> &'static str {
+        "drop-inbound-peers"
+    }
+
+    fn drop_inbound_peers(&mut self, slot: u64) -> bool {
+        if self.probability <= 0.0 || slot == 0 {
+            return false;
+        }
+        // Deterministic per-(seed, slot) draw in [0, 1): replays
+        // identically from a seed (no clock / OS entropy).
+        let mut h = blake2b_simd::Params::new().hash_length(8).to_state();
+        h.update(&self.seed.to_le_bytes());
+        h.update(&slot.to_le_bytes());
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&h.finalize().as_bytes()[..8]);
+        let draw = (u64::from_le_bytes(buf) as f64) / (u64::MAX as f64);
+        draw < self.probability
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn never_drops_at_zero_probability() {
+        let mut b = DropInboundPeers::new(42, 0.0);
+        assert!(!b.drop_inbound_peers(100));
+        assert!(!b.drop_inbound_peers(200));
+    }
+
+    #[test]
+    fn always_drops_at_probability_one() {
+        let mut b = DropInboundPeers::new(42, 1.0);
+        assert!(b.drop_inbound_peers(1));
+        assert!(b.drop_inbound_peers(2));
+        assert!(!b.drop_inbound_peers(0), "genesis never drops");
+    }
+
+    #[test]
+    fn deterministic_for_a_given_seed_and_slot() {
+        let mut a = DropInboundPeers::new(7, 0.5);
+        let mut b = DropInboundPeers::new(7, 0.5);
+        for slot in 1..50 {
+            assert_eq!(a.drop_inbound_peers(slot), b.drop_inbound_peers(slot));
+        }
+    }
+}

--- a/shared-rs/consensus/src/behaviour/behaviours/rb_equivocator.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/rb_equivocator.rs
@@ -95,11 +95,7 @@ impl Behaviour for RbHeaderEquivocator {
             .map(|v| v.body.clone())
     }
 
-    fn transform_outbound(
-        &mut self,
-        peer: PeerId,
-        out: Outbound<'_>,
-    ) -> OutboundDecision {
+    fn transform_outbound(&mut self, peer: PeerId, out: Outbound<'_>) -> OutboundDecision {
         let Outbound::RbHeader { slot, header } = out;
         let Some(set) = self.variants.get(&slot) else {
             // Either this isn't a slot we equivocated on, or the cache
@@ -242,10 +238,7 @@ mod tests {
             },
         );
         match out {
-            OutboundDecision::Replace(OwnedOutbound::RbHeader {
-                slot,
-                header,
-            }) => {
+            OutboundDecision::Replace(OwnedOutbound::RbHeader { slot, header }) => {
                 assert_eq!(slot, 42);
                 assert_eq!(header, variant_header);
             }

--- a/shared-rs/consensus/src/behaviour/behaviours/t22.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/t22.rs
@@ -29,12 +29,12 @@ could be unimplementable in practice, e.g. in case of direct links between hones
 Parameters:
 -----------
 - `vote_threshold`: Percentage of EB-related messages (0-100), that are to be delivered to
-   voting (committee) nodes.
+  voting (committee) nodes.
 - `non_voting_threshold`: Percentage of EB-related messages (0-100), that are to be delivered
-   to non-voting (non-committee) nodes.
+  to non-voting (non-committee) nodes.
 - `hide_eb_tx_received`: In case of `false`, only eb-offered, eb-txs-offered events are
-   ignored (so block offers are dropped). In case of `true`, also eb-received and tx-received
-   events are ignored.
+  ignored (so block offers are dropped). In case of `true`, also eb-received and tx-received
+  events are ignored.
 
 The threshold parameters are probabilistic: they specify average cutoff. So, if some threshold
 is set to 70, it means that for some points 75% of nodes will have hash%100 > 70 (and pass the
@@ -82,8 +82,7 @@ impl T22ThreatBehaviour {
         };
         // `checksum % 100` yields values in 0..=99, so use `< threshold` to make
         // threshold semantics match percentages exactly: 0 => 0%, 100 => 100%.
-        let decision = ((checksum % 100) as u8) < threshold;
-        decision
+        ((checksum % 100) as u8) < threshold
     }
 }
 

--- a/shared-rs/consensus/src/behaviour/behaviours/t22.rs
+++ b/shared-rs/consensus/src/behaviour/behaviours/t22.rs
@@ -127,8 +127,8 @@ impl Behaviour for T22ThreatBehaviour {
         point: &Point,
         _tx_hashes: &[[u8; 32]],
     ) -> BehaviourOutcome<LeiosEffect> {
-        let skip_process =
-            self.hide_eb_tx_received && !self.should_process_eb_data("on_eb_received", state, point);
+        let skip_process = self.hide_eb_tx_received
+            && !self.should_process_eb_data("on_eb_received", state, point);
         if skip_process {
             BehaviourOutcome::Replace(vec![])
         } else {

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -85,10 +85,12 @@ pub mod selection;
 pub mod behaviours {
     //! Concrete [`super::Behaviour`] implementations.  Each lives in its
     //! own file so contributors can add one without touching the others.
+    pub mod deep_reorg;
     pub mod lazy_voter;
     pub mod rb_equivocator;
     pub mod t22;
 
+    pub use deep_reorg::DeepReorg;
     pub use lazy_voter::LazyVoter;
     pub use rb_equivocator::RbHeaderEquivocator;
     pub use t22::T22ThreatBehaviour;
@@ -332,6 +334,17 @@ pub trait Behaviour: Send + Sync {
         _slot: u64,
     ) -> RbProductionStrategy {
         RbProductionStrategy::Normal
+    }
+
+    /// Deliberately trigger a self-reorg on a producing node: return
+    /// `Some(depth)` to roll the adopted chain back `depth` blocks this
+    /// slot.  The I/O wrapper calls [`PraosState::force_rollback`] and
+    /// diffuses the resulting rollback, so downstream followers see a
+    /// deep `RollBackward` + fork.  `None` (the default) leaves the
+    /// chain untouched.  Exercises deep-rollback recovery; not part of
+    /// honest consensus.
+    fn praos_reorg(&mut self, _slot: u64) -> Option<u64> {
+        None
     }
 
     /// Hand the I/O wrapper's freshly-produced RB variants to the
@@ -606,6 +619,15 @@ impl Behaviour for CompositeBehaviour {
             }
         }
         RbProductionStrategy::Normal
+    }
+
+    fn praos_reorg(&mut self, slot: u64) -> Option<u64> {
+        for c in self.children.iter_mut() {
+            if let Some(depth) = c.praos_reorg(slot) {
+                return Some(depth);
+            }
+        }
+        None
     }
 
     fn transform_outbound(

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -86,11 +86,13 @@ pub mod behaviours {
     //! Concrete [`super::Behaviour`] implementations.  Each lives in its
     //! own file so contributors can add one without touching the others.
     pub mod deep_reorg;
+    pub mod drop_inbound;
     pub mod lazy_voter;
     pub mod rb_equivocator;
     pub mod t22;
 
     pub use deep_reorg::DeepReorg;
+    pub use drop_inbound::DropInboundPeers;
     pub use lazy_voter::LazyVoter;
     pub use rb_equivocator::RbHeaderEquivocator;
     pub use t22::T22ThreatBehaviour;
@@ -345,6 +347,15 @@ pub trait Behaviour: Send + Sync {
     /// honest consensus.
     fn praos_reorg(&mut self, _slot: u64) -> Option<u64> {
         None
+    }
+
+    /// Deliberately reset accepted (inbound) peer connections this slot.
+    /// `true` asks the I/O wrapper to drop every inbound peer, so the
+    /// remote reconnects and re-runs ChainSync intersection from scratch
+    /// — mimicking a relay that resets inbound connections.  The default
+    /// is `false`.  Not part of honest consensus.
+    fn drop_inbound_peers(&mut self, _slot: u64) -> bool {
+        false
     }
 
     /// Hand the I/O wrapper's freshly-produced RB variants to the
@@ -628,6 +639,18 @@ impl Behaviour for CompositeBehaviour {
             }
         }
         None
+    }
+
+    fn drop_inbound_peers(&mut self, slot: u64) -> bool {
+        // Poll every child (no short-circuit) so a child that tracks
+        // per-call state stays deterministic.
+        let mut drop = false;
+        for c in self.children.iter_mut() {
+            if c.drop_inbound_peers(slot) {
+                drop = true;
+            }
+        }
+        drop
     }
 
     fn transform_outbound(

--- a/shared-rs/consensus/src/behaviour/mod.rs
+++ b/shared-rs/consensus/src/behaviour/mod.rs
@@ -189,11 +189,7 @@ pub trait Behaviour: Send + Sync {
 
     // -- Leios reactive hooks ------------------------------------------------
 
-    fn on_slot_leios(
-        &mut self,
-        _state: &LeiosState,
-        _slot: u64,
-    ) -> BehaviourOutcome<LeiosEffect> {
+    fn on_slot_leios(&mut self, _state: &LeiosState, _slot: u64) -> BehaviourOutcome<LeiosEffect> {
         BehaviourOutcome::Continue
     }
 
@@ -393,11 +389,7 @@ pub trait Behaviour: Send + Sync {
     /// when the wrapper asks.  Determinism is the behaviour's
     /// responsibility (see the seed accepted at
     /// [`registry::build`]).
-    fn transform_outbound(
-        &mut self,
-        _peer: PeerId,
-        _out: Outbound<'_>,
-    ) -> OutboundDecision {
+    fn transform_outbound(&mut self, _peer: PeerId, _out: Outbound<'_>) -> OutboundDecision {
         OutboundDecision::Send
     }
 }
@@ -442,11 +434,7 @@ impl Behaviour for CompositeBehaviour {
         "composite"
     }
 
-    fn on_slot_leios(
-        &mut self,
-        state: &LeiosState,
-        slot: u64,
-    ) -> BehaviourOutcome<LeiosEffect> {
+    fn on_slot_leios(&mut self, state: &LeiosState, slot: u64) -> BehaviourOutcome<LeiosEffect> {
         for c in self.children.iter_mut() {
             let out = c.on_slot_leios(state, slot);
             if !out.is_continue() {
@@ -653,11 +641,7 @@ impl Behaviour for CompositeBehaviour {
         drop
     }
 
-    fn transform_outbound(
-        &mut self,
-        peer: PeerId,
-        out: Outbound<'_>,
-    ) -> OutboundDecision {
+    fn transform_outbound(&mut self, peer: PeerId, out: Outbound<'_>) -> OutboundDecision {
         for c in self.children.iter_mut() {
             let d = c.transform_outbound(peer, out);
             if !d.is_send() {
@@ -806,11 +790,8 @@ mod tests {
             on_slot_calls: 0,
             on_slot_reply: BehaviourOutcome::Replace(vec![]),
         };
-        let mut composite = CompositeBehaviour::new(vec![
-            Box::new(first),
-            Box::new(second),
-            Box::new(third),
-        ]);
+        let mut composite =
+            CompositeBehaviour::new(vec![Box::new(first), Box::new(second), Box::new(third)]);
         let out = composite.on_slot_leios(&s, 5);
         assert!(matches!(out, BehaviourOutcome::Replace(_)));
         // Third never ran.  We can't introspect after wrapping in Box<dyn>,

--- a/shared-rs/consensus/src/behaviour/registry.rs
+++ b/shared-rs/consensus/src/behaviour/registry.rs
@@ -17,7 +17,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::behaviours::{LazyVoter, RbHeaderEquivocator, T22ThreatBehaviour};
+use super::behaviours::{DeepReorg, LazyVoter, RbHeaderEquivocator, T22ThreatBehaviour};
 use super::{Behaviour, CompositeBehaviour, HonestBehaviour};
 use crate::leios::NoVoteReason;
 
@@ -61,6 +61,12 @@ pub enum BehaviourSpec {
         non_voting_threshold: u8,
         hide_eb_tx_received: bool,
     },
+    /// Producer-side chain chaos: every `every_slots` slots, roll this
+    /// node's adopted chain back `depth` blocks and fork, so downstream
+    /// followers must recover from a deep rollback that orphans their
+    /// adopted tip.  See [`super::behaviours::DeepReorg`].
+    #[serde(rename = "deep-reorg")]
+    DeepReorg { every_slots: u64, depth: u64 },
 }
 
 fn default_lazy_reason() -> NoVoteReason {
@@ -115,6 +121,9 @@ pub fn build(spec: &BehaviourSpec, seed: u64) -> Box<dyn Behaviour> {
             non_voting_threshold,
             hide_eb_tx_received,
         } => Box::new(T22ThreatBehaviour::new(*vote_threshold, *non_voting_threshold, *hide_eb_tx_received)),
+        BehaviourSpec::DeepReorg { every_slots, depth } => {
+            Box::new(DeepReorg::new(*every_slots, *depth))
+        }
     }
 }
 

--- a/shared-rs/consensus/src/behaviour/registry.rs
+++ b/shared-rs/consensus/src/behaviour/registry.rs
@@ -130,7 +130,11 @@ pub fn build(spec: &BehaviourSpec, seed: u64) -> Box<dyn Behaviour> {
             vote_threshold,
             non_voting_threshold,
             hide_eb_tx_received,
-        } => Box::new(T22ThreatBehaviour::new(*vote_threshold, *non_voting_threshold, *hide_eb_tx_received)),
+        } => Box::new(T22ThreatBehaviour::new(
+            *vote_threshold,
+            *non_voting_threshold,
+            *hide_eb_tx_received,
+        )),
         BehaviourSpec::DeepReorg { every_slots, depth } => {
             Box::new(DeepReorg::new(*every_slots, *depth))
         }
@@ -195,7 +199,10 @@ mod tests {
             BehaviourSpec::Composite { children } => {
                 assert_eq!(children.len(), 3);
                 assert!(matches!(children[0], BehaviourSpec::Honest));
-                assert!(matches!(children[1], BehaviourSpec::RbHeaderEquivocator { ways: 2 }));
+                assert!(matches!(
+                    children[1],
+                    BehaviourSpec::RbHeaderEquivocator { ways: 2 }
+                ));
                 assert!(matches!(
                     children[2],
                     BehaviourSpec::T22 {

--- a/shared-rs/consensus/src/behaviour/registry.rs
+++ b/shared-rs/consensus/src/behaviour/registry.rs
@@ -17,7 +17,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::behaviours::{DeepReorg, LazyVoter, RbHeaderEquivocator, T22ThreatBehaviour};
+use super::behaviours::{
+    DeepReorg, DropInboundPeers, LazyVoter, RbHeaderEquivocator, T22ThreatBehaviour,
+};
 use super::{Behaviour, CompositeBehaviour, HonestBehaviour};
 use crate::leios::NoVoteReason;
 
@@ -67,6 +69,14 @@ pub enum BehaviourSpec {
     /// adopted tip.  See [`super::behaviours::DeepReorg`].
     #[serde(rename = "deep-reorg")]
     DeepReorg { every_slots: u64, depth: u64 },
+    /// Server-side chaos: each slot, with `probability`, reset all
+    /// accepted (inbound) peer connections so the remote reconnects and
+    /// re-intersects.  Mimics a relay that RSTs inbound peers — the
+    /// reconnect-handover trigger.  Compose with [`Self::DeepReorg`] so
+    /// the reconnect lands on a reorged chain.  See
+    /// [`super::behaviours::DropInboundPeers`].
+    #[serde(rename = "drop-inbound-peers")]
+    DropInboundPeers { probability: f64 },
 }
 
 fn default_lazy_reason() -> NoVoteReason {
@@ -123,6 +133,9 @@ pub fn build(spec: &BehaviourSpec, seed: u64) -> Box<dyn Behaviour> {
         } => Box::new(T22ThreatBehaviour::new(*vote_threshold, *non_voting_threshold, *hide_eb_tx_received)),
         BehaviourSpec::DeepReorg { every_slots, depth } => {
             Box::new(DeepReorg::new(*every_slots, *depth))
+        }
+        BehaviourSpec::DropInboundPeers { probability } => {
+            Box::new(DropInboundPeers::new(seed, *probability))
         }
     }
 }

--- a/shared-rs/consensus/src/behaviour/selection.rs
+++ b/shared-rs/consensus/src/behaviour/selection.rs
@@ -362,7 +362,7 @@ mod tests {
             out.get(&1),
             Some(BehaviourSpec::RbHeaderEquivocator { ways: 2 })
         ));
-        assert!(out.get(&2).is_none());
+        assert!(!out.contains_key(&2));
     }
 
     #[test]

--- a/shared-rs/consensus/src/behaviour/selection.rs
+++ b/shared-rs/consensus/src/behaviour/selection.rs
@@ -221,8 +221,11 @@ mod tests {
     #[test]
     fn stake_ordered_filters_zero_stake_and_takes_top_n() {
         let stakes = vec![10, 100, 50, 0, 200];
-        let set =
-            resolve_selection(&BehaviourSelection::StakeOrdered { count: 2 }, &stakes, None);
+        let set = resolve_selection(
+            &BehaviourSelection::StakeOrdered { count: 2 },
+            &stakes,
+            None,
+        );
         // Sorted desc by stake: 4 (200), 1 (100), 2 (50), 0 (10); top 2 = {1, 4}.
         assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![1, 4]);
     }
@@ -252,7 +255,11 @@ mod tests {
     fn stake_random_is_deterministic_for_seed() {
         let stakes = vec![10, 0, 20, 0, 30, 0, 40, 0, 50];
         let mk = |seed: u64| -> BTreeSet<usize> {
-            resolve_selection(&BehaviourSelection::StakeRandom { count: 2 }, &stakes, Some(seed))
+            resolve_selection(
+                &BehaviourSelection::StakeRandom { count: 2 },
+                &stakes,
+                Some(seed),
+            )
         };
         assert_eq!(mk(42), mk(42));
         let a = mk(42);
@@ -443,7 +450,10 @@ mod tests {
                 BehaviourSpec::RbHeaderEquivocator { ways: 2 },
                 BehaviourSelection::Nodes { indices: vec![0] },
             ),
-            (BehaviourSpec::Honest, BehaviourSelection::Nodes { indices: vec![0] }),
+            (
+                BehaviourSpec::Honest,
+                BehaviourSelection::Nodes { indices: vec![0] },
+            ),
         ];
         let out = resolve_specs(&items, &[1], None);
         match out.get(&0) {

--- a/shared-rs/consensus/src/chain_tree.rs
+++ b/shared-rs/consensus/src/chain_tree.rs
@@ -290,6 +290,19 @@ impl ChainTree {
         true
     }
 
+    /// Drop every block strictly above `block_number` and recompute the
+    /// best tip.  Used to abandon a chain suffix on a deliberate
+    /// self-reorg (see [`crate::praos::PraosState::force_rollback`]): the
+    /// rolled-back blocks must leave the tree so they aren't re-selected
+    /// as the best tip.
+    pub fn remove_above(&mut self, block_number: u64) {
+        let before = self.nodes.len();
+        self.nodes.retain(|_, node| node.block_number <= block_number);
+        if self.nodes.len() != before {
+            self.recompute_best_tip();
+        }
+    }
+
     /// Recompute `best_tip` by scanning all nodes for the highest
     /// `block_number` (ties broken by lower hash).  Deterministic despite
     /// HashMap iteration: the result is the maximum under the total order

--- a/shared-rs/consensus/src/chain_tree.rs
+++ b/shared-rs/consensus/src/chain_tree.rs
@@ -265,18 +265,47 @@ impl ChainTree {
             None => false,
         };
         if pruned {
-            self.best_tip = None;
-            for (hash, node) in &self.nodes {
-                let is_new_best = match &self.best_tip {
-                    None => true,
-                    Some((_, best_bn)) => {
-                        let best_hash = self.best_tip_hash().unwrap_or([0xFF; 32]);
-                        is_better_tip(node.block_number, hash, *best_bn, &best_hash)
-                    }
-                };
-                if is_new_best {
-                    self.best_tip = Some((node.point.clone(), node.block_number));
+            self.recompute_best_tip();
+        }
+    }
+
+    /// Remove a single block node — used to drop a fork tip that no
+    /// connected peer can serve, so it stops being chosen as `best_tip`
+    /// and wedging chain selection.  This happens after a deep rollback:
+    /// blocks we cached from the peer's chain become unreachable when the
+    /// peer rolls back past them, but they linger here as a far-ahead,
+    /// disconnected best tip that the gap-bridge can never fetch.
+    ///
+    /// Recomputes `best_tip` from the remaining nodes when the removed
+    /// node was the best tip.  Returns true if a node was removed.  If a
+    /// peer later re-announces that chain, ChainSync re-inserts it.
+    pub fn remove_fork_tip(&mut self, hash: &[u8; 32]) -> bool {
+        let was_best = self.best_tip_hash() == Some(*hash);
+        if self.nodes.remove(hash).is_none() {
+            return false;
+        }
+        if was_best {
+            self.recompute_best_tip();
+        }
+        true
+    }
+
+    /// Recompute `best_tip` by scanning all nodes for the highest
+    /// `block_number` (ties broken by lower hash).  Deterministic despite
+    /// HashMap iteration: the result is the maximum under the total order
+    /// defined by [`is_better_tip`], independent of visit order.
+    fn recompute_best_tip(&mut self) {
+        self.best_tip = None;
+        for (hash, node) in &self.nodes {
+            let is_new_best = match &self.best_tip {
+                None => true,
+                Some((_, best_bn)) => {
+                    let best_hash = self.best_tip_hash().unwrap_or([0xFF; 32]);
+                    is_better_tip(node.block_number, hash, *best_bn, &best_hash)
                 }
+            };
+            if is_new_best {
+                self.best_tip = Some((node.point.clone(), node.block_number));
             }
         }
     }

--- a/shared-rs/consensus/src/chain_tree.rs
+++ b/shared-rs/consensus/src/chain_tree.rs
@@ -276,7 +276,8 @@ impl ChainTree {
     /// as the best tip.
     pub fn remove_above(&mut self, block_number: u64) {
         let before = self.nodes.len();
-        self.nodes.retain(|_, node| node.block_number <= block_number);
+        self.nodes
+            .retain(|_, node| node.block_number <= block_number);
         if self.nodes.len() != before {
             self.recompute_best_tip();
         }
@@ -313,16 +314,7 @@ impl ChainTree {
         slot: u64,
         prev_hash: Option<[u8; 32]>,
     ) -> bool {
-        self.insert(
-            hash,
-            point,
-            block_number,
-            slot,
-            prev_hash,
-            0,
-            None,
-            false,
-        )
+        self.insert(hash, point, block_number, slot, prev_hash, 0, None, false)
     }
 
     /// Test-only convenience: snapshot with a no-op EB-manifest lookup.
@@ -444,9 +436,9 @@ impl ChainTree {
                 // (queries the wrapper's live manifest cache) so the
                 // count appears as soon as a manifest arrives, before
                 // it's been stashed.
-                let eb_tx_count = node.cached_eb_tx_count.or_else(|| {
-                    node.announced_eb_hash.as_ref().and_then(&eb_manifest_count)
-                });
+                let eb_tx_count = node
+                    .cached_eb_tx_count
+                    .or_else(|| node.announced_eb_hash.as_ref().and_then(&eb_manifest_count));
                 Some(ChainTreeEntry {
                     block_number: node.block_number,
                     hash: short_hash(h),

--- a/shared-rs/consensus/src/chain_tree.rs
+++ b/shared-rs/consensus/src/chain_tree.rs
@@ -269,27 +269,6 @@ impl ChainTree {
         }
     }
 
-    /// Remove a single block node — used to drop a fork tip that no
-    /// connected peer can serve, so it stops being chosen as `best_tip`
-    /// and wedging chain selection.  This happens after a deep rollback:
-    /// blocks we cached from the peer's chain become unreachable when the
-    /// peer rolls back past them, but they linger here as a far-ahead,
-    /// disconnected best tip that the gap-bridge can never fetch.
-    ///
-    /// Recomputes `best_tip` from the remaining nodes when the removed
-    /// node was the best tip.  Returns true if a node was removed.  If a
-    /// peer later re-announces that chain, ChainSync re-inserts it.
-    pub fn remove_fork_tip(&mut self, hash: &[u8; 32]) -> bool {
-        let was_best = self.best_tip_hash() == Some(*hash);
-        if self.nodes.remove(hash).is_none() {
-            return false;
-        }
-        if was_best {
-            self.recompute_best_tip();
-        }
-        true
-    }
-
     /// Drop every block strictly above `block_number` and recompute the
     /// best tip.  Used to abandon a chain suffix on a deliberate
     /// self-reorg (see [`crate::praos::PraosState::force_rollback`]): the

--- a/shared-rs/consensus/src/committee.rs
+++ b/shared-rs/consensus/src/committee.rs
@@ -397,7 +397,10 @@ mod tests {
         };
         // Committee contents irrelevant — denominator is the network total.
         let committee = BTreeMap::new();
-        assert_eq!(expected_total_weight(&selection, &committee, 1_000_000), 1_000_000);
+        assert_eq!(
+            expected_total_weight(&selection, &committee, 1_000_000),
+            1_000_000
+        );
     }
 
     // -- NPV eligibility ----------------------------------------------------

--- a/shared-rs/consensus/src/elections.rs
+++ b/shared-rs/consensus/src/elections.rs
@@ -15,9 +15,9 @@ use std::collections::BTreeMap;
 use tracing::info;
 
 use crate::aggregation::{self, hex_prefix, QuorumFormed};
+use crate::committee;
 use crate::config::CommitteeSelection;
 use crate::pipeline::{EbElection, PipelineConfig, PipelinePhase};
-use crate::committee;
 
 /// What the caller should do as a result of a slot tick.
 ///
@@ -209,8 +209,7 @@ impl Elections {
         // Pass 1: collect EligibleToVote in BTreeMap order.
         for (hash, election) in &self.elections {
             let elapsed = slot.saturating_sub(election.announced_slot);
-            if pipeline.phase_for_elapsed(elapsed) == PipelinePhase::Voting && !election.voted
-            {
+            if pipeline.phase_for_elapsed(elapsed) == PipelinePhase::Voting && !election.voted {
                 effects.push(SlotEffect::EligibleToVote {
                     eb_hash: *hash,
                     eb_slot: election.announced_slot,
@@ -226,8 +225,8 @@ impl Elections {
         // chain-progress prune in [`crate::leios::LeiosState::on_slot`]
         // (via [`Self::prune_below_slot`]), not by elapsed slots.
         for election in self.elections.values_mut() {
-            election.phase = pipeline
-                .phase_for_elapsed(slot.saturating_sub(election.announced_slot));
+            election.phase =
+                pipeline.phase_for_elapsed(slot.saturating_sub(election.announced_slot));
         }
         effects
     }
@@ -292,11 +291,7 @@ impl Elections {
         match (tag, npv_signature, &self.cfg.committee_selection) {
             (0, _, CommitteeSelection::StakeCentile { .. }) => {
                 if self.cfg.persistent_committee.contains_key(voter_id) {
-                    self.cfg
-                        .stake_registry
-                        .get(voter_id)
-                        .copied()
-                        .unwrap_or(0)
+                    self.cfg.stake_registry.get(voter_id).copied().unwrap_or(0)
                 } else {
                     0
                 }
@@ -312,12 +307,7 @@ impl Elections {
                 if self.cfg.persistent_committee.contains_key(voter_id) {
                     return 0;
                 }
-                let stake = self
-                    .cfg
-                    .stake_registry
-                    .get(voter_id)
-                    .copied()
-                    .unwrap_or(0);
+                let stake = self.cfg.stake_registry.get(voter_id).copied().unwrap_or(0);
                 committee::count_npv_wins(
                     sig,
                     stake,
@@ -397,8 +387,7 @@ impl Elections {
     /// RB is no longer the chain tip is permanently dead, and its
     /// election state is dead weight.
     pub fn prune_below_slot(&mut self, min_slot: u64) {
-        self.elections
-            .retain(|_, e| e.announced_slot >= min_slot);
+        self.elections.retain(|_, e| e.announced_slot >= min_slot);
     }
 
     /// Slot of the EB at `eb_hash` if it is both at quorum and

--- a/shared-rs/consensus/src/fetch.rs
+++ b/shared-rs/consensus/src/fetch.rs
@@ -105,22 +105,12 @@ impl PeerRtt for PeerRttCache {
 
 /// Pick the peer(s) to issue a Praos `BlockFetch` request to.
 pub trait BlockFetchPolicy {
-    fn pick(
-        &self,
-        point: &Point,
-        candidates: &[PeerId],
-        rtt: &dyn PeerRtt,
-    ) -> Vec<PeerId>;
+    fn pick(&self, point: &Point, candidates: &[PeerId], rtt: &dyn PeerRtt) -> Vec<PeerId>;
 }
 
 /// Pick the peer(s) to fetch a Leios EB body from.
 pub trait EbFetchPolicy {
-    fn pick(
-        &self,
-        point: &Point,
-        candidates: &[PeerId],
-        rtt: &dyn PeerRtt,
-    ) -> Vec<PeerId>;
+    fn pick(&self, point: &Point, candidates: &[PeerId], rtt: &dyn PeerRtt) -> Vec<PeerId>;
 }
 
 /// Pick the peer(s) to fetch Leios EB transactions from, given the
@@ -423,10 +413,14 @@ impl CandidateTracker {
         self.block_offers.retain(|p, _| point_slot(p) >= min_slot);
         self.eb_offers.retain(|p, _| point_slot(p) >= min_slot);
         self.eb_txs_offers.retain(|p, _| point_slot(p) >= min_slot);
-        self.pending_block_fetches.retain(|p| point_slot(p) >= min_slot);
-        self.pending_eb_fetches.retain(|p| point_slot(p) >= min_slot);
-        self.pending_eb_txs_fetches.retain(|p| point_slot(p) >= min_slot);
-        self.eb_txs_attempts.retain(|p, _| point_slot(p) >= min_slot);
+        self.pending_block_fetches
+            .retain(|p| point_slot(p) >= min_slot);
+        self.pending_eb_fetches
+            .retain(|p| point_slot(p) >= min_slot);
+        self.pending_eb_txs_fetches
+            .retain(|p| point_slot(p) >= min_slot);
+        self.eb_txs_attempts
+            .retain(|p, _| point_slot(p) >= min_slot);
     }
 }
 
@@ -472,8 +466,7 @@ mod tests {
     fn lowest_rtt_first_picks_min() {
         let policy = LowestRttFirst;
         let rtt = rtts(&[(1, 50), (2, 10), (3, 30)]);
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
         assert_eq!(picked, vec![pid(2)]);
     }
 
@@ -482,8 +475,7 @@ mod tests {
         let policy = LowestRttFirst;
         // pid(2) has no measurement → treated as effectively infinite.
         let rtt = rtts(&[(1, 50), (3, 100)]);
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
         assert_eq!(picked, vec![pid(1)]);
     }
 
@@ -501,8 +493,7 @@ mod tests {
     fn broadcast_n_one_matches_request_from_first() {
         let policy = BroadcastN::one();
         let rtt = rtts(&[(1, 50), (2, 10), (3, 30)]);
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
         assert_eq!(picked, vec![pid(2)]);
     }
 
@@ -510,8 +501,7 @@ mod tests {
     fn broadcast_n_two_picks_two_lowest() {
         let policy = BroadcastN { n: 2 };
         let rtt = rtts(&[(1, 50), (2, 10), (3, 30)]);
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
         // Sorted ascending by RTT: pid(2) 10ms, pid(3) 30ms.
         assert_eq!(picked, vec![pid(2), pid(3)]);
     }
@@ -520,8 +510,7 @@ mod tests {
     fn broadcast_n_all_matches_request_from_all() {
         let policy = BroadcastN::all();
         let rtt = rtts(&[(1, 50), (2, 10), (3, 30)]);
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &rtt);
         // Sorted by RTT.
         assert_eq!(picked, vec![pid(2), pid(3), pid(1)]);
     }
@@ -530,8 +519,7 @@ mod tests {
     fn broadcast_n_zero_returns_empty() {
         let policy = BroadcastN { n: 0 };
         let rtt = UniformRtt(Duration::from_millis(10));
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2)], &rtt);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2)], &rtt);
         assert!(picked.is_empty());
     }
 
@@ -631,8 +619,7 @@ mod tests {
         cache.set(pid(2), Duration::from_millis(10));
         cache.set(pid(3), Duration::from_millis(30));
         let policy = LowestRttFirst;
-        let picked =
-            BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &cache);
+        let picked = BlockFetchPolicy::pick(&policy, &pt(1, 1), &[pid(1), pid(2), pid(3)], &cache);
         assert_eq!(picked, vec![pid(2)]);
     }
 }

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -427,6 +427,16 @@ impl LeiosState {
         guard.rb_production_strategy(self, praos, slot)
     }
 
+    /// Consult the behaviour for a deliberate self-reorg this slot.
+    /// Returns the rollback depth the behaviour wants (see
+    /// [`crate::behaviour::behaviours::DeepReorg`]), or `None` for the
+    /// honest default.
+    pub fn ask_praos_reorg(&mut self, slot: u64) -> Option<u64> {
+        let arc = self.behaviour.clone();
+        let mut guard = arc.lock().expect("behaviour mutex poisoned");
+        guard.praos_reorg(slot)
+    }
+
     /// Short name of the current behaviour, e.g. `"honest"`,
     /// `"rb-header-equivocator"`.  Useful for telemetry and structured logs.
     pub fn behaviour_name(&self) -> &'static str {

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -437,6 +437,16 @@ impl LeiosState {
         guard.praos_reorg(slot)
     }
 
+    /// Consult the behaviour for whether to reset inbound peer
+    /// connections this slot (see
+    /// [`crate::behaviour::behaviours::DropInboundPeers`]).  `false` for
+    /// the honest default.
+    pub fn ask_drop_inbound_peers(&mut self, slot: u64) -> bool {
+        let arc = self.behaviour.clone();
+        let mut guard = arc.lock().expect("behaviour mutex poisoned");
+        guard.drop_inbound_peers(slot)
+    }
+
     /// Short name of the current behaviour, e.g. `"honest"`,
     /// `"rb-header-equivocator"`.  Useful for telemetry and structured logs.
     pub fn behaviour_name(&self) -> &'static str {

--- a/shared-rs/consensus/src/leios.rs
+++ b/shared-rs/consensus/src/leios.rs
@@ -27,6 +27,7 @@ use tracing::info;
 
 use crate::aggregation::QuorumFormed;
 use crate::behaviour::{Behaviour, BehaviourOutcome, HonestBehaviour};
+use crate::committee;
 use crate::config::CommitteeSelection;
 use crate::elections::{Elections, SlotEffect};
 use crate::fetch::{
@@ -34,9 +35,8 @@ use crate::fetch::{
 };
 use crate::peer::PeerId;
 use crate::pipeline::PipelineConfig;
-use crate::types::Vote;
 use crate::types::Point;
-use crate::committee;
+use crate::types::Vote;
 
 /// How long an in-flight fetch entry remains "active" before being
 /// considered stale and eligible for retry.
@@ -246,7 +246,7 @@ pub enum LeiosTelemetryEvent {
     LeiosElectionInfo {
         eb_slot: u64,
         perm_committee: bool,
-    }
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -543,20 +543,15 @@ impl LeiosState {
     /// locally?" — used by the CIP-0164 `MissingTX` voting check in
     /// TX-by-references mode.  Wrappers without a mempool surface yet
     /// can pass `&|_| true`; in that case the predicate is a no-op.
-    pub fn on_slot(
-        &mut self,
-        slot: u64,
-        tx_known: &dyn Fn(&[u8; 32]) -> bool,
-    ) -> Vec<LeiosEffect> {
+    pub fn on_slot(&mut self, slot: u64, tx_known: &dyn Fn(&[u8; 32]) -> bool) -> Vec<LeiosEffect> {
         // Behaviour reactive hook.  Replace short-circuits the honest
         // path; Append accumulates extras to splice in after the
         // honest fx.
-        let appended: Vec<LeiosEffect> =
-            match self.invoke_hook(|b, s| b.on_slot_leios(s, slot)) {
-                BehaviourOutcome::Continue => Vec::new(),
-                BehaviourOutcome::Replace(effects) => return effects,
-                BehaviourOutcome::Append(extra) => extra,
-            };
+        let appended: Vec<LeiosEffect> = match self.invoke_hook(|b, s| b.on_slot_leios(s, slot)) {
+            BehaviourOutcome::Continue => Vec::new(),
+            BehaviourOutcome::Replace(effects) => return effects,
+            BehaviourOutcome::Append(extra) => extra,
+        };
 
         let mut fx: Vec<LeiosEffect> = Vec::new();
         for eff in self.elections.on_slot(slot) {
@@ -575,9 +570,7 @@ impl LeiosState {
                     drop(guard);
                     let resolved = decision.resolve(honest_vote);
                     match resolved {
-                        Ok((emit_pv, npv_signature))
-                            if emit_pv || npv_signature.is_some() =>
-                        {
+                        Ok((emit_pv, npv_signature)) if emit_pv || npv_signature.is_some() => {
                             info!(
                                 node_id = %self.node_id,
                                 eb_slot,
@@ -673,7 +666,8 @@ impl LeiosState {
         // EB is potentially relevant to the chain we'll soon adopt.
         if let Some(min_keep) = self.chain_tip_ctx.tip_rb_slot {
             self.eb_tx_hashes.retain(|_, (s, _)| *s >= min_keep);
-            self.pending_eb_tx_fetches.retain(|_, (s, _)| *s >= min_keep);
+            self.pending_eb_tx_fetches
+                .retain(|_, (s, _)| *s >= min_keep);
             self.endorsed_unvalidated_ebs.retain(|_, s| *s >= min_keep);
             self.elections.prune_below_slot(min_keep);
             self.candidates.prune_below_slot(min_keep);
@@ -764,22 +758,26 @@ impl LeiosState {
         // persistent seat is *not* eligible as an NPV candidate.  A
         // pool emits exactly one vote per election: PV xor NPV.
         let emit_pv = self.voting_config.persistent_seats > 0;
-        let n_npv = self.voting_config.committee_selection.non_persistent_voters();
+        let n_npv = self
+            .voting_config
+            .committee_selection
+            .non_persistent_voters();
         let npv_signature = if emit_pv || n_npv == 0 {
             None
         } else {
-            let sig = committee::npv_eligibility_signature(
-                self.node_id.as_bytes(),
-                eb_hash,
-                eb_slot,
-            );
+            let sig =
+                committee::npv_eligibility_signature(self.node_id.as_bytes(), eb_hash, eb_slot);
             let wins = committee::count_npv_wins(
                 &sig,
                 self.voting_config.stake,
                 self.voting_config.total_stake,
                 n_npv,
             );
-            if wins > 0 { Some(sig) } else { None }
+            if wins > 0 {
+                Some(sig)
+            } else {
+                None
+            }
         };
         Ok((emit_pv, npv_signature))
     }
@@ -791,12 +789,7 @@ impl LeiosState {
     /// against the current candidate set and emits one
     /// `FetchLeiosBlock` carrying the chosen peers.  Idempotent: a
     /// repeat offer from the same peer is silently absorbed.
-    pub fn on_eb_offered(
-        &mut self,
-        point: Point,
-        peer: PeerId,
-        now: Instant,
-    ) -> Vec<LeiosEffect> {
+    pub fn on_eb_offered(&mut self, point: Point, peer: PeerId, now: Instant) -> Vec<LeiosEffect> {
         let appended: Vec<LeiosEffect> =
             match self.invoke_hook(|b, s| b.on_eb_offered(s, &point, peer)) {
                 BehaviourOutcome::Continue => Vec::new(),
@@ -809,9 +802,7 @@ impl LeiosState {
             return appended;
         }
         let candidates = self.candidates.eb_candidates(&point);
-        let peers = self
-            .eb_policy
-            .pick(&point, &candidates, self.rtt.as_ref());
+        let peers = self.eb_policy.pick(&point, &candidates, self.rtt.as_ref());
         if peers.is_empty() {
             return appended;
         }
@@ -839,13 +830,12 @@ impl LeiosState {
         bitmap: BTreeMap<u16, u64>,
         now: Instant,
     ) -> Vec<LeiosEffect> {
-        let appended: Vec<LeiosEffect> = match self
-            .invoke_hook(|b, s| b.on_eb_txs_offered(s, &point, peer, &bitmap))
-        {
-            BehaviourOutcome::Continue => Vec::new(),
-            BehaviourOutcome::Replace(effects) => return effects,
-            BehaviourOutcome::Append(extra) => extra,
-        };
+        let appended: Vec<LeiosEffect> =
+            match self.invoke_hook(|b, s| b.on_eb_txs_offered(s, &point, peer, &bitmap)) {
+                BehaviourOutcome::Continue => Vec::new(),
+                BehaviourOutcome::Replace(effects) => return effects,
+                BehaviourOutcome::Append(extra) => extra,
+            };
         self.evict_stale_in_flight(now);
         let slot = match &point {
             Point::Specific { slot, .. } => *slot,
@@ -871,9 +861,9 @@ impl LeiosState {
             return appended;
         }
         let candidates = self.candidates.eb_txs_candidates(&point);
-        let peers =
-            self.eb_txs_policy
-                .pick(&point, &bitmap, &candidates, self.rtt.as_ref());
+        let peers = self
+            .eb_txs_policy
+            .pick(&point, &bitmap, &candidates, self.rtt.as_ref());
         if peers.is_empty() {
             return appended;
         }
@@ -908,13 +898,12 @@ impl LeiosState {
         manifest_hashes: Option<Vec<[u8; 32]>>,
     ) -> Vec<LeiosEffect> {
         let hashes_for_hook: &[[u8; 32]] = manifest_hashes.as_deref().unwrap_or(&[]);
-        let appended: Vec<LeiosEffect> = match self.invoke_hook(|b, s| {
-            b.on_eb_received(s, &point, hashes_for_hook)
-        }) {
-            BehaviourOutcome::Continue => Vec::new(),
-            BehaviourOutcome::Replace(effects) => return effects,
-            BehaviourOutcome::Append(extra) => extra,
-        };
+        let appended: Vec<LeiosEffect> =
+            match self.invoke_hook(|b, s| b.on_eb_received(s, &point, hashes_for_hook)) {
+                BehaviourOutcome::Continue => Vec::new(),
+                BehaviourOutcome::Replace(effects) => return effects,
+                BehaviourOutcome::Append(extra) => extra,
+            };
         self.in_flight.remove(&point);
         let mut fx = Vec::new();
         if let (Some(hashes), Point::Specific { slot, hash }) = (manifest_hashes, &point) {
@@ -1024,7 +1013,9 @@ impl LeiosState {
         if self.elections.is_announced(&eb_hash) {
             return;
         }
-        self.endorsed_unvalidated_ebs.entry(eb_hash).or_insert(eb_slot);
+        self.endorsed_unvalidated_ebs
+            .entry(eb_hash)
+            .or_insert(eb_slot);
     }
 
     /// Producer-side EB-safety predicate consumed by
@@ -1049,11 +1040,9 @@ impl LeiosState {
         let mut fx = Vec::new();
         for body in vote_bodies {
             let voter_id_str = String::from_utf8_lossy(body.voter_id).into_owned();
-            let weight = self.elections.weight_for(
-                &voter_id_str,
-                body.tag,
-                body.eligibility_signature,
-            );
+            let weight =
+                self.elections
+                    .weight_for(&voter_id_str, body.tag, body.eligibility_signature);
             if weight == 0 {
                 continue;
             }
@@ -1123,11 +1112,8 @@ impl LeiosState {
             };
         };
         // Build hash → manifest-index map.
-        let manifest_index: BTreeMap<&[u8; 32], usize> = manifest
-            .iter()
-            .enumerate()
-            .map(|(i, h)| (h, i))
-            .collect();
+        let manifest_index: BTreeMap<&[u8; 32], usize> =
+            manifest.iter().enumerate().map(|(i, h)| (h, i)).collect();
         // Match each body, sorting by manifest index.
         let mut matched: BTreeMap<usize, Vec<u8>> = BTreeMap::new();
         for (body, body_hash) in bodies_with_hashes {
@@ -1138,27 +1124,25 @@ impl LeiosState {
         let matched_bodies: Vec<Vec<u8>> = matched.values().cloned().collect();
 
         // Compute `requested` and `remaining_bitmap`.
-        let (requested, remaining_bitmap) =
-            match self.pending_eb_tx_fetches.get(&hash).cloned() {
-                Some((_, bitmap)) => {
-                    let requested_indices: BTreeSet<u32> = bitmap_to_indices(&bitmap);
-                    let matched_indices: BTreeSet<u32> =
-                        matched.keys().map(|i| *i as u32).collect();
-                    let remaining: Vec<u32> = requested_indices
-                        .difference(&matched_indices)
-                        .copied()
-                        .collect();
-                    let remaining_bitmap = indices_to_bitmap(&remaining);
-                    if remaining.is_empty() {
-                        self.pending_eb_tx_fetches.remove(&hash);
-                    } else {
-                        self.pending_eb_tx_fetches
-                            .insert(hash, (eb_slot, remaining_bitmap.clone()));
-                    }
-                    (requested_indices.len(), remaining_bitmap)
+        let (requested, remaining_bitmap) = match self.pending_eb_tx_fetches.get(&hash).cloned() {
+            Some((_, bitmap)) => {
+                let requested_indices: BTreeSet<u32> = bitmap_to_indices(&bitmap);
+                let matched_indices: BTreeSet<u32> = matched.keys().map(|i| *i as u32).collect();
+                let remaining: Vec<u32> = requested_indices
+                    .difference(&matched_indices)
+                    .copied()
+                    .collect();
+                let remaining_bitmap = indices_to_bitmap(&remaining);
+                if remaining.is_empty() {
+                    self.pending_eb_tx_fetches.remove(&hash);
+                } else {
+                    self.pending_eb_tx_fetches
+                        .insert(hash, (eb_slot, remaining_bitmap.clone()));
                 }
-                None => (0, BTreeMap::new()),
-            };
+                (requested_indices.len(), remaining_bitmap)
+            }
+            None => (0, BTreeMap::new()),
+        };
         EbTxMatchOutcome {
             matched_bodies,
             requested,
@@ -1184,9 +1168,9 @@ impl LeiosState {
             return Vec::new();
         }
         let candidates = self.candidates.eb_txs_candidates(&point);
-        let peers =
-            self.eb_txs_policy
-                .pick(&point, &bitmap, &candidates, self.rtt.as_ref());
+        let peers = self
+            .eb_txs_policy
+            .pick(&point, &bitmap, &candidates, self.rtt.as_ref());
         if peers.is_empty() {
             return Vec::new();
         }
@@ -1539,7 +1523,10 @@ mod tests {
         assert_eq!(fx.len(), 2);
         assert!(matches!(fx[0], LeiosEffect::RecordLeiosEbManifest { .. }));
         assert!(matches!(fx[1], LeiosEffect::ValidateEb { .. }));
-        assert_eq!(state.eb_tx_hashes.get(&h(1)).map(|(_, v)| v), Some(&manifest));
+        assert_eq!(
+            state.eb_tx_hashes.get(&h(1)).map(|(_, v)| v),
+            Some(&manifest)
+        );
     }
 
     #[test]
@@ -1573,7 +1560,9 @@ mod tests {
     fn slot_tick_prunes_stale_eb_tx_state_via_chain_progress() {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
         state.eb_tx_hashes.insert(h(1), (10, vec![h(0xAA)]));
-        state.pending_eb_tx_fetches.insert(h(1), (10, BTreeMap::new()));
+        state
+            .pending_eb_tx_fetches
+            .insert(h(1), (10, BTreeMap::new()));
         // No chain tip set → no prune, EB stays even far past the
         // old time-based expiry.
         state.on_slot(1_000_000, &tx_all);
@@ -1643,12 +1632,7 @@ mod tests {
     #[test]
     fn on_eb_txs_offered_origin_point_is_noop() {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
-        let fx = state.on_eb_txs_offered(
-            Point::Origin,
-            PeerId(1),
-            BTreeMap::new(),
-            Instant::now(),
-        );
+        let fx = state.on_eb_txs_offered(Point::Origin, PeerId(1), BTreeMap::new(), Instant::now());
         assert!(fx.is_empty());
     }
 
@@ -1744,7 +1728,9 @@ mod tests {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
         // The retry path consults eb_txs_candidates, so we need at
         // least one peer that hasn't been attempted.
-        state.candidates.note_eb_txs_offered(point(10, 1), PeerId(1));
+        state
+            .candidates
+            .note_eb_txs_offered(point(10, 1), PeerId(1));
         let mut bitmap = BTreeMap::new();
         bitmap.insert(0u16, 0b10u64);
         let fx = state.retry_eb_tx_fetch(point(10, 1), bitmap.clone());
@@ -1781,8 +1767,7 @@ mod tests {
         requested.insert(0u16, 0b11u64);
         state.pending_eb_tx_fetches.insert(h(1), (10, requested));
         // Only body for index 0 (ha) arrives.
-        let outcome =
-            state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
+        let outcome = state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
         assert_eq!(outcome.matched_bodies, vec![b"body-a".to_vec()]);
         assert_eq!(outcome.requested, 2);
         // Index 1 still missing.
@@ -1791,7 +1776,10 @@ mod tests {
         assert_eq!(outcome.remaining_bitmap, expected_remaining);
         // pending_eb_tx_fetches updated to remaining-only.
         assert_eq!(
-            state.pending_eb_tx_fetches.get(&h(1)).map(|(_, b)| b.clone()),
+            state
+                .pending_eb_tx_fetches
+                .get(&h(1))
+                .map(|(_, b)| b.clone()),
             Some(expected_remaining)
         );
     }
@@ -1804,8 +1792,7 @@ mod tests {
         let mut requested = BTreeMap::new();
         requested.insert(0u16, 0b1u64);
         state.pending_eb_tx_fetches.insert(h(1), (10, requested));
-        let outcome =
-            state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
+        let outcome = state.match_eb_tx_response(&point(10, 1), &[(b"body-a".to_vec(), ha)]);
         assert!(outcome.remaining_bitmap.is_empty());
         assert!(!state.pending_eb_tx_fetches.contains_key(&h(1)));
     }
@@ -1813,10 +1800,8 @@ mod tests {
     #[test]
     fn match_eb_tx_response_unknown_manifest_passes_bodies_through() {
         let mut state = LeiosState::new("n0".into(), elections_for("n0"), cfg(0), pipeline());
-        let outcome = state.match_eb_tx_response(
-            &point(10, 1),
-            &[(b"some-body".to_vec(), h(0xAA))],
-        );
+        let outcome =
+            state.match_eb_tx_response(&point(10, 1), &[(b"some-body".to_vec(), h(0xAA))]);
         assert_eq!(outcome.matched_bodies, vec![b"some-body".to_vec()]);
         assert_eq!(outcome.requested, 0);
         assert!(outcome.remaining_bitmap.is_empty());
@@ -1873,9 +1858,7 @@ mod tests {
         assert_eq!(fx.len(), 1, "expected one NoVote, got {fx:?}");
         match &fx[0] {
             LeiosEffect::NoVote {
-                eb_hash: h,
-                reason,
-                ..
+                eb_hash: h, reason, ..
             } => {
                 assert_eq!(*h, eb_hash);
                 assert_eq!(*reason, expected);
@@ -1964,7 +1947,10 @@ mod tests {
         let _ = state.on_slot(30, &tx_all);
 
         assert!(state.candidates.eb_candidates(&point(5, 0xAA)).is_empty());
-        assert!(state.candidates.eb_txs_candidates(&point(5, 0xCC)).is_empty());
+        assert!(state
+            .candidates
+            .eb_txs_candidates(&point(5, 0xCC))
+            .is_empty());
         assert_eq!(state.candidates.eb_candidates(&point(8, 0xBB)), vec![peer]);
         assert_eq!(
             state.candidates.eb_txs_candidates(&point(8, 0xDD)),
@@ -2130,7 +2116,9 @@ mod tests {
             _slot: u64,
         ) -> BehaviourOutcome<LeiosEffect> {
             self.slot_calls += 1;
-            self.slot_reply.clone().unwrap_or(BehaviourOutcome::Continue)
+            self.slot_reply
+                .clone()
+                .unwrap_or(BehaviourOutcome::Continue)
         }
         fn decide_vote(
             &mut self,

--- a/shared-rs/consensus/src/lib.rs
+++ b/shared-rs/consensus/src/lib.rs
@@ -10,6 +10,7 @@ pub mod aggregation;
 pub mod behaviour;
 pub mod bitmap;
 pub mod chain_tree;
+pub mod committee;
 pub mod config;
 pub mod elections;
 pub mod fetch;
@@ -22,7 +23,6 @@ pub mod pipeline;
 pub mod praos;
 pub mod production;
 pub mod types;
-pub mod committee;
 
 pub use config::{CommitteeSelection, StakeEntry};
 pub use peer::PeerId;

--- a/shared-rs/consensus/src/mempool.rs
+++ b/shared-rs/consensus/src/mempool.rs
@@ -79,10 +79,7 @@ pub enum MempoolEffect {
     /// A tx was dropped before reaching the mempool (overflow,
     /// validation failure) or evicted from it.  Telemetry only — the
     /// wrapper forwards this to its events sink.
-    TxRejected {
-        tx_id: TxId,
-        reason: TxRejectReason,
-    },
+    TxRejected { tx_id: TxId, reason: TxRejectReason },
 }
 
 /// Why a tx was rejected.
@@ -255,11 +252,7 @@ impl MempoolState {
 
     /// Validator rejected `tx_id`.  Drops the pending body and emits
     /// `TxRejected { ValidationFailed }`.
-    pub fn on_tx_validation_failed(
-        &mut self,
-        tx_id: TxId,
-        reason: String,
-    ) -> Vec<MempoolEffect> {
+    pub fn on_tx_validation_failed(&mut self, tx_id: TxId, reason: String) -> Vec<MempoolEffect> {
         self.pending_validation.remove(&tx_id);
         vec![MempoolEffect::TxRejected {
             tx_id,
@@ -271,12 +264,7 @@ impl MempoolState {
     /// a locally-produced tx the wrapper has validated against its own
     /// ledger view, or a test fixture.  Bypasses the
     /// `on_tx_received` → `ValidateTx` → `on_tx_validated` dance.
-    pub fn admit_validated(
-        &mut self,
-        tx_id: TxId,
-        body: Vec<u8>,
-        size: u32,
-    ) -> Vec<MempoolEffect> {
+    pub fn admit_validated(&mut self, tx_id: TxId, body: Vec<u8>, size: u32) -> Vec<MempoolEffect> {
         if self.contains(&tx_id) {
             return vec![MempoolEffect::TxRejected {
                 tx_id,
@@ -489,24 +477,21 @@ impl MempoolState {
     /// collection grows without bound across consecutive lines, that's
     /// the leak.
     pub fn log_state_sizes(&self, node_id: &str) {
-        let peer_advertised_total: usize =
-            self.peer_advertised.values().map(|s| s.len()).sum();
+        let peer_advertised_total: usize = self.peer_advertised.values().map(|s| s.len()).sum();
         let peer_advertised_max: usize = self
             .peer_advertised
             .values()
             .map(|s| s.len())
             .max()
             .unwrap_or(0);
-        let peer_unannounced_total: usize =
-            self.peer_unannounced.values().map(|s| s.len()).sum();
+        let peer_unannounced_total: usize = self.peer_unannounced.values().map(|s| s.len()).sum();
         let peer_unannounced_max: usize = self
             .peer_unannounced
             .values()
             .map(|s| s.len())
             .max()
             .unwrap_or(0);
-        let eb_manifest_entries_total: usize =
-            self.eb_manifests.values().map(|v| v.len()).sum();
+        let eb_manifest_entries_total: usize = self.eb_manifests.values().map(|v| v.len()).sum();
         info!(
             node_id,
             txs = self.txs.len(),
@@ -541,11 +526,7 @@ impl MempoolState {
     /// Returns the manifest and any `TxRejected{EbClosurePruned}`
     /// effects emitted when older EB closures aged out of the
     /// retention window.
-    pub fn produce_eb(
-        &mut self,
-        eb_key: EbKey,
-        count: usize,
-    ) -> (Vec<TxId>, Vec<MempoolEffect>) {
+    pub fn produce_eb(&mut self, eb_key: EbKey, count: usize) -> (Vec<TxId>, Vec<MempoolEffect>) {
         let take = count.min(self.txs.len());
         let mut drained: Vec<PendingTx> = Vec::with_capacity(take);
         for _ in 0..take {
@@ -591,14 +572,8 @@ impl MempoolState {
         if self.contains(&tx_id) || self.eb_pinned.contains_key(&tx_id) {
             return;
         }
-        self.eb_pinned.insert(
-            tx_id.clone(),
-            PendingTx {
-                tx_id,
-                body,
-                size,
-            },
-        );
+        self.eb_pinned
+            .insert(tx_id.clone(), PendingTx { tx_id, body, size });
     }
 
     /// True iff the body for `tx_id` is locally available — either
@@ -685,12 +660,7 @@ impl MempoolState {
         fx
     }
 
-    fn admit_internal(
-        &mut self,
-        tx_id: TxId,
-        body: Vec<u8>,
-        size: u32,
-    ) -> Vec<MempoolEffect> {
+    fn admit_internal(&mut self, tx_id: TxId, body: Vec<u8>, size: u32) -> Vec<MempoolEffect> {
         let mut fx = Vec::new();
         if self.txs.len() >= self.capacity {
             if let Some(old) = self.txs.pop_front() {
@@ -716,11 +686,7 @@ impl MempoolState {
         for set in self.peer_unannounced.values_mut() {
             set.insert(tx_id.clone());
         }
-        self.txs.push_back(PendingTx {
-            tx_id,
-            body,
-            size,
-        });
+        self.txs.push_back(PendingTx { tx_id, body, size });
         fx
     }
 
@@ -739,8 +705,7 @@ impl MempoolState {
     /// entry exists.
     fn ensure_peer_registered(&mut self, peer_id: PeerId) {
         if !self.peer_unannounced.contains_key(&peer_id) {
-            self.peer_unannounced
-                .insert(peer_id, self.tx_index.clone());
+            self.peer_unannounced.insert(peer_id, self.tx_index.clone());
         }
     }
 }

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -58,6 +58,23 @@ pub const ORPHAN_COOLDOWN: Duration = Duration::from_secs(1);
 /// long enough for a different one to be picked.
 pub const BLOCK_FETCH_COOLDOWN: Duration = Duration::from_secs(2);
 
+/// How long validation must be frozen with peers offering strictly-better
+/// tips before a stuck-rollup WARN is considered.  Catches genuine wedges
+/// without crying wolf during the short pauses between bursts of
+/// validation.
+pub const STUCK_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// Minimum interval between stuck-rollup WARNs.  The per-event INFO logs
+/// already fire ~1/sec; this rollup is a synthesised once-per-minute
+/// summary aimed at an operator skimming logs.
+pub const STUCK_WARNING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Per-peer cooldown between non-contiguous-header WARNs emitted at
+/// ChainSync ingress.  The signal is "upstream is forwarding a gappy
+/// chain"; reporting every individual gap floods the log without adding
+/// information.
+pub const GAP_WARNING_INTERVAL: Duration = Duration::from_secs(10);
+
 /// Snapshot of [`PraosState`]'s internal collection sizes plus byte
 /// estimates for the equivocation tracking maps.  Emitted per slot via
 /// telemetry so leak rate can be plotted independently of run length.
@@ -248,6 +265,17 @@ pub struct PraosState {
     pub queued_validator_tip: Option<[u8; 32]>,
     /// Hash of the last block the validator has actually `Applied`.
     pub last_validated_tip: Option<[u8; 32]>,
+    /// Wall-clock instant of the last successful validation.  Drives the
+    /// once-per-minute "chain stuck" rollup WARN; `None` until the first
+    /// block is validated so a freshly-booted node doesn't immediately
+    /// complain about being stuck.
+    pub last_validated_at: Option<Instant>,
+    /// Throttle for the stuck-rollup WARN: the timestamp of the most
+    /// recent emission.  Compared against [`STUCK_WARNING_INTERVAL`].
+    pub last_stuck_warning_at: Option<Instant>,
+    /// Per-peer throttle for the ChainSync ingress-time non-contiguous
+    /// header WARN.  Compared against [`GAP_WARNING_INTERVAL`].
+    pub last_gap_warning_at: BTreeMap<PeerId, Instant>,
 
     /// Slot at which this node first observed each header hash.
     /// Populated by [`PraosState::note_header_first_seen`] from any
@@ -324,6 +352,9 @@ impl PraosState {
             in_flight_validation: BTreeSet::new(),
             queued_validator_tip: None,
             last_validated_tip: None,
+            last_validated_at: None,
+            last_stuck_warning_at: None,
+            last_gap_warning_at: BTreeMap::new(),
             header_first_seen: BTreeMap::new(),
             header_hashes_by_slot_issuer: BTreeMap::new(),
             equivocating_rb_slots: BTreeSet::new(),
@@ -653,10 +684,61 @@ impl PraosState {
             prev_hash: header_prev_hash,
         };
         let cap = self.peer_chain_cap();
-        self.peer_chains
+        let chain = self
+            .peer_chains
             .entry(peer_id)
-            .or_insert_with(|| PeerChain::new(cap))
-            .append(entry);
+            .or_insert_with(|| PeerChain::new(cap));
+
+        // Detect non-contiguous ChainSync forwarding: the just-arrived
+        // header should link to the previously-announced one's hash via
+        // `prev_hash`.  When it doesn't, the upstream skipped one or more
+        // blocks on this branch.  PeerChain doesn't enforce contiguity
+        // (sliding-window cap means some divergence is expected at the
+        // anchor edge), so we check explicitly here and only fire when
+        // the previous entry is still in the window — that rules out
+        // anchor-edge false positives.
+        let gap_after_hash = chain.iter().next_back().and_then(|prev| {
+            match (entry.prev_hash, prev.hash) {
+                (Some(p), h) if p != h => {
+                    Some((prev.hash, prev.block_no, prev.point.clone()))
+                }
+                _ => None,
+            }
+        });
+
+        chain.append(entry);
+
+        if let Some((prev_hash, prev_block_no, prev_point)) = gap_after_hash {
+            let now = Instant::now();
+            let throttled = matches!(
+                self.last_gap_warning_at.get(&peer_id),
+                Some(last) if now.saturating_duration_since(*last) < GAP_WARNING_INTERVAL,
+            );
+            if !throttled {
+                warn!(
+                    node_id = %self.node_id,
+                    %peer_id,
+                    prev_block_no,
+                    %prev_point,
+                    prev_hash = format!(
+                        "{:02x}{:02x}{:02x}{:02x}",
+                        prev_hash[0], prev_hash[1], prev_hash[2], prev_hash[3]
+                    ),
+                    new_block_no = header_block_no,
+                    new_prev_hash_expected = format!(
+                        "{:02x}{:02x}{:02x}{:02x}",
+                        prev_hash[0], prev_hash[1], prev_hash[2], prev_hash[3]
+                    ),
+                    new_prev_hash_actual = header_prev_hash.map(|h| format!(
+                        "{:02x}{:02x}{:02x}{:02x}",
+                        h[0], h[1], h[2], h[3]
+                    )).unwrap_or_else(|| "none".to_string()),
+                    gap_block_count = header_block_no.saturating_sub(prev_block_no).saturating_sub(1),
+                    "ChainSync forwarded a non-contiguous header: upstream skipped one or more blocks between the last announced tip and this one"
+                );
+                self.last_gap_warning_at.insert(peer_id, now);
+            }
+        }
     }
 
     /// Store the ChainSync intersection as the peer chain's anchor.
@@ -1007,6 +1089,7 @@ impl PraosState {
         };
         self.validated.insert(hash);
         self.last_validated_tip = Some(hash);
+        self.last_validated_at = Some(now);
         info!(
             node_id = %self.node_id,
             %point,
@@ -1197,7 +1280,87 @@ impl PraosState {
                 }
             }
         }
+        self.maybe_emit_stuck_warning(now);
         fx
+    }
+
+    /// Synthesised once-per-minute WARN that surfaces a wedged-chain
+    /// diagnosis without forcing an operator to grep across the per-event
+    /// INFO traffic.  Fires when:
+    ///
+    /// - we've validated at least one block (otherwise we're still
+    ///   booting, not stuck),
+    /// - validation has been frozen for [`STUCK_THRESHOLD`] or longer,
+    /// - the throttle ([`STUCK_WARNING_INTERVAL`]) has elapsed since the
+    ///   last emission, and
+    /// - some peer announces a strictly-better tip than the one we've
+    ///   adopted (otherwise there's nothing to be stuck on).
+    ///
+    /// The diagnostic counts how many entries in that peer's announced
+    /// replay carry a `prev_hash` we don't have locally (neither in
+    /// `chain_tree` nor in `block_cache`).  A nonzero count means the
+    /// peer's chain has parents we never received — typically because
+    /// ChainSync skipped their headers and BlockFetch range requests
+    /// don't include them either.  In a healthy interop that count is
+    /// zero; a steady nonzero count points the operator at an upstream
+    /// chain inconsistency rather than at a local consensus bug.
+    fn maybe_emit_stuck_warning(&mut self, now: Instant) {
+        let last_validated_at = match self.last_validated_at {
+            Some(t) => t,
+            None => return,
+        };
+        let stuck_for = now.saturating_duration_since(last_validated_at);
+        if stuck_for < STUCK_THRESHOLD {
+            return;
+        }
+        if let Some(last) = self.last_stuck_warning_at {
+            if now.saturating_duration_since(last) < STUCK_WARNING_INTERVAL {
+                return;
+            }
+        }
+        let our_block_no = self
+            .adopted_tip_hash
+            .and_then(|h| self.chain_tree.block_number(&h))
+            .unwrap_or(0);
+        // Pick the peer with the highest announced tip strictly above
+        // ours.  Ties broken by PeerId order so the choice is stable
+        // across calls; the warning is informational, not load-bearing.
+        let best = self
+            .peer_chains
+            .iter()
+            .filter_map(|(pid, chain)| {
+                chain.iter().next_back().map(|e| (*pid, e.block_no, chain))
+            })
+            .filter(|(_, bn, _)| *bn > our_block_no)
+            .max_by_key(|(pid, bn, _)| (*bn, *pid));
+        let (peer_id, peer_tip_block_no, peer_chain) = match best {
+            Some(b) => b,
+            None => return,
+        };
+        let adopted_ancestors: HashSet<[u8; 32]> = self
+            .adopted_tip_hash
+            .map(|h| self.chain_tree.ancestors(h).into_iter().collect())
+            .unwrap_or_default();
+        let unreachable_parents = peer_chain
+            .iter()
+            .filter(|e| match e.prev_hash {
+                Some(p) => {
+                    !adopted_ancestors.contains(&p) && !self.block_cache.contains_key(&p)
+                }
+                None => false,
+            })
+            .count();
+        warn!(
+            node_id = %self.node_id,
+            stuck_secs = stuck_for.as_secs(),
+            adopted_tip_block_no = our_block_no,
+            %peer_id,
+            peer_tip_block_no,
+            unreachable_parent_hashes = unreachable_parents,
+            peer_chain_len = peer_chain.iter().count(),
+            "chain stuck: best peer offers a strictly-better tip but its replay has parent hashes we never received — likely upstream chain inconsistency (gappy ChainSync forwarding)"
+        );
+        self.last_stuck_warning_at = Some(now);
     }
 
     // -- Pure algorithm queries (also used by tests) ------------------------

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -1069,6 +1069,54 @@ impl PraosState {
         fx
     }
 
+    /// Deliberately roll the *own* adopted chain back by `depth` blocks
+    /// and re-anchor at that ancestor, abandoning the suffix, so the next
+    /// block produced forks from there.  Emits `InjectRollback` so the
+    /// served chain store mirrors it — downstream followers then see a
+    /// `RollBackward(depth)` + `RollForward(fork)`.
+    ///
+    /// This is a deliberate self-reorg trigger (the `DeepReorg`
+    /// behaviour); it is *not* part of honest consensus.  No-op if there
+    /// is no adopted tip or the chain is shorter than `depth`.
+    pub fn force_rollback(&mut self, depth: u64) -> Vec<PraosEffect> {
+        let mut fx = Vec::new();
+        if depth == 0 {
+            return fx;
+        }
+        let tip = match self.adopted_tip_hash {
+            Some(h) => h,
+            None => return fx,
+        };
+        // ancestors() yields [tip, parent, grandparent, …]; index `depth`
+        // is the block `depth` steps back.
+        let ancestors = self.chain_tree.ancestors(tip);
+        let target_hash = match ancestors.get(depth as usize) {
+            Some(h) => *h,
+            None => return fx, // chain too short to roll back this far
+        };
+        let target = match self.chain_tree.point(&target_hash) {
+            Some(p) => p.clone(),
+            None => return fx,
+        };
+        let target_bn = self.chain_tree.block_number(&target_hash).unwrap_or(0);
+
+        // Re-anchor every chain-state pointer at the target.
+        self.adopted_tip_hash = Some(target_hash);
+        self.last_validated_tip = Some(target_hash);
+        self.queued_validator_tip = Some(target_hash);
+        // Drop the abandoned suffix so it can't be re-selected as best tip.
+        self.chain_tree.remove_above(target_bn);
+
+        info!(
+            node_id = %self.node_id,
+            %target,
+            depth,
+            "force rollback: self-reorg, abandoning chain suffix"
+        );
+        fx.push(PraosEffect::InjectRollback { target });
+        fx
+    }
+
     // -- Periodic retry -----------------------------------------------------
 
     /// Periodic slot-driven retry: evict stale in-flight fetches and
@@ -2443,6 +2491,39 @@ mod tests {
         s.in_flight.insert(pt(100, 1), stale);
         let _ = s.retry_select_chain(Instant::now());
         assert!(s.in_flight.is_empty());
+    }
+
+    #[test]
+    fn force_rollback_reanchors_and_abandons_suffix() {
+        // Deliberate self-reorg: roll back `depth` blocks, abandon the
+        // suffix, and emit InjectRollback so the served chain mirrors it.
+        let mut s = fresh();
+        install_validated_block(&mut s, 100, 1, 1, None);
+        install_validated_block(&mut s, 101, 2, 2, Some(1));
+        install_validated_block(&mut s, 102, 3, 3, Some(2));
+        install_validated_block(&mut s, 103, 4, 4, Some(3));
+        install_validated_block(&mut s, 104, 5, 5, Some(4));
+        s.adopted_tip_hash = Some(h(5));
+        s.last_validated_tip = Some(h(5));
+
+        let fx = s.force_rollback(2); // 5 -> 3
+
+        assert_eq!(s.adopted_tip_hash, Some(h(3)), "re-anchored 2 blocks back");
+        assert_eq!(
+            s.chain_tree.best_tip_hash(),
+            Some(h(3)),
+            "abandoned suffix pruned; best tip is the target"
+        );
+        assert!(s.chain_tree.block_number(&h(4)).is_none(), "block 4 abandoned");
+        assert!(s.chain_tree.block_number(&h(5)).is_none(), "block 5 abandoned");
+        match fx.as_slice() {
+            [PraosEffect::InjectRollback { target }] => assert_eq!(*target, pt(102, 3)),
+            other => panic!("expected single InjectRollback to block 3, got {other:?}"),
+        }
+
+        // Too-deep / zero rollbacks are no-ops.
+        assert!(s.force_rollback(0).is_empty());
+        assert!(s.force_rollback(999).is_empty());
     }
 
     #[test]

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -758,12 +758,12 @@ impl PraosState {
     pub fn record_peer_disconnected(&mut self, peer_id: PeerId) {
         self.peer_chains.remove(&peer_id);
         self.orphan_cooldown.remove(&peer_id);
+        self.last_gap_warning_at.remove(&peer_id);
     }
 
     // -- High-level event handlers (effect-emitting) ------------------------
 
     /// A peer announced a new tip.  Records it and runs chain selection.
-    #[allow(clippy::too_many_arguments)]
     #[allow(clippy::too_many_arguments)]
     pub fn on_tip_advanced(
         &mut self,
@@ -1338,14 +1338,20 @@ impl PraosState {
             Some(b) => b,
             None => return,
         };
-        let adopted_ancestors: HashSet<[u8; 32]> = self
-            .adopted_tip_hash
-            .map(|h| self.chain_tree.ancestors(h).into_iter().collect())
-            .unwrap_or_default();
+        // "Unreachable" means we have no record of the parent at all,
+        // anywhere in our local view of the network's chain.  Check the
+        // whole `chain_tree` (every fork we've heard of, not just our
+        // adopted ancestry) plus `block_cache` (fetched bodies not yet in
+        // the tree).  Restricting to adopted-tip ancestors here would
+        // false-positive whenever the peer's chain forks off into a
+        // branch we hold but haven't adopted.
         let unreachable_parents = peer_chain
             .iter()
             .filter(|e| match e.prev_hash {
-                Some(p) => !adopted_ancestors.contains(&p) && !self.block_cache.contains_key(&p),
+                Some(p) => {
+                    self.chain_tree.block_number(&p).is_none()
+                        && !self.block_cache.contains_key(&p)
+                }
                 None => false,
             })
             .count();

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -1203,6 +1203,19 @@ impl PraosState {
         self.queued_validator_tip = Some(target_hash);
         // Drop the abandoned suffix so it can't be re-selected as best tip.
         self.chain_tree.remove_above(target_bn);
+        // Evict the suffix from the cache too.  The dedup at the top of
+        // `on_block_received` short-circuits when a hash is already in
+        // `block_cache` / `validated` / `in_flight_validation`, so a peer
+        // re-offering an abandoned block after the reorg would be silently
+        // dropped — `chain_tree` would never re-acquire it and the node
+        // would be pinned on its dead fork.  Mirror the k-prune retention
+        // pattern in `on_block_applied`, opposite direction.
+        self.block_cache.retain(|_, cb| cb.block_no <= target_bn);
+        self.validated.retain(|h| self.block_cache.contains_key(h));
+        self.in_flight_validation
+            .retain(|h| self.block_cache.contains_key(h));
+        self.header_first_seen
+            .retain(|h, _| self.block_cache.contains_key(h));
 
         info!(
             node_id = %self.node_id,
@@ -2705,6 +2718,15 @@ mod tests {
         );
         assert!(s.chain_tree.block_number(&h(4)).is_none(), "block 4 abandoned");
         assert!(s.chain_tree.block_number(&h(5)).is_none(), "block 5 abandoned");
+        // Cache and validated set must also drop the suffix, otherwise the
+        // on_block_received dedup would block re-adoption when a peer
+        // re-offers blocks 4/5.
+        assert!(!s.block_cache.contains_key(&h(4)), "block 4 evicted from cache");
+        assert!(!s.block_cache.contains_key(&h(5)), "block 5 evicted from cache");
+        assert!(s.block_cache.contains_key(&h(3)), "target block kept in cache");
+        assert!(!s.validated.contains(&h(4)), "block 4 cleared from validated");
+        assert!(!s.validated.contains(&h(5)), "block 5 cleared from validated");
+        assert!(s.validated.contains(&h(3)), "target block kept in validated");
         match fx.as_slice() {
             [PraosEffect::InjectRollback { target }] => assert_eq!(*target, pt(102, 3)),
             other => panic!("expected single InjectRollback to block 3, got {other:?}"),

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -1179,39 +1179,20 @@ impl PraosState {
                         && !bridge_cooling
                     {
                         let peers = self.choose_block_fetch_peers(&gap_point, None);
-                        if peers.is_empty() {
-                            // No connected peer can serve this gap, so the
-                            // best tip is on a fork the peers have abandoned
-                            // — typically a deep rollback left us holding
-                            // blocks the peers rolled back past.  Re-issuing
-                            // a peerless fetch is a silent no-op that wedges
-                            // chain selection forever (best_tip never
-                            // advances, the live tip never adopts).  Drop the
-                            // unreachable tip so best_tip falls back to a
-                            // block we can still pursue; ChainSync re-inserts
-                            // it if a peer ever serves that chain again.
-                            info!(
-                                node_id = %self.node_id,
-                                tip = %gap_point,
-                                "retry: best_tip unreachable (no peer offers it); pruning fork tip"
-                            );
-                            self.chain_tree.remove_fork_tip(&best);
-                        } else {
-                            info!(
-                                node_id = %self.node_id,
-                                %from,
-                                to = %gap_point,
-                                peer_count = peers.len(),
-                                "retry: fetching gap to bridge chain_tree"
-                            );
-                            self.in_flight.insert(gap_point.clone(), now);
-                            self.bridge_cooldown = Some((from.clone(), now + BRIDGE_COOLDOWN));
-                            fx.push(PraosEffect::FetchBlockRange {
-                                from,
-                                to: gap_point,
-                                peers,
-                            });
-                        }
+                        info!(
+                            node_id = %self.node_id,
+                            %from,
+                            to = %gap_point,
+                            peer_count = peers.len(),
+                            "retry: fetching gap to bridge chain_tree"
+                        );
+                        self.in_flight.insert(gap_point.clone(), now);
+                        self.bridge_cooldown = Some((from.clone(), now + BRIDGE_COOLDOWN));
+                        fx.push(PraosEffect::FetchBlockRange {
+                            from,
+                            to: gap_point,
+                            peers,
+                        });
                     }
                 }
             }
@@ -1450,54 +1431,31 @@ impl PraosState {
                 let walk_result = self.walk_ancestors_hybrid(last_hash);
                 let walk: HashSet<[u8; 32]> = walk_result.chain.iter().copied().collect();
                 let all_on_chain = replay_hashes.iter().all(|h| walk.contains(h));
-                let reaches_ancestor = if ancestor == [0u8; 32] {
-                    walk_result.reached_origin
-                } else {
-                    walk.contains(&ancestor)
-                };
-                if !all_on_chain || !reaches_ancestor {
-                    // Our cached copy of this (strictly better) candidate
-                    // chain is non-contiguous: the peer fragment skipped a
-                    // header, and that gap block was never fetched because it
-                    // never appeared in `missing` (it isn't in the fragment).
-                    // Abandoning the peer and re-intersecting just loops
-                    // forever — the gap never heals.  Instead, fetch the
-                    // contiguous range from the common ancestor up to the
-                    // candidate tip: a range request needs only the two
-                    // endpoints, and the peer streams every intermediate
-                    // block, filling the gap so a later pass can switch.
-                    //
-                    // A genesis ancestor can't anchor a range (a standard
-                    // server resets the bearer on an Origin lower bound), so
-                    // fall back to the conservative orphan verdict there.
-                    let anchor_pt = if ancestor == [0u8; 32] {
-                        None
-                    } else {
-                        self.chain_tree.point(&ancestor).cloned()
-                    };
-                    if let Some(anchor_pt) = anchor_pt {
-                        info!(
-                            node_id = %self.node_id,
-                            %peer_id,
-                            tip_block_no = candidate_tip.block_no,
-                            all_on_chain,
-                            reaches_ancestor,
-                            "select_chain: cached candidate chain non-contiguous; fetching range to heal gap"
-                        );
-                        return SelectionDecision::WaitingForBlocks {
-                            peer_id,
-                            ancestor,
-                            anchor_point: Some(anchor_pt),
-                            missing: vec![candidate_tip.point.clone()],
-                            tip_block_no: candidate_tip.block_no,
-                        };
-                    }
+                if !all_on_chain {
                     tracing::debug!(
                         node_id = %self.node_id,
                         %peer_id,
                         tip_block_no = candidate_tip.block_no,
                         replay_len = replay_hashes.len(),
-                        "select_chain: non-contiguous replay rooted at genesis; skipping peer"
+                        "select_chain: non-contiguous replay (mixed forks); skipping peer"
+                    );
+                    return SelectionDecision::OrphanCandidate {
+                        peer_id,
+                        tip_block_no: candidate_tip.block_no,
+                    };
+                }
+                let reaches_ancestor = if ancestor == [0u8; 32] {
+                    walk_result.reached_origin
+                } else {
+                    walk.contains(&ancestor)
+                };
+                if !reaches_ancestor {
+                    info!(
+                        node_id = %self.node_id,
+                        %peer_id,
+                        tip_block_no = candidate_tip.block_no,
+                        ancestor = format!("{:02x}{:02x}", ancestor[30], ancestor[31]),
+                        "select_chain: fork mismatch (replay doesn't reach ancestor); skipping peer"
                     );
                     return SelectionDecision::OrphanCandidate {
                         peer_id,
@@ -2651,82 +2609,6 @@ mod tests {
                 SelectionDecision::OrphanCandidate { .. }
             ),
             "reorg of depth 150 > k=100 must be refused"
-        );
-    }
-
-    #[test]
-    fn select_chain_heals_noncontiguous_cached_candidate_via_range_fetch() {
-        // A peer announces a strictly-better chain, but our cached copy has a
-        // gap (the fragment skipped a header that was never fetched).  Rather
-        // than declare it an orphan and loop on re-intersection forever,
-        // select_chain must request the contiguous range [ancestor ..
-        // candidate_tip] so the peer can stream the missing block and heal it.
-        let mut s = fresh();
-        install_validated_block(&mut s, 100, 1, 1, None); // adopted tip = block 1
-        s.adopted_tip_hash = Some(h(1));
-
-        // Cached blocks 2 (prev 1) and 4 (prev 3) — block 3 absent, so the
-        // cached chain 1→2→_→4 is non-contiguous.
-        install_validated_block(&mut s, 101, 2, 2, Some(1));
-        install_validated_block(&mut s, 103, 4, 4, Some(3));
-
-        // Peer fragment skips block 3: announces 2 then 4.
-        let pid = PeerId(7);
-        s.record_peer_tip(pid, pt(101, 2), 2, 2, h(2), 101, Some(h(1)));
-        s.record_peer_tip(pid, pt(103, 4), 4, 4, h(4), 103, Some(h(3)));
-
-        match s.select_chain_once(&HashSet::new()) {
-            SelectionDecision::WaitingForBlocks {
-                anchor_point,
-                missing,
-                ..
-            } => {
-                assert_eq!(
-                    anchor_point,
-                    Some(pt(100, 1)),
-                    "range anchored at the common ancestor (adopted tip)"
-                );
-                assert_eq!(
-                    missing,
-                    vec![pt(103, 4)],
-                    "range extends to the candidate tip so the gap is streamed"
-                );
-            }
-            other => panic!("expected WaitingForBlocks range-heal, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn retry_prunes_unreachable_best_tip_instead_of_peerless_fetch() {
-        // A deep rollback can leave us holding a far-ahead block from a fork
-        // the peers abandoned: it lingers as chain_tree.best_tip, but no
-        // connected peer can serve the gap needed to reach it.  The periodic
-        // retry must drop that tip rather than re-issue a peerless bridge
-        // fetch forever (which wedges selection — best_tip never advances and
-        // the live tip never adopts).
-        let mut s = fresh();
-        install_validated_block(&mut s, 100, 1, 1, None); // adopted tip = block 1
-        s.adopted_tip_hash = Some(h(1));
-
-        // Disconnected fork tip far ahead: block 10 at slot 200 whose parent
-        // h(98) we don't have — as if fetched earlier from a now-abandoned
-        // fork.  Lives in chain_tree only.
-        s.chain_tree
-            .insert(h(10), pt(200, 10), 10, 200, Some(h(98)), 0, None, false);
-        assert_eq!(s.chain_tree.best_tip_hash(), Some(h(10)));
-
-        // No peer chains → no peer offers the gap block.
-        let fx = s.retry_select_chain(Instant::now());
-
-        assert!(
-            !fx.iter()
-                .any(|e| matches!(e, PraosEffect::FetchBlockRange { .. })),
-            "must not emit a peerless bridge fetch"
-        );
-        assert_eq!(
-            s.chain_tree.best_tip_hash(),
-            Some(h(1)),
-            "unreachable fork tip pruned; best_tip falls back to adopted"
         );
     }
 

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -1318,6 +1318,48 @@ impl PraosState {
                 }
             }
         }
+        // Final fallback: trust the ChainSync intersection anchor as the
+        // common ancestor even when it isn't in `adopted_ancestors`.  This
+        // is the multi-peer reconnect-handover case: after reconnecting to
+        // a peer on a divergent fork, our per-peer fragment is too short to
+        // reach the fork point and `adopted_ancestors` may be truncated by
+        // pruning — but `find_intersection` already probed back to genesis,
+        // so its anchor is authoritative.  Bound the switch by k (Praos
+        // finality): a reorg deeper than the security parameter would roll
+        // back settled blocks, so it is refused (the peer is left
+        // unresolved → OrphanCandidate → cooldown, no spin).
+        //
+        // Restricted to a *real block we hold* (not Origin): a switch that
+        // shares only genesis needs a full re-sync from block 1, which the
+        // range-fetch path can't anchor at Origin — that is out of scope
+        // here and not the round-robin-backend case (those share real
+        // history at the fork point).
+        if ancestor.is_none() {
+            if let Some(anchor) = candidate.anchor() {
+                if anchor.hash != [0u8; 32] {
+                    if let Some(anchor_bn) = self.chain_tree.block_number(&anchor.hash) {
+                        let reorg_depth = adopted_bn.saturating_sub(anchor_bn);
+                        if reorg_depth <= self.security_param_k {
+                            info!(
+                                node_id = %self.node_id,
+                                %peer_id,
+                                reorg_depth,
+                                "select_chain: trusting intersection anchor as common ancestor (reorg within k)"
+                            );
+                            ancestor = Some(anchor.hash);
+                        } else {
+                            info!(
+                                node_id = %self.node_id,
+                                %peer_id,
+                                reorg_depth,
+                                k = self.security_param_k,
+                                "select_chain: refusing reorg deeper than k (settled blocks); skipping peer"
+                            );
+                        }
+                    }
+                }
+            }
+        }
         let ancestor = match ancestor {
             Some(a) => a,
             None => {
@@ -2524,6 +2566,66 @@ mod tests {
         // Too-deep / zero rollbacks are no-ops.
         assert!(s.force_rollback(0).is_empty());
         assert!(s.force_rollback(999).is_empty());
+    }
+
+    #[test]
+    fn select_chain_trusts_intersection_anchor_within_k() {
+        // Reconnect-handover: the peer is on a divergent fork; our fragment
+        // doesn't reach the fork point and adopted_ancestors is truncated,
+        // but the ChainSync intersection anchor points at a real block we
+        // hold, within k.  Trust it and switch (WaitingForBlocks), don't
+        // declare orphan.
+        let mut s = fresh(); // k = 100
+        // Adopted tip = block 10, but its parent (9) is absent → ancestors(10)
+        // = {10} (truncated, as after pruning).
+        install_validated_block(&mut s, 110, 10, 10, Some(9));
+        s.adopted_tip_hash = Some(h(10));
+        // A real block 5 we hold — the would-be common ancestor, reorg depth 5.
+        install_validated_block(&mut s, 105, 5, 5, Some(4));
+
+        let pid = PeerId(7);
+        s.record_peer_intersection(pid, pt(105, 5)); // anchor = block 5
+        // Peer fragment: divergent blocks 11, 12 (prev not in our ancestry).
+        s.record_peer_tip(pid, pt(111, 11), 11, 11, h(11), 111, Some(h(99)));
+        s.record_peer_tip(pid, pt(112, 12), 12, 12, h(12), 112, Some(h(11)));
+
+        match s.select_chain_once(&HashSet::new()) {
+            SelectionDecision::WaitingForBlocks {
+                ancestor,
+                anchor_point,
+                ..
+            } => {
+                assert_eq!(ancestor, h(5), "trusts the intersection anchor as ancestor");
+                assert_eq!(
+                    anchor_point,
+                    Some(pt(105, 5)),
+                    "fetch range anchored at the intersection block"
+                );
+            }
+            other => panic!("expected WaitingForBlocks (anchor-trust switch), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_chain_refuses_reorg_deeper_than_k() {
+        // Same shape, but the intersection anchor is deeper than k below the
+        // adopted tip → a settled-block reorg, which must be refused.
+        let mut s = fresh(); // k = 100
+        install_validated_block(&mut s, 300, 200, 200, Some(199));
+        s.adopted_tip_hash = Some(h(200));
+        install_validated_block(&mut s, 150, 50, 50, Some(49)); // depth 150 > k
+
+        let pid = PeerId(7);
+        s.record_peer_intersection(pid, pt(150, 50));
+        s.record_peer_tip(pid, pt(301, 201), 201, 201, h(201), 301, Some(h(99)));
+
+        assert!(
+            matches!(
+                s.select_chain_once(&HashSet::new()),
+                SelectionDecision::OrphanCandidate { .. }
+            ),
+            "reorg of depth 150 > k=100 must be refused"
+        );
     }
 
     #[test]

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -292,8 +292,7 @@ pub struct PraosState {
     /// (`on_block_received`, `register_self_produced`); insertions
     /// that grow a set past size 1 flag the slot in
     /// [`PraosState::equivocating_rb_slots`].
-    pub header_hashes_by_slot_issuer:
-        BTreeMap<(u64, Vec<u8>), BTreeSet<[u8; 32]>>,
+    pub header_hashes_by_slot_issuer: BTreeMap<(u64, Vec<u8>), BTreeSet<[u8; 32]>>,
     /// Slots at which RB-header equivocation has been detected.
     /// CIP-0164's "It has not detected any equivocating RB header for
     /// the same slot" voting condition consults this set via
@@ -395,10 +394,7 @@ impl PraosState {
     }
 
     /// Replace the block-fetch policy.
-    pub fn set_fetch_policy(
-        &mut self,
-        policy: Box<dyn BlockFetchPolicy + Send + Sync>,
-    ) {
+    pub fn set_fetch_policy(&mut self, policy: Box<dyn BlockFetchPolicy + Send + Sync>) {
         self.block_policy = policy;
     }
 
@@ -420,8 +416,12 @@ impl PraosState {
     /// and by `log_state_sizes` for the periodic info line.
     pub fn state_sizes(&self) -> PraosStateSizes {
         let peer_chain_total: usize = self.peer_chains.values().map(|c| c.len()).sum();
-        let peer_chain_max: usize =
-            self.peer_chains.values().map(|c| c.len()).max().unwrap_or(0);
+        let peer_chain_max: usize = self
+            .peer_chains
+            .values()
+            .map(|c| c.len())
+            .max()
+            .unwrap_or(0);
         let issuer_key_count = self.header_hashes_by_slot_issuer.len();
         let issuer_hashes_total: usize = self
             .header_hashes_by_slot_issuer
@@ -431,8 +431,9 @@ impl PraosState {
         // Rough byte estimate: outer BTreeMap entry ~ 100 bytes (key tuple
         // + tree overhead, amortized); each inner BTreeSet<[u8;32]> entry
         // ~ 80 bytes (32-byte hash + tree overhead).
-        let equivocation_bytes_estimate =
-            issuer_key_count * 100 + issuer_hashes_total * 80 + self.equivocating_rb_slots.len() * 56;
+        let equivocation_bytes_estimate = issuer_key_count * 100
+            + issuer_hashes_total * 80
+            + self.equivocating_rb_slots.len() * 56;
         PraosStateSizes {
             chain_tree: self.chain_tree.len(),
             block_cache: self.block_cache.len(),
@@ -544,10 +545,7 @@ impl PraosState {
     /// announced EB hash.  Used by the I/O wrapper to feed
     /// [`crate::leios::LeiosState::on_chain_endorsement`] on every
     /// successful block apply.
-    pub fn parent_announced_eb_for_cert(
-        &self,
-        point: &Point,
-    ) -> Option<(u64, [u8; 32])> {
+    pub fn parent_announced_eb_for_cert(&self, point: &Point) -> Option<(u64, [u8; 32])> {
         let hash = match point {
             Point::Specific { hash, .. } => *hash,
             Point::Origin => return None,
@@ -572,7 +570,9 @@ impl PraosState {
     /// surfaces a header (peer tip announcement, fetched body, self-
     /// produced) without coordinating among them.
     pub fn note_header_first_seen(&mut self, header_hash: [u8; 32], current_slot: u64) {
-        self.header_first_seen.entry(header_hash).or_insert(current_slot);
+        self.header_first_seen
+            .entry(header_hash)
+            .or_insert(current_slot);
     }
 
     /// Record an observed RB header for equivocation detection.
@@ -583,12 +583,7 @@ impl PraosState {
     /// arrives for the same `(slot, issuer)`, the slot is added to
     /// [`Self::equivocating_rb_slots`] and CIP-0164 voters will
     /// abstain from voting on any EB associated with that slot.
-    fn note_header_for_equivocation(
-        &mut self,
-        slot: u64,
-        issuer: &[u8],
-        header_hash: [u8; 32],
-    ) {
+    fn note_header_for_equivocation(&mut self, slot: u64, issuer: &[u8], header_hash: [u8; 32]) {
         if issuer.is_empty() {
             return;
         }
@@ -626,7 +621,9 @@ impl PraosState {
         match self.adopted_tip_hash {
             Some(hash) => {
                 let block_no = self.chain_tree.block_number(&hash);
-                let entries = self.chain_tree.snapshot(hash, 10, block_no, eb_manifest_count);
+                let entries = self
+                    .chain_tree
+                    .snapshot(hash, 10, block_no, eb_manifest_count);
                 let tip_hash = Some(format!("{:02x}{:02x}", hash[30], hash[31]));
                 (entries, block_no, tip_hash)
             }
@@ -641,8 +638,7 @@ impl PraosState {
     /// [`Self::chain_tree_snapshot`] can surface it after the wrapper's
     /// short-lived manifest cache has aged out.
     pub fn record_announced_eb_tx_count(&mut self, eb_hash: &[u8; 32], count: u32) {
-        self.chain_tree
-            .record_announced_eb_tx_count(eb_hash, count);
+        self.chain_tree.record_announced_eb_tx_count(eb_hash, count);
     }
 
     // -- Peer-event mutations (no effects) ----------------------------------
@@ -697,14 +693,14 @@ impl PraosState {
         // anchor edge), so we check explicitly here and only fire when
         // the previous entry is still in the window — that rules out
         // anchor-edge false positives.
-        let gap_after_hash = chain.iter().next_back().and_then(|prev| {
-            match (entry.prev_hash, prev.hash) {
-                (Some(p), h) if p != h => {
-                    Some((prev.hash, prev.block_no, prev.point.clone()))
-                }
-                _ => None,
-            }
-        });
+        let gap_after_hash =
+            chain
+                .iter()
+                .next_back()
+                .and_then(|prev| match (entry.prev_hash, prev.hash) {
+                    (Some(p), h) if p != h => Some((prev.hash, prev.block_no, prev.point.clone())),
+                    _ => None,
+                });
 
         chain.append(entry);
 
@@ -979,11 +975,7 @@ impl PraosState {
 
     /// A peer disconnected; drop its fragment and re-run selection in
     /// case its absence frees up a different peer.
-    pub fn on_peer_disconnected(
-        &mut self,
-        peer_id: PeerId,
-        now: Instant,
-    ) -> Vec<PraosEffect> {
+    pub fn on_peer_disconnected(&mut self, peer_id: PeerId, now: Instant) -> Vec<PraosEffect> {
         use crate::behaviour::BehaviourOutcome;
         let appended: Vec<PraosEffect> =
             match self.invoke_hook(|b, s| b.on_peer_disconnected(s, peer_id)) {
@@ -1035,17 +1027,15 @@ impl PraosState {
                     info.announced_eb_hash,
                     info.certified_eb,
                 );
-                self.block_cache
-                    .entry(hash)
-                    .or_insert(CachedBlock {
-                        point: point.clone(),
-                        block_no: info.block_number,
-                        prev_hash: info.prev_hash,
-                        header: header_bytes,
-                        body: body_bytes.clone(),
-                        announced_eb_hash: info.announced_eb_hash,
-                        certified_eb: info.certified_eb,
-                    });
+                self.block_cache.entry(hash).or_insert(CachedBlock {
+                    point: point.clone(),
+                    block_no: info.block_number,
+                    prev_hash: info.prev_hash,
+                    header: header_bytes,
+                    body: body_bytes.clone(),
+                    announced_eb_hash: info.announced_eb_hash,
+                    certified_eb: info.certified_eb,
+                });
                 self.submit_for_validation_internal(point, body_bytes, info.prev_hash, &mut fx);
                 self.try_switch_and_execute_internal(hash, &mut fx);
             }
@@ -1341,9 +1331,7 @@ impl PraosState {
         let best = self
             .peer_chains
             .iter()
-            .filter_map(|(pid, chain)| {
-                chain.iter().next_back().map(|e| (*pid, e.block_no, chain))
-            })
+            .filter_map(|(pid, chain)| chain.iter().next_back().map(|e| (*pid, e.block_no, chain)))
             .filter(|(_, bn, _)| *bn > our_block_no)
             .max_by_key(|(pid, bn, _)| (*bn, *pid));
         let (peer_id, peer_tip_block_no, peer_chain) = match best {
@@ -1357,9 +1345,7 @@ impl PraosState {
         let unreachable_parents = peer_chain
             .iter()
             .filter(|e| match e.prev_hash {
-                Some(p) => {
-                    !adopted_ancestors.contains(&p) && !self.block_cache.contains_key(&p)
-                }
+                Some(p) => !adopted_ancestors.contains(&p) && !self.block_cache.contains_key(&p),
                 None => false,
             })
             .count();
@@ -1483,9 +1469,7 @@ impl PraosState {
                         // either it's already in the adopted chain's
                         // ancestry, or we have no adopted chain (fresh
                         // node) so any parent is acceptable.
-                        if adopted_ancestors.contains(&parent)
-                            || self.adopted_tip_hash.is_none()
-                        {
+                        if adopted_ancestors.contains(&parent) || self.adopted_tip_hash.is_none() {
                             ancestor = Some(parent);
                         }
                     }
@@ -1998,11 +1982,7 @@ impl PraosState {
     /// in the candidate pool; otherwise the candidate set is the union
     /// of every peer whose announced chain contains `point`.  The
     /// policy then picks one or more from that pool.
-    fn choose_block_fetch_peers(
-        &self,
-        point: &Point,
-        hint: Option<PeerId>,
-    ) -> Vec<PeerId> {
+    fn choose_block_fetch_peers(&self, point: &Point, hint: Option<PeerId>) -> Vec<PeerId> {
         let mut candidates: Vec<PeerId> = self
             .peer_chains
             .iter()
@@ -2017,7 +1997,8 @@ impl PraosState {
                 candidates.push(h);
             }
         }
-        self.block_policy.pick(point, &candidates, self.rtt.as_ref())
+        self.block_policy
+            .pick(point, &candidates, self.rtt.as_ref())
     }
 }
 
@@ -2092,9 +2073,16 @@ mod tests {
         let hash = h(seed);
         let point = pt(slot, seed);
         let prev_hash = prev_seed.map(h);
-        state
-            .chain_tree
-            .insert(hash, point.clone(), block_no, slot, prev_hash, 0, None, false);
+        state.chain_tree.insert(
+            hash,
+            point.clone(),
+            block_no,
+            slot,
+            prev_hash,
+            0,
+            None,
+            false,
+        );
         state.block_cache.insert(
             hash,
             CachedBlock {
@@ -2215,8 +2203,20 @@ mod tests {
     #[test]
     fn two_distinct_headers_same_slot_issuer_flag_slot() {
         let mut s = fresh();
-        s.on_block_received(pt(100, 1), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
-        s.on_block_received(pt(100, 2), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
+        s.on_block_received(
+            pt(100, 1),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
+        s.on_block_received(
+            pt(100, 2),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
         assert!(s.is_equivocating_slot(100));
         assert!(s.equivocating_rb_slots.contains(&100));
     }
@@ -2226,8 +2226,20 @@ mod tests {
         // Two different producers winning the same slot via VRF is a
         // legitimate Praos fork — not equivocation by CIP-0164.
         let mut s = fresh();
-        s.on_block_received(pt(100, 1), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
-        s.on_block_received(pt(100, 2), vec![], vec![], Some(parsed_with_issuer(100, 0xBB)), 0);
+        s.on_block_received(
+            pt(100, 1),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
+        s.on_block_received(
+            pt(100, 2),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xBB)),
+            0,
+        );
         assert!(!s.is_equivocating_slot(100));
     }
 
@@ -2246,7 +2258,13 @@ mod tests {
         // Same hash arriving twice (e.g., from two peers) isn't
         // equivocation — it's the same header.
         let mut s = fresh();
-        s.on_block_received(pt(100, 1), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
+        s.on_block_received(
+            pt(100, 1),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
         // Second on_block_received with the same hash is a no-op via
         // the block_cache dedup; manually probe the tracker invariant.
         s.note_header_for_equivocation(100, &[0xAA; 4], h(1));
@@ -2259,8 +2277,20 @@ mod tests {
         // headers at the same slot equivocates against itself; the
         // tracker honors that.
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
-        s.register_self_produced(pt(100, 2), vec![], vec![], Some(parsed_with_issuer(100, 0xAA)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
+        s.register_self_produced(
+            pt(100, 2),
+            vec![],
+            vec![],
+            Some(parsed_with_issuer(100, 0xAA)),
+            0,
+        );
         assert!(s.is_equivocating_slot(100));
     }
 
@@ -2326,7 +2356,13 @@ mod tests {
     #[test]
     fn adopted_tip_announced_eb_none_for_pre_leios_header() {
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![0xAA], vec![0xBB], Some(hi(1, 100, None)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![0xAA],
+            vec![0xBB],
+            Some(hi(1, 100, None)),
+            0,
+        );
         // hi() defaults announced_eb_hash to None.
         assert_eq!(s.adopted_tip_announced_eb(), None);
     }
@@ -2334,7 +2370,13 @@ mod tests {
     #[test]
     fn note_header_first_seen_is_used_for_arrival() {
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![0xAA], vec![0xBB], Some(hi(1, 100, None)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![0xAA],
+            vec![0xBB],
+            Some(hi(1, 100, None)),
+            0,
+        );
         // Wrapper observed the header at slot 102 (e.g., body arrived
         // 2 slots after the RB's own slot via fetch).
         s.note_header_first_seen(h(1), 102);
@@ -2344,7 +2386,13 @@ mod tests {
     #[test]
     fn note_header_first_seen_is_idempotent() {
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![0xAA], vec![0xBB], Some(hi(1, 100, None)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![0xAA],
+            vec![0xBB],
+            Some(hi(1, 100, None)),
+            0,
+        );
         s.note_header_first_seen(h(1), 105);
         // Subsequent calls don't overwrite — only the first arrival counts.
         s.note_header_first_seen(h(1), 200);
@@ -2354,8 +2402,7 @@ mod tests {
     #[test]
     fn register_self_produced_origin_point_is_noop() {
         let mut s = fresh();
-        let fx =
-            s.register_self_produced(Point::Origin, vec![], vec![], Some(hi(1, 0, None)), 0);
+        let fx = s.register_self_produced(Point::Origin, vec![], vec![], Some(hi(1, 0, None)), 0);
         assert!(fx.is_empty());
         assert!(s.self_produced.contains(&Point::Origin));
     }
@@ -2365,7 +2412,13 @@ mod tests {
     #[test]
     fn on_block_applied_emits_inject_block() {
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![0xAA], vec![0xBB], Some(hi(1, 100, None)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![0xAA],
+            vec![0xBB],
+            Some(hi(1, 100, None)),
+            0,
+        );
         let fx = s.on_block_applied(pt(100, 1), Instant::now());
         assert!(matches!(fx[0], PraosEffect::InjectBlock { .. }));
         assert!(s.validated.contains(&h(1)));
@@ -2387,7 +2440,8 @@ mod tests {
         install_validated_block(&mut s, 101, 2, 2, Some(1));
         install_validated_block(&mut s, 102, 3, 3, Some(2));
         // Stage block 4 in cache (not yet validated).
-        s.chain_tree.insert(h(4), pt(103, 4), 4, 103, Some(h(3)), 0, None, false);
+        s.chain_tree
+            .insert(h(4), pt(103, 4), 4, 103, Some(h(3)), 0, None, false);
         s.block_cache.insert(
             h(4),
             CachedBlock {
@@ -2414,7 +2468,13 @@ mod tests {
     #[test]
     fn on_block_apply_failed_rewinds_to_last_validated() {
         let mut s = fresh();
-        s.register_self_produced(pt(100, 1), vec![0xAA], vec![0xBB], Some(hi(1, 100, None)), 0);
+        s.register_self_produced(
+            pt(100, 1),
+            vec![0xAA],
+            vec![0xBB],
+            Some(hi(1, 100, None)),
+            0,
+        );
         let _ = s.on_block_applied(pt(100, 1), Instant::now());
         s.register_self_produced(
             pt(101, 2),
@@ -2481,7 +2541,9 @@ mod tests {
             Some(hi(1, 100, None)),
             0,
         );
-        assert!(fx.iter().any(|e| matches!(e, PraosEffect::ValidatorApply { .. })));
+        assert!(fx
+            .iter()
+            .any(|e| matches!(e, PraosEffect::ValidatorApply { .. })));
         assert!(s.block_cache.contains_key(&h(1)));
         assert_eq!(s.chain_tree.block_number(&h(1)), Some(1));
     }
@@ -2716,17 +2778,41 @@ mod tests {
             Some(h(3)),
             "abandoned suffix pruned; best tip is the target"
         );
-        assert!(s.chain_tree.block_number(&h(4)).is_none(), "block 4 abandoned");
-        assert!(s.chain_tree.block_number(&h(5)).is_none(), "block 5 abandoned");
+        assert!(
+            s.chain_tree.block_number(&h(4)).is_none(),
+            "block 4 abandoned"
+        );
+        assert!(
+            s.chain_tree.block_number(&h(5)).is_none(),
+            "block 5 abandoned"
+        );
         // Cache and validated set must also drop the suffix, otherwise the
         // on_block_received dedup would block re-adoption when a peer
         // re-offers blocks 4/5.
-        assert!(!s.block_cache.contains_key(&h(4)), "block 4 evicted from cache");
-        assert!(!s.block_cache.contains_key(&h(5)), "block 5 evicted from cache");
-        assert!(s.block_cache.contains_key(&h(3)), "target block kept in cache");
-        assert!(!s.validated.contains(&h(4)), "block 4 cleared from validated");
-        assert!(!s.validated.contains(&h(5)), "block 5 cleared from validated");
-        assert!(s.validated.contains(&h(3)), "target block kept in validated");
+        assert!(
+            !s.block_cache.contains_key(&h(4)),
+            "block 4 evicted from cache"
+        );
+        assert!(
+            !s.block_cache.contains_key(&h(5)),
+            "block 5 evicted from cache"
+        );
+        assert!(
+            s.block_cache.contains_key(&h(3)),
+            "target block kept in cache"
+        );
+        assert!(
+            !s.validated.contains(&h(4)),
+            "block 4 cleared from validated"
+        );
+        assert!(
+            !s.validated.contains(&h(5)),
+            "block 5 cleared from validated"
+        );
+        assert!(
+            s.validated.contains(&h(3)),
+            "target block kept in validated"
+        );
         match fx.as_slice() {
             [PraosEffect::InjectRollback { target }] => assert_eq!(*target, pt(102, 3)),
             other => panic!("expected single InjectRollback to block 3, got {other:?}"),
@@ -2745,8 +2831,8 @@ mod tests {
         // hold, within k.  Trust it and switch (WaitingForBlocks), don't
         // declare orphan.
         let mut s = fresh(); // k = 100
-        // Adopted tip = block 10, but its parent (9) is absent → ancestors(10)
-        // = {10} (truncated, as after pruning).
+                             // Adopted tip = block 10, but its parent (9) is absent → ancestors(10)
+                             // = {10} (truncated, as after pruning).
         install_validated_block(&mut s, 110, 10, 10, Some(9));
         s.adopted_tip_hash = Some(h(10));
         // A real block 5 we hold — the would-be common ancestor, reorg depth 5.
@@ -2754,7 +2840,7 @@ mod tests {
 
         let pid = PeerId(7);
         s.record_peer_intersection(pid, pt(105, 5)); // anchor = block 5
-        // Peer fragment: divergent blocks 11, 12 (prev not in our ancestry).
+                                                     // Peer fragment: divergent blocks 11, 12 (prev not in our ancestry).
         s.record_peer_tip(pid, pt(111, 11), 11, 11, h(11), 111, Some(h(99)));
         s.record_peer_tip(pid, pt(112, 12), 12, 12, h(12), 112, Some(h(11)));
 
@@ -2871,9 +2957,7 @@ mod tests {
 
         let range_of = |fx: &[PraosEffect]| {
             fx.iter().find_map(|e| match e {
-                PraosEffect::FetchBlockRange { from, to, .. } => {
-                    Some((from.clone(), to.clone()))
-                }
+                PraosEffect::FetchBlockRange { from, to, .. } => Some((from.clone(), to.clone())),
                 _ => None,
             })
         };

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -33,6 +33,14 @@ use crate::types::Point;
 /// window, allow a fresh fetch.
 pub const IN_FLIGHT_TTL: Duration = Duration::from_secs(15);
 
+/// Minimum interval between chain_tree gap-bridge fetches anchored at the
+/// same adopted tip.  Without it, an advancing `best_tip` (the live peer
+/// keeps producing) defeats the per-block in-flight dedup — `gap_point`
+/// changes every tick, so the bridge re-issues the entire
+/// `[adopted_tip → best_tip]` range continuously, amplifying block
+/// traffic.  Resets as soon as the adopted tip advances (real progress).
+pub const BRIDGE_COOLDOWN: Duration = Duration::from_secs(10);
+
 /// After a peer is classified as `OrphanCandidate`, this much time must
 /// pass before it is reconsidered for chain selection.  Caps the
 /// orphan-cascade rate at 1/sec per peer even when re-intersection
@@ -226,6 +234,11 @@ pub struct PraosState {
 
     /// Points currently being fetched (avoid duplicate requests).
     pub in_flight: BTreeMap<Point, Instant>,
+    /// Gap-bridge rate-limit: `(adopted_tip_point, next_allowed)`.  The
+    /// bridge re-fetches `[adopted_tip → best_tip]`; this stops it from
+    /// re-issuing every retry tick while `best_tip` advances.  Cleared
+    /// (allowed immediately) when the adopted tip changes.
+    pub bridge_cooldown: Option<(Point, Instant)>,
     /// Hashes already submitted to the validator but not yet
     /// `Applied` / `ApplyFailed`.
     pub in_flight_validation: BTreeSet<[u8; 32]>,
@@ -307,6 +320,7 @@ impl PraosState {
             orphan_cooldown: BTreeMap::new(),
             block_fetch_cooldown: BTreeMap::new(),
             in_flight: BTreeMap::new(),
+            bridge_cooldown: None,
             in_flight_validation: BTreeSet::new(),
             queued_validator_tip: None,
             last_validated_tip: None,
@@ -1152,7 +1166,18 @@ impl PraosState {
                     _ => 0,
                 };
                 if let Some(from) = from {
-                    if to_slot > from_slot && !self.in_flight.contains_key(&gap_point) {
+                    // Rate-limit the bridge: skip if we recently bridged from
+                    // this same adopted tip.  An advancing best_tip changes
+                    // `gap_point` every tick and defeats the in-flight dedup,
+                    // so without this the whole range re-fetches continuously.
+                    let bridge_cooling = matches!(
+                        &self.bridge_cooldown,
+                        Some((cooled_from, until)) if *cooled_from == from && now < *until
+                    );
+                    if to_slot > from_slot
+                        && !self.in_flight.contains_key(&gap_point)
+                        && !bridge_cooling
+                    {
                         let peers = self.choose_block_fetch_peers(&gap_point, None);
                         if peers.is_empty() {
                             // No connected peer can serve this gap, so the
@@ -1180,6 +1205,7 @@ impl PraosState {
                                 "retry: fetching gap to bridge chain_tree"
                             );
                             self.in_flight.insert(gap_point.clone(), now);
+                            self.bridge_cooldown = Some((from.clone(), now + BRIDGE_COOLDOWN));
                             fx.push(PraosEffect::FetchBlockRange {
                                 from,
                                 to: gap_point,

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -1106,19 +1106,38 @@ impl PraosState {
                 if let Some(from) = from {
                     if to_slot > from_slot && !self.in_flight.contains_key(&gap_point) {
                         let peers = self.choose_block_fetch_peers(&gap_point, None);
-                        info!(
-                            node_id = %self.node_id,
-                            %from,
-                            to = %gap_point,
-                            peer_count = peers.len(),
-                            "retry: fetching gap to bridge chain_tree"
-                        );
-                        self.in_flight.insert(gap_point.clone(), now);
-                        fx.push(PraosEffect::FetchBlockRange {
-                            from,
-                            to: gap_point,
-                            peers,
-                        });
+                        if peers.is_empty() {
+                            // No connected peer can serve this gap, so the
+                            // best tip is on a fork the peers have abandoned
+                            // — typically a deep rollback left us holding
+                            // blocks the peers rolled back past.  Re-issuing
+                            // a peerless fetch is a silent no-op that wedges
+                            // chain selection forever (best_tip never
+                            // advances, the live tip never adopts).  Drop the
+                            // unreachable tip so best_tip falls back to a
+                            // block we can still pursue; ChainSync re-inserts
+                            // it if a peer ever serves that chain again.
+                            info!(
+                                node_id = %self.node_id,
+                                tip = %gap_point,
+                                "retry: best_tip unreachable (no peer offers it); pruning fork tip"
+                            );
+                            self.chain_tree.remove_fork_tip(&best);
+                        } else {
+                            info!(
+                                node_id = %self.node_id,
+                                %from,
+                                to = %gap_point,
+                                peer_count = peers.len(),
+                                "retry: fetching gap to bridge chain_tree"
+                            );
+                            self.in_flight.insert(gap_point.clone(), now);
+                            fx.push(PraosEffect::FetchBlockRange {
+                                from,
+                                to: gap_point,
+                                peers,
+                            });
+                        }
                     }
                 }
             }
@@ -1315,31 +1334,54 @@ impl PraosState {
                 let walk_result = self.walk_ancestors_hybrid(last_hash);
                 let walk: HashSet<[u8; 32]> = walk_result.chain.iter().copied().collect();
                 let all_on_chain = replay_hashes.iter().all(|h| walk.contains(h));
-                if !all_on_chain {
-                    tracing::debug!(
-                        node_id = %self.node_id,
-                        %peer_id,
-                        tip_block_no = candidate_tip.block_no,
-                        replay_len = replay_hashes.len(),
-                        "select_chain: non-contiguous replay (mixed forks); skipping peer"
-                    );
-                    return SelectionDecision::OrphanCandidate {
-                        peer_id,
-                        tip_block_no: candidate_tip.block_no,
-                    };
-                }
                 let reaches_ancestor = if ancestor == [0u8; 32] {
                     walk_result.reached_origin
                 } else {
                     walk.contains(&ancestor)
                 };
-                if !reaches_ancestor {
-                    info!(
+                if !all_on_chain || !reaches_ancestor {
+                    // Our cached copy of this (strictly better) candidate
+                    // chain is non-contiguous: the peer fragment skipped a
+                    // header, and that gap block was never fetched because it
+                    // never appeared in `missing` (it isn't in the fragment).
+                    // Abandoning the peer and re-intersecting just loops
+                    // forever — the gap never heals.  Instead, fetch the
+                    // contiguous range from the common ancestor up to the
+                    // candidate tip: a range request needs only the two
+                    // endpoints, and the peer streams every intermediate
+                    // block, filling the gap so a later pass can switch.
+                    //
+                    // A genesis ancestor can't anchor a range (a standard
+                    // server resets the bearer on an Origin lower bound), so
+                    // fall back to the conservative orphan verdict there.
+                    let anchor_pt = if ancestor == [0u8; 32] {
+                        None
+                    } else {
+                        self.chain_tree.point(&ancestor).cloned()
+                    };
+                    if let Some(anchor_pt) = anchor_pt {
+                        info!(
+                            node_id = %self.node_id,
+                            %peer_id,
+                            tip_block_no = candidate_tip.block_no,
+                            all_on_chain,
+                            reaches_ancestor,
+                            "select_chain: cached candidate chain non-contiguous; fetching range to heal gap"
+                        );
+                        return SelectionDecision::WaitingForBlocks {
+                            peer_id,
+                            ancestor,
+                            anchor_point: Some(anchor_pt),
+                            missing: vec![candidate_tip.point.clone()],
+                            tip_block_no: candidate_tip.block_no,
+                        };
+                    }
+                    tracing::debug!(
                         node_id = %self.node_id,
                         %peer_id,
                         tip_block_no = candidate_tip.block_no,
-                        ancestor = format!("{:02x}{:02x}", ancestor[30], ancestor[31]),
-                        "select_chain: fork mismatch (replay doesn't reach ancestor); skipping peer"
+                        replay_len = replay_hashes.len(),
+                        "select_chain: non-contiguous replay rooted at genesis; skipping peer"
                     );
                     return SelectionDecision::OrphanCandidate {
                         peer_id,
@@ -2401,6 +2443,82 @@ mod tests {
         s.in_flight.insert(pt(100, 1), stale);
         let _ = s.retry_select_chain(Instant::now());
         assert!(s.in_flight.is_empty());
+    }
+
+    #[test]
+    fn select_chain_heals_noncontiguous_cached_candidate_via_range_fetch() {
+        // A peer announces a strictly-better chain, but our cached copy has a
+        // gap (the fragment skipped a header that was never fetched).  Rather
+        // than declare it an orphan and loop on re-intersection forever,
+        // select_chain must request the contiguous range [ancestor ..
+        // candidate_tip] so the peer can stream the missing block and heal it.
+        let mut s = fresh();
+        install_validated_block(&mut s, 100, 1, 1, None); // adopted tip = block 1
+        s.adopted_tip_hash = Some(h(1));
+
+        // Cached blocks 2 (prev 1) and 4 (prev 3) — block 3 absent, so the
+        // cached chain 1→2→_→4 is non-contiguous.
+        install_validated_block(&mut s, 101, 2, 2, Some(1));
+        install_validated_block(&mut s, 103, 4, 4, Some(3));
+
+        // Peer fragment skips block 3: announces 2 then 4.
+        let pid = PeerId(7);
+        s.record_peer_tip(pid, pt(101, 2), 2, 2, h(2), 101, Some(h(1)));
+        s.record_peer_tip(pid, pt(103, 4), 4, 4, h(4), 103, Some(h(3)));
+
+        match s.select_chain_once(&HashSet::new()) {
+            SelectionDecision::WaitingForBlocks {
+                anchor_point,
+                missing,
+                ..
+            } => {
+                assert_eq!(
+                    anchor_point,
+                    Some(pt(100, 1)),
+                    "range anchored at the common ancestor (adopted tip)"
+                );
+                assert_eq!(
+                    missing,
+                    vec![pt(103, 4)],
+                    "range extends to the candidate tip so the gap is streamed"
+                );
+            }
+            other => panic!("expected WaitingForBlocks range-heal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_prunes_unreachable_best_tip_instead_of_peerless_fetch() {
+        // A deep rollback can leave us holding a far-ahead block from a fork
+        // the peers abandoned: it lingers as chain_tree.best_tip, but no
+        // connected peer can serve the gap needed to reach it.  The periodic
+        // retry must drop that tip rather than re-issue a peerless bridge
+        // fetch forever (which wedges selection — best_tip never advances and
+        // the live tip never adopts).
+        let mut s = fresh();
+        install_validated_block(&mut s, 100, 1, 1, None); // adopted tip = block 1
+        s.adopted_tip_hash = Some(h(1));
+
+        // Disconnected fork tip far ahead: block 10 at slot 200 whose parent
+        // h(98) we don't have — as if fetched earlier from a now-abandoned
+        // fork.  Lives in chain_tree only.
+        s.chain_tree
+            .insert(h(10), pt(200, 10), 10, 200, Some(h(98)), 0, None, false);
+        assert_eq!(s.chain_tree.best_tip_hash(), Some(h(10)));
+
+        // No peer chains → no peer offers the gap block.
+        let fx = s.retry_select_chain(Instant::now());
+
+        assert!(
+            !fx.iter()
+                .any(|e| matches!(e, PraosEffect::FetchBlockRange { .. })),
+            "must not emit a peerless bridge fetch"
+        );
+        assert_eq!(
+            s.chain_tree.best_tip_hash(),
+            Some(h(1)),
+            "unreachable fork tip pruned; best_tip falls back to adopted"
+        );
     }
 
     #[test]

--- a/shared-rs/consensus/src/praos.rs
+++ b/shared-rs/consensus/src/praos.rs
@@ -95,9 +95,9 @@ pub struct PraosStateSizes {
     pub equivocating_rb_slots: usize,
     pub orphan_cooldown: usize,
     pub block_fetch_cooldown: usize,
-    /// Rough byte estimate covering `header_hashes_by_slot_issuer` (outer
-    /// + inner) and `equivocating_rb_slots`.  Multiplies counts by
-    /// per-entry constants — not exact heap usage.
+    /// Rough byte estimate covering `header_hashes_by_slot_issuer` (outer +
+    /// inner) and `equivocating_rb_slots`.  Multiplies counts by per-entry
+    /// constants — not exact heap usage.
     pub equivocation_bytes_estimate: usize,
 }
 

--- a/shared-rs/consensus/src/production.rs
+++ b/shared-rs/consensus/src/production.rs
@@ -290,7 +290,18 @@ mod tests {
         // the residual ends up in the manifest.
         let mut state = MempoolState::new(100);
         let leios = empty_leios();
-        populate(&mut state, &[(1, 200), (2, 200), (3, 200), (4, 200), (5, 200), (6, 200), (7, 200)]);
+        populate(
+            &mut state,
+            &[
+                (1, 200),
+                (2, 200),
+                (3, 200),
+                (4, 200),
+                (5, 200),
+                (6, 200),
+                (7, 200),
+            ],
+        );
         // 1400 bytes total, RB cap 500 → drain takes [1, 2] (400);
         // residual = [3..7]. EB cap 500 → manifest = first 2 of
         // residual = [3, 4] (400 ≤ 500; next would push to 600).

--- a/shared-rs/tcp-model/src/curve.rs
+++ b/shared-rs/tcp-model/src/curve.rs
@@ -75,7 +75,11 @@ mod tests {
         let seg = CurveSegment::new(D, Curve::Linear);
         approx(seg.interp(1.0, 0.1, Duration::ZERO), 1.0, 1e-12);
         approx(seg.interp(1.0, 0.1, D), 0.1, 1e-12);
-        approx(seg.interp(1.0, 0.1, Duration::from_millis(500)), 0.55, 1e-12);
+        approx(
+            seg.interp(1.0, 0.1, Duration::from_millis(500)),
+            0.55,
+            1e-12,
+        );
     }
 
     #[test]

--- a/shared-rs/tcp-model/src/envelope.rs
+++ b/shared-rs/tcp-model/src/envelope.rs
@@ -144,10 +144,10 @@ mod tests {
             bw_release: CurveSegment::new(ms(2000), Curve::Linear),
             lat_stall: ms(1000),
         };
-        assert!((e.bw_mult_at(ms(1500)) - 0.4).abs() < 1e-12);     // mid-stall
-        assert!((e.bw_mult_at(ms(2000)) - 0.2).abs() < 1e-12);     // stall end → depth
-        assert!((e.bw_mult_at(ms(3000)) - 0.6).abs() < 1e-12);     // halfway recovery
-        assert!((e.bw_mult_at(ms(4000)) - 1.0).abs() < 1e-12);     // fully recovered
+        assert!((e.bw_mult_at(ms(1500)) - 0.4).abs() < 1e-12); // mid-stall
+        assert!((e.bw_mult_at(ms(2000)) - 0.2).abs() < 1e-12); // stall end → depth
+        assert!((e.bw_mult_at(ms(3000)) - 0.6).abs() < 1e-12); // halfway recovery
+        assert!((e.bw_mult_at(ms(4000)) - 1.0).abs() < 1e-12); // fully recovered
     }
 
     #[test]

--- a/shared-rs/tcp-model/src/link.rs
+++ b/shared-rs/tcp-model/src/link.rs
@@ -47,7 +47,10 @@ impl LinkState {
     /// Multiplier on nominal bandwidth at time `t`. `1.0` when no envelope
     /// is active or the active envelope has fully released.
     pub fn bw_mult(&self, t: Duration) -> f64 {
-        self.current.as_ref().map(|e| e.bw_mult_at(t)).unwrap_or(1.0)
+        self.current
+            .as_ref()
+            .map(|e| e.bw_mult_at(t))
+            .unwrap_or(1.0)
     }
 
     /// Stall-window end-time if `t` lies inside an active stall, else `t`.
@@ -196,7 +199,9 @@ impl LinkState {
     }
 
     fn loss_envelope(&self, t: Duration, start_mult: f64, lat_stall: Duration) -> Envelope {
-        let depth = (start_mult * self.cfg.loss_bw_depth).max(1e-6).min(start_mult);
+        let depth = (start_mult * self.cfg.loss_bw_depth)
+            .max(1e-6)
+            .min(start_mult);
         Envelope {
             fired_at: t,
             bw_start: start_mult,

--- a/sim-rs/sim-core/src/config.rs
+++ b/sim-rs/sim-core/src/config.rs
@@ -1532,7 +1532,7 @@ mod consensus_behaviour_tests {
         // total 300, target 120 → cover with 2 nodes (100 + 100).
         let picked: Vec<NodeId> = out.keys().copied().collect();
         assert_eq!(picked, vec![NodeId::new(0), NodeId::new(1)]);
-        for (_, spec) in &out {
+        for spec in out.values() {
             assert!(matches!(spec, BehaviourSpec::LazyVoter { .. }));
         }
     }

--- a/sim-rs/sim-core/src/network/connection.rs
+++ b/sim-rs/sim-core/src/network/connection.rs
@@ -317,6 +317,7 @@ fn compute_bandwidth_delay(total_bps: u64, split: u64, bytes: u64) -> Duration {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use std::time::Duration;
 
@@ -726,6 +727,7 @@ mod tests {
 ///
 /// Both present the same interface so the rest of the network layer can treat
 /// them uniformly.
+#[allow(clippy::large_enum_variant)]
 pub enum ConnectionKind<TProtocol, TMessage> {
     /// Fair-bandwidth-sharing model (the existing `Connection`).
     Simple(Connection<TProtocol, TMessage>),

--- a/sim-rs/sim-core/src/network/tcp_connection.rs
+++ b/sim-rs/sim-core/src/network/tcp_connection.rs
@@ -75,7 +75,7 @@ impl<TMessage> TcpConnection<TMessage> {
             None => now,
         };
 
-        let old_state = std::mem::replace(&mut self.state, TcpState::default());
+        let old_state = std::mem::take(&mut self.state);
         let (forecast, _, new_state) =
             forecast_tcp_msg_send(&self.props, old_state, effective_now, bytes);
         self.state = new_state;


### PR DESCRIPTION
Stacked on `prc/leios-interop` (#931). Adds the consensus reconciliation fixes
and chaos behaviours that recover a stake-0 follower from a wedged catch-up
against the public Leios dev relay, **plus the diagnostic that surfaces
the actual underlying cause as upstream — relay-side ChainSync is
forwarding a non-contiguous header sequence**, not a problem on our side.

## Background and root cause

A stake-0 follower against `leios-node.play.dev.cardano.org:3001`
(magic 164, leios-prototype branch of `cardano-scaling/cardano-blueprint`)
catches up cleanly to roughly block 33,773 and then freezes there, looping
on `select_chain: orphan` or — with this PR's earlier diff — looping on
`fetching range to heal gap` that never closes the gap.

Wire-level investigation during this PR confirmed:

- Around block 33,773 the relay's ChainSync starts forwarding
  **non-contiguous headers** — block 33,776's announced `prev_hash`
  doesn't match block 33,773's hash (the gap is the missing blocks
  33,774 and 33,775).  This happens at the moment of forward, not as
  any side effect on our side.
- The same upstream condition recurs ~1,026 times in the range
  33,774–39,478 (avg gap 1.35 block_nos, max 8).
- A subsequent `MsgRequestRange [adopted_tip → peer_best_tip]` returns
  a deterministic 5,615-block response that's byte-identical across
  retries and **does not include any of the gap blocks**.
- Cross-backend test (pinned-IP configs against each of the three
  EC2 backends, `eu-central-1`, `eu-west-1`, `us-east-2`) showed
  current-day chain content agreeing across two of the three
  backends — i.e. the cluster is in sync now, but the chain content
  above block 33,773 **changed at least once during a single day's
  testing** (same backend served `89c8…` for block 33,775's hash in
  the morning and `f0162a91…` in the afternoon).  Consistent with a
  relay-side resync / snapshot restore mid-day.

The wedge is therefore an upstream condition, not a chain-selection
bug we can fix here.  This PR keeps the recovery improvements that
*are* genuinely on our side, removes the heal-non-contig attempt
that turned out to be dead-on-arrival in the field, and adds the
diagnostic logs that point an operator straight at the upstream
cause.

## Commits

1. **`praos: trust the ChainSync intersection anchor as the common ancestor`** — core reconciliation fix.  After reconnecting to a peer on a divergent fork, the per-peer fragment is too short to reach the fork point and `adopted_ancestors` may have been pruned, so the better peer was classified orphan forever.  `find_intersection` already probes back to genesis, so its anchor is authoritative: trust it when it's a real block we hold and the reorg is within k (Praos finality — deeper is refused).  Genesis/Origin anchors excluded.
2. **`mux: RunningMux::abort must cancel the muxer/demuxer, not just the supervisor`** — abort only cancelled the supervisor, leaving the muxer/demuxer (which own the TCP halves) running, so a dropped peer's socket stayed open until the 60s keepalive timeout.  Affects all abort-driven teardown.
3. **`coordinator: throttle re-intersection per address`** — graceful exponential back-off (1s→30s) keyed by peer *address* (stable across the reconnect handovers that change `PeerId`), so an unreconcilable peer can't spin.  The throttle's effect is visible via the rate of `select_chain: orphan` log lines flattening after the first burst.
4. **`praos: rate-limit the chain_tree gap-bridge`** — the gap-bridge re-fetched `[adopted_tip → best_tip]` gated only on the moving `gap_point`; an advancing `best_tip` defeats the in-flight dedup, so the whole range re-fetched every tick (~44 blocks/s with the tip frozen).  Rate-limit per adopted tip (`BRIDGE_COOLDOWN` 10s), reset when the adopted tip advances.
5. **`behaviour: add DeepReorg`** and **`behaviour: add DropInboundPeers`** — deterministic chaos behaviours used to reproduce the orphan/reconnect-handover wedges offline.  Opt-in (no runtime change by default).
6. **`net-node: configs for the public Leios dev relay`** — the dev-relay base + overlay configs.  `fetch_policy.eb_txs = "no_fetch"` works around the relay's RST on `MsgLeiosBlockTxsRequest` (see [cardano-scaling/cardano-blueprint#68](https://github.com/cardano-scaling/cardano-blueprint/issues/68)).
7. **`praos: surface upstream gappy ChainSync via two complementary WARNs`** — two operator-facing diagnostics:
   - *Ingress-time*: in `record_peer_tip`, when an arriving header's `prev_hash` doesn't link to the previously-announced one's hash, WARN with the (block_no, hash) pairs and the implied gap size.  Throttled per peer (10s).  Fires the moment upstream commits the offence.
   - *Rollup*: in `retry_select_chain`, when validation has been frozen for ≥30s and some peer offers a strictly-better tip, WARN once per minute with stuck duration, adopted vs best-peer block_no, and the count of entries in that peer's replay whose parent_hash we don't have locally.  Covers the general "stuck for any reason" case.
8. **Reverts of `praos: heal non-contiguous candidate chains` and its test fixup** — the heal-non-contig path was added to bridge the gap upstream of itself, but live testing showed the relay's range response doesn't include the gap blocks (the same ones missing from ChainSync), so the heal path was dead-on-arrival.  The retained `coordinator: throttle re-intersection` and `praos: rate-limit gap-bridge` provide sufficient cost-bounding without it.

## Validation

- **Unit tests**: `shared-consensus` 310 passed, `net-node` 112 passed, `net-core` 318 passed, `sim-rs` 79 passed.
- **Live relay** (multiple runs today):
  - Catch-up 0→33,773 is clean: `recv == valid` 1:1, no orphan loops, no codec errors.
  - At block 33,774 the ingress-time WARN fires with the expected block_no and the actual mismatched prev_hash (e.g. expected `5fc9a5ce…`, actual `f0162a91…`).
  - 30s later the stuck rollup fires with `unreachable_parent_hashes > 0`.
  - Both WARNs respect their throttles (10s per peer / 60s for the rollup) under sustained wedge load.

## Operational note (not part of this PR's scope)

The dev relay's three A records resolve to three different AWS regions
(`eu-central-1`, `eu-west-1`, `us-east-2`).  Catch-up rate from a
European workstation is ~4× slower against the `us-east-2` backend
purely due to RTT (95 ms vs ~21 ms in the EU regions).  Devops
reportedly believes the backends should be in the same class; the
spread is worth a separate flag.

## Reproduction

```
cargo build --release -p net-node
cargo run --release -p net-node -- \
    --config net-rs/net-node/configs/leios-dev.toml \
    --config net-rs/net-node/configs/follow-dev-relay.toml
```

Wait ~10–15 min for catch-up to reach block 33,773.  Watch for `ChainSync
forwarded a non-contiguous header` followed (after 30s) by `chain stuck:
…likely upstream chain inconsistency`.

## Scope notes

- The real relay case (deep-but-shared fork, real-block intersection anchor) is handled and unit-proven.
- Genesis-only divergence between independent producers is intentionally not auto-switched (two independent producers can't share history since block hash binds issuer/`node_id` → diverge at block 1).

Base is `prc/leios-interop`; retarget to `main` (or rebase) once #931 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)