### PR TITLE
demo/proto-devnet: also ObserveTip for Node2 and Node3, just far less often

### DIFF
--- a/demo/proto-devnet/process-compose.yaml
+++ b/demo/proto-devnet/process-compose.yaml
@@ -65,3 +65,23 @@ processes:
     depends_on:
       Node1:
         condition: process_started
+
+  ObserveTip2:
+    environment:
+      - CARDANO_NODE_NETWORK_ID=164
+      - CARDANO_NODE_SOCKET_PATH=${WORKING_DIR}/node2/node.socket
+    command: watch -n10 "cardano-cli query tip && cardano-cli query tx-mempool info"
+    is_interactive: true
+    depends_on:
+      Node2:
+        condition: process_started
+
+  ObserveTip3:
+    environment:
+      - CARDANO_NODE_NETWORK_ID=164
+      - CARDANO_NODE_SOCKET_PATH=${WORKING_DIR}/node3/node.socket
+    command: watch -n10 "cardano-cli query tip && cardano-cli query tx-mempool info"
+    is_interactive: true
+    depends_on:
+      Node3:
+        condition: process_started


### PR DESCRIPTION
It's helpful to be able to easily see that the nodes are all on the same chain from within the `process-compose` TUI.