### PR TITLE
Fix Moog CLI download for new asset naming

### DIFF
--- a/.github/workflows/antithesis-leios.yaml
+++ b/.github/workflows/antithesis-leios.yaml
@@ -273,9 +273,10 @@ jobs:
 
       - name: Download and install Moog
         run: |
+          VERSION="${MOOG_TAG#v}"
           gh release download "$MOOG_TAG" \
             -R cardano-foundation/moog \
-            -p "moog-*-linux64.tar.gz" -O moog.tar.gz
+            -p "moog-${VERSION}-x86_64-linux-musl.tar.gz" -O moog.tar.gz
           tar xzf moog.tar.gz
           sudo mv moog /usr/local/bin/
           moog --version


### PR DESCRIPTION
The antithesis-leios workflow downloaded the Moog CLI with the glob "moog-*-linux64.tar.gz". As of Moog v0.5.1.3 the release asset naming changed and no "*-linux64.tar.gz" asset exists, so "gh release download" failed with "no assets match the file pattern", breaking CI on main.

Update the pattern to the current convention,
"moog-<version>-x86_64-linux-musl.tar.gz", deriving the version from the release tag. The v2.0.1 CLI interface (facts test-runs, requester create-test, and the MOOG_* env vars) is unchanged, so no other updates are needed.

Resolves #944