### PR TITLE
sim-rs: fix build by migrating to spec-faithful Praos lottery API

### DIFF
--- a/sim-rs/sim-core/src/sim/shared_consensus.rs
+++ b/sim-rs/sim-core/src/sim/shared_consensus.rs
@@ -596,10 +596,10 @@ impl NodeImpl for SharedConsensus {
         // Praos RB lottery — shared formula with net-rs, sim-rs keeps
         // its own VRF draw form (`Rng::draw_range`).
         let success_rate = self.sim_config.block_generation_probability;
-        let target = con_lottery::rb_win_threshold(success_rate, self.config_stake);
-        let total_stake = self.total_stake;
+        let params = con_lottery::LotteryParams::new(success_rate);
+        let target = params.rb_win_threshold(self.config_stake, self.total_stake);
         let rng = Rng::new(self.sim_config.seed);
-        let draw = rng.draw_range(self.id, slot, DrawSite::RbLottery, total_stake);
+        let draw = rng.draw_u64(self.id, slot, DrawSite::RbLottery);
         if draw < target {
             self.try_produce_rb(slot, draw, &mut out);
         }


### PR DESCRIPTION
## Problem

`sim-rs` no longer builds on `main`:

```
error[E0425]: cannot find function `rb_win_threshold` in module `con_lottery`
   --> sim-core/src/sim/shared_consensus.rs:599:35
```

Commit `758d38a87` ("shared-consensus, net-node: spec-faithful Praos lottery threshold") replaced the linear lottery approximation `(stake * f) as u64` with the exact Praos formula `φ(σ) = 1 − (1 − f)^σ`, changing the shared-consensus API:

- **Old:** free fn `rb_win_threshold(rate: f64, stake: u64) -> u64`, draw over `[0, total_stake)`
- **New:** `LotteryParams::new(f).rb_win_threshold(stake, total_stake) -> u64`, full-width draw over `[0, 2^64)`

That commit updated net-node's call site but **missed sim-rs's** in `shared_consensus.rs`. Since shared-consensus is a separate crate, sim-rs only broke when recompiled against the new API.

## Fix

Apply the same migration net-node received:

- Construct `LotteryParams::new(success_rate)` and call `.rb_win_threshold(self.config_stake, self.total_stake)`.
- Switch the draw from `draw_range(.., total_stake)` (range `[0, total_stake)`) to `draw_u64(..)` (range `[0, 2^64)`) so it matches the new threshold scale.

The draw is only stored opaquely as the RB header's `vrf` field, so the wider range is harmless (and more VRF-faithful).

As a side benefit this also picks up the bug `758d38a87` was fixing: the old truncation locked any node with `stake × f < 1` out of the lottery entirely.

## Testing

- `cargo build --release` — succeeds
- `cargo test -p sim-core` — 79 passed, 0 failed, 1 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)