### PR TITLE
docs: update leios-tools links to input-output-hk org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Two technical report snapshots capture the R&D trajectory: [report 1](docs/techn
 
 The repository contains two independent simulations of the Leios protocol, each with its own README covering build instructions, configuration parameters, and Docker usage.
 
-[sim-rs/](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs) is a high-performance Rust simulation producing JSONL or CBOR traces and is the actively maintained simulation. [simulation/](simulation/) is an earlier Haskell simulation with built-in Gtk+ visualisation; it predates the move away from input blocks and is no longer up to date with the current protocol design. Both read shared topology and configuration files from [data/](data/).
+[sim-rs/](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs) is a high-performance Rust simulation producing JSONL or CBOR traces and is the actively maintained simulation. [simulation/](simulation/) is an earlier Haskell simulation with built-in Gtk+ visualisation; it predates the move away from input blocks and is no longer up to date with the current protocol design. Both read shared topology and configuration files from [data/](data/).
 
 Traces from either simulation can be explored in the [web-based visualiser](ui/), which also supports live streaming from a running network via Loki. Docker images for both simulations are built from the root [Dockerfile](Dockerfile).
 

--- a/analysis/sims/2026w18/CLAUDE.md
+++ b/analysis/sims/2026w18/CLAUDE.md
@@ -41,8 +41,8 @@ and saves all outputs into a `{voting-mode}/seed-{N}/` subdirectory.
 | `--turbo` | *(default)* | Sequential DES, 6-shard zero-latency-clusters |
 | `--actor` | | Async actor engine (non-deterministic) |
 | `--sequential` | | Sequential DES, single shard |
-| `--memory-limit` | off | Apply backlog caps from [`sim-rs/parameters/memory-limit.yaml`](https://github.com/cardano-scaling/leios-tools/blob/main/sim-rs/parameters/memory-limit.yaml) (generated=10, peer=10000, max-age=24). Note: these caps **alter behaviour** at high throughput — generated=10 drops ~17% of TXs at 0.350 TxMB/s. Avoid for production runs. |
-| `--memory-limit-file PATH` | | Use a custom memory-limit YAML instead of the default; PATH is relative to [`sim-rs/parameters/`](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs/parameters). |
+| `--memory-limit` | off | Apply backlog caps from [`sim-rs/parameters/memory-limit.yaml`](https://github.com/input-output-hk/leios-tools/blob/main/sim-rs/parameters/memory-limit.yaml) (generated=10, peer=10000, max-age=24). Note: these caps **alter behaviour** at high throughput — generated=10 drops ~17% of TXs at 0.350 TxMB/s. Avoid for production runs. |
+| `--memory-limit-file PATH` | | Use a custom memory-limit YAML instead of the default; PATH is relative to [`sim-rs/parameters/`](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs/parameters). |
 | `--quorum-fraction F` | `0.75` | Quorum fraction for vote threshold |
 | `--stake-fraction F` | `0.99` | Stake fraction for top-stake-fraction mode |
 | `--topology NAME` | `topology-v2` | Basename of topology file under `data/simulation/pseudo-mainnet/` (e.g. `topology-v2-1500` for 1500 nodes) |
@@ -171,7 +171,7 @@ Concrete values:
 | `topology-v2` (750 nodes) | 750 | 458 | 292 | 450 | 563 | 160 (top-213) |
 | `topology-v2-1500` | 1500 | 458 | 1042 | 450 | 1125 | 336 (top-448) |
 
-Note that `everyone` and `top-stake-fraction` use *persistent* vote sizes/CPU costs (no VRF eligibility proof needed since selection is deterministic), so each individual vote is smaller and cheaper than a `wfa-ls` non-persistent vote. See `vote_weighted_average` in [`sim-rs/sim-core/src/config.rs`](https://github.com/cardano-scaling/leios-tools/blob/main/sim-rs/sim-core/src/config.rs).
+Note that `everyone` and `top-stake-fraction` use *persistent* vote sizes/CPU costs (no VRF eligibility proof needed since selection is deterministic), so each individual vote is smaller and cheaper than a `wfa-ls` non-persistent vote. See `vote_weighted_average` in [`sim-rs/sim-core/src/config.rs`](https://github.com/input-output-hk/leios-tools/blob/main/sim-rs/sim-core/src/config.rs).
 
 ## Engine modes
 

--- a/analysis/sims/ReadMe.md
+++ b/analysis/sims/ReadMe.md
@@ -19,7 +19,7 @@ Instructions for building the Haskell simulator `ols` are available in [/simulat
 
 ### Rust simulator
 
-Instructions for building the Rust simulator `sim-cli` are available in [/sim-rs/](https://github.com/cardano-scaling/leios-tools/blob/main/sim-rs/README.md).
+Instructions for building the Rust simulator `sim-cli` are available in [/sim-rs/](https://github.com/input-output-hk/leios-tools/blob/main/sim-rs/README.md).
 
 
 ### Building the trace processor
@@ -245,7 +245,7 @@ These instructions are valid for the folders `2025w25/` and onwards. Earlier fol
     - *Nix:* use the default dev shell of the `sims/` flake `nix develop ..`
 3. Copy or link the Rust simulator `sim-cli` executable to that folder.
     - If you want to reproduce the study, check out the git commit listed in the `sim-cli.hash` file.
-    - Build with `cargo build --release` in the [sim-rs](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs) folder.
+    - Build with `cargo build --release` in the [sim-rs](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs) folder.
     - Link with `ln -s ../../../sim-rs/target/release/sim-cli` from the study folder.
 4. Copy of link the Haskell `leios-trace-processor` executable to that folder.
     - *Cabal:* compile using `cabal build all`.

--- a/analysis/sims/trace-processor/ReadMe.md
+++ b/analysis/sims/trace-processor/ReadMe.md
@@ -1,6 +1,6 @@
 # Data processing tool for simulation traces
 
-The `leios-trace-processor` reads simulation trace log files from the Leios [Haskell](../../../simulation/) or [Rust](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs) simulator, analyzes them, and formats the results as CSV files.
+The `leios-trace-processor` reads simulation trace log files from the Leios [Haskell](../../../simulation/) or [Rust](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs) simulator, analyzes them, and formats the results as CSV files.
 
 
 ## Running the tool

--- a/docs/technical-report-1.md
+++ b/docs/technical-report-1.md
@@ -337,23 +337,23 @@ For more details on each parameter, refer to the comments in the
 
 ### Rust simulation
 
-The Rust simulator, found in the [sim-rs/](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs) folder, contains the
+The Rust simulator, found in the [sim-rs/](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs) folder, contains the
 following crates.
 
 - The `sim-cli` crate provides a command-line interface for controlling the
   simulation.
 - The `sim-core` crate implements the simulation itself.
 
-![Container diagram of Rust simulation](https://raw.githubusercontent.com/cardano-scaling/leios-tools/main/sim-rs/docs/container.png)
+![Container diagram of Rust simulation](https://raw.githubusercontent.com/input-output-hk/leios-tools/main/sim-rs/docs/container.png)
 
 The simulation is partitioned into components that deal with the protocol
 itself, network transport, event logging, and configuration.
 
-![Component diagram of Rust simulation](https://raw.githubusercontent.com/cardano-scaling/leios-tools/main/sim-rs/docs/component.png)
+![Component diagram of Rust simulation](https://raw.githubusercontent.com/input-output-hk/leios-tools/main/sim-rs/docs/component.png)
 
 #### Running the simulator
 
-Execute the following in the [sim-rs/](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs) folder to run the Rust
+Execute the following in the [sim-rs/](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs) folder to run the Rust
 simulation of Short Leios.
 
 ```sh

--- a/net-rs/README.md
+++ b/net-rs/README.md
@@ -2,8 +2,8 @@
 
 The Rust networking simulator (`net-rs`) now lives in its own repository:
 
-**https://github.com/cardano-scaling/leios-tools/tree/main/net-rs**
+**https://github.com/input-output-hk/leios-tools/tree/main/net-rs**
 
 It was extracted from this monorepo together with `sim-rs` and `shared-rs`,
 with full git history preserved. Please file issues and open pull requests
-against [cardano-scaling/leios-tools](https://github.com/cardano-scaling/leios-tools).
+against [input-output-hk/leios-tools](https://github.com/input-output-hk/leios-tools).

--- a/shared-rs/README.md
+++ b/shared-rs/README.md
@@ -3,8 +3,8 @@
 The shared Rust crates (`shared-rs`, e.g. `consensus` and `tcp-model`) now
 live in their own repository:
 
-**https://github.com/cardano-scaling/leios-tools/tree/main/shared-rs**
+**https://github.com/input-output-hk/leios-tools/tree/main/shared-rs**
 
 It was extracted from this monorepo together with `sim-rs` and `net-rs`,
 with full git history preserved. Please file issues and open pull requests
-against [cardano-scaling/leios-tools](https://github.com/cardano-scaling/leios-tools).
+against [input-output-hk/leios-tools](https://github.com/input-output-hk/leios-tools).

--- a/sim-rs/README.md
+++ b/sim-rs/README.md
@@ -2,8 +2,8 @@
 
 The Rust Leios simulator (`sim-rs`) now lives in its own repository:
 
-**https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs**
+**https://github.com/input-output-hk/leios-tools/tree/main/sim-rs**
 
 It was extracted from this monorepo together with `net-rs` and `shared-rs`,
 with full git history preserved. Please file issues and open pull requests
-against [cardano-scaling/leios-tools](https://github.com/cardano-scaling/leios-tools).
+against [input-output-hk/leios-tools](https://github.com/input-output-hk/leios-tools).

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,7 +1,7 @@
 This directory contains an early Haskell simulation and visualisation code for Ouroboros Leios.
 
 > [!NOTE]
-> This simulation predates the move away from input blocks and implements Short Leios, which is no longer the current protocol design. For up-to-date simulation work see [sim-rs/](https://github.com/cardano-scaling/leios-tools/tree/main/sim-rs). The visualisations of Praos and basic network behaviour are still useful, but the Leios-specific parts are outdated.
+> This simulation predates the move away from input blocks and implements Short Leios, which is no longer the current protocol design. For up-to-date simulation work see [sim-rs/](https://github.com/input-output-hk/leios-tools/tree/main/sim-rs). The visualisations of Praos and basic network behaviour are still useful, but the Leios-specific parts are outdated.
 
 The simulations are not completely configurable from the command line.
 The code for the simulation configurations needs to be adjusted or

--- a/ui/README.md
+++ b/ui/README.md
@@ -27,7 +27,7 @@ nix run .#ui-live
 ## Add a scenario from sim-rs
 
 The Rust Leios simulator (`sim-rs`) and a few baseline topologies (`small.yaml`,
-`thousand.yaml`) now live in [cardano-scaling/leios-tools](https://github.com/cardano-scaling/leios-tools).
+`thousand.yaml`) now live in [input-output-hk/leios-tools](https://github.com/input-output-hk/leios-tools).
 Bundled topologies in `public/topologies/` are kept here directly.
 
 To add a new topology, drop the YAML file in `public/topologies/`. Then generate


### PR DESCRIPTION
The `leios-tools` repo (`sim-rs` / `net-rs` / `shared-rs`) moved from
`cardano-scaling/leios-tools` to `input-output-hk/leios-tools`. This repoints
all forwarding links and embedded diagram image URLs to the new org.

## Changes
- 19 URL references across 10 files: `cardano-scaling/leios-tools` → `input-output-hk/leios-tools`
- Covers both `github.com/...` tree/blob links and `raw.githubusercontent.com/...` image URLs
- The stub READMEs (`sim-rs/`, `net-rs/`, `shared-rs/`) and top-level pointers (`README.md`, `simulation/README.md`, `ui/README.md`) now point to the new location
- Verified every linked path still exists on `main` of the new repo (incl. the `sim-rs/docs/*.png` diagrams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)