### PR TITLE
demo/proto-devnet: don't start tx-centrifuge until nodes are ready

### DIFF
--- a/demo/proto-devnet/process-compose.yaml
+++ b/demo/proto-devnet/process-compose.yaml
@@ -9,6 +9,12 @@ processes:
       PORT="${PORT_NODE1}" \
       bash "${SOURCE_DIR}/run-node.sh"
     log_location: "${WORKING_DIR}/node1/node.log"
+    readiness_probe:
+      exec:
+        command: "bash -c ': </dev/tcp/${IP_NODE1}/${PORT_NODE1}'"
+      initial_delay_seconds: 5
+      period_seconds: 2
+      failure_threshold: 60
 
   Node2:
     command: |
@@ -17,6 +23,12 @@ processes:
       PORT="${PORT_NODE2}" \
       bash "${SOURCE_DIR}/run-node.sh"
     log_location: "${WORKING_DIR}/node2/node.log"
+    readiness_probe:
+      exec:
+        command: "bash -c ': </dev/tcp/${IP_NODE2}/${PORT_NODE2}'"
+      initial_delay_seconds: 5
+      period_seconds: 2
+      failure_threshold: 60
 
   Node3:
     command: |
@@ -25,6 +37,12 @@ processes:
       PORT="${PORT_NODE3}" \
       bash "${SOURCE_DIR}/run-node.sh"
     log_location: "${WORKING_DIR}/node3/node.log"
+    readiness_probe:
+      exec:
+        command: "bash -c ': </dev/tcp/${IP_NODE3}/${PORT_NODE3}'"
+      initial_delay_seconds: 5
+      period_seconds: 2
+      failure_threshold: 60
 
   TxCentrifuge:
     working_dir: ${WORKING_DIR}
@@ -32,11 +50,11 @@ processes:
     log_location: "${WORKING_DIR}/tx-centrifuge.log"
     depends_on:
       Node1:
-        condition: process_started
+        condition: process_healthy
       Node2:
-        condition: process_started
+        condition: process_healthy
       Node3:
-        condition: process_started
+        condition: process_healthy
 
   ObserveTip:
     environment:


### PR DESCRIPTION
When I ran `run.sh` locally, `tx-centrifuge` would immediately fail, complaining about the Node1 socket file not being present.

This is Claude's suggested fix, which seems reasonable to me.