### PR TITLE
Release prototype-2026w27b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ We are using the ouroboros-leios repository to cut releases on preliminary versi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 As a minor extension, we may also keep `UNRELEASED` changes on top of it.
 
+## prototype-2026w27b - 2026-07-08
+
+Fixes permanent stalling when syncing from genesis.
+
+- Fix use of headerContainsLeiosCert for HFC
+- Fix pruning logic which was deleting some EBs from an acquired set of EBs
+- Fix pipelined LeiosFetch client from incorrect discards
+- Fix NTC chainsync server certificate gate on EB inlining
+
 ## prototype-2026w27a - 2026-07-08
 
 The partial fix to the previous `prototype-2026w27` release.
@@ -13,7 +22,6 @@ but still suffering from the stall when syncing from Genesis.
 
 - Fix SQLite segfaults due to use after free in `sqlite3_finalize`.
 - Improve SQLite LeiosDB performance that uses `JSON1` queries
-
 
 ## prototype-2026w27 - 2026-07-05
 

--- a/flake.lock
+++ b/flake.lock
@@ -553,11 +553,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1783503711,
-        "narHash": "sha256-Gsgs5cGqxxKjUYFEfT8B5Pv6HW4VikDHcZqYklIlHyg=",
+        "lastModified": 1783552177,
+        "narHash": "sha256-KnbQ1T8d6CV4JfYRKzMmssiRnzuohOC1tD118CB0R2g=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "439bda73310137ee29faaca66a71c1f878875384",
+        "rev": "3be9f2e28cfa2f1c23d2f2b461787a552a140c91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Release of `prototype-2026w27b` which fixes permanent stalling when syncing from genesis.