### PR TITLE
net-core: encode LeiosFetch bitmaps as indefinite-length

### DIFF
--- a/net-rs/net-core/src/protocols/leios_fetch/codec.rs
+++ b/net-rs/net-core/src/protocols/leios_fetch/codec.rs
@@ -183,11 +183,16 @@ fn encode_bitmap<W: minicbor::encode::Write>(
     e: &mut Encoder<W>,
     bitmap: &BTreeMap<u16, u64>,
 ) -> Result<(), EncodeError<W::Error>> {
-    e.map(bitmap.len() as u64)?;
+    // Indefinite-length map per the leios-prototype CDDL:
+    //   bitmaps = { * base.word16 => base.word64 }  ; indefinite-length
+    // The prototype relay's parser rejects the definite-length form
+    // and immediately RSTs the bearer on receipt.
+    e.begin_map()?;
     for (index, bits) in bitmap {
         e.u16(*index)?;
         e.u64(*bits)?;
     }
+    e.end()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

The `leios-prototype` CDDL defines the bitmap field in
`MsgLeiosBlockTxsRequest` / `MsgLeiosBlockTxs` as an **indefinite-length** map:

```cddl
; indefinite-length map from 64-tx window index to 64-bit presence bitmap
bitmaps = { * base.word16 => base.word64 }
```

Our codec was encoding it as a **definite-length** map
(`e.map(len)` writes a CBOR major-5 header with explicit length).
The reference relay (`leios-node.play.dev.cardano.org`,
`cardano-scaling/cardano-blueprint` `leios-prototype` branch) enforces
the indefinite form: receiving the definite variant triggers an
**immediate TCP RST** within ~25–45 ms of the `MsgLeiosBlockTxsRequest`,
tearing down the bearer before any reply is sent.

This was the wire incompatibility behind the `fetch_policy.eb_txs = "no_fetch"` workaround in net-rs's dev-relay configs (see
[#934](https://github.com/input-output-hk/ouroboros-leios/pull/934)).

## Fix

Switch `encode_bitmap` from `e.map(len)` to `e.begin_map()` / `e.end()`
— same pattern TxSubmission uses for its indefinite-length inner
lists.  Decoder already handles both forms.

## Validation

- `cargo test -p net-core leios_fetch` — 36 passed (existing codec
  round-trip tests stayed green; they don't pin definite-vs-indefinite
  because the decoder accepts both).
- **Live relay**: with the fix in place, `MsgLeiosBlockTxsRequest`
  is accepted and the relay streams back the EB-tx list cleanly:

  ```
  shared_consensus::leios: leios block txs received
    point=1001150/08a3fc4ee529ba6f count=512
  ```

  Zero connection resets, zero decode errors.  Reproducible on first
  EB-tx attempt against the live dev relay.

## Related

- Closes the "Known follow-up" noted in
  [`2bb330e1d` (net: align LeiosFetch with the prototype CDDL)](https://github.com/input-output-hk/ouroboros-leios/commit/2bb330e1d).
- The blueprint comment already says "indefinite-length", so no
  blueprint change is required; this is purely an implementation
  alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)