### PR TITLE
Add saw tooth graph of last EB events

### DIFF
--- a/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
+++ b/demo/proto-devnet/config/dashboards/proto-devnet-throughput.json
@@ -357,6 +357,160 @@
       ],
       "title": "Confirmed tx throughput",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "last_over_time({service=\"cardano-node\", ns=\"Consensus.LeiosKernel.BlockAnnounced\"} | label_format ts=`{{ __timestamp__.UnixMilli }}` | unwrap ts [1h])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "announced_ts",
+          "queryType": "range",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "last_over_time({service=\"cardano-node\", ns=\"Consensus.LeiosKernel.BlockCertified\"} | label_format ts=`{{ __timestamp__.UnixMilli }}` | unwrap ts [1h])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "certified_ts",
+          "queryType": "range",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Time since last Leios EB event",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "since last EB announced",
+            "binary": {
+              "left": "Time",
+              "operator": "-",
+              "right": "announced_ts"
+            },
+            "mode": "binary",
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "since last EB certified",
+            "binary": {
+              "left": "Time",
+              "operator": "-",
+              "right": "certified_ts"
+            },
+            "mode": "binary",
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "announced_ts": true,
+              "certified_ts": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -374,5 +528,5 @@
   "timezone": "browser",
   "title": "Proto DevNet - Throughput",
   "uid": "gg7w7r",
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
https://github.com/IntersectMBO/ouroboros-consensus/pull/2105 implements the code that allows applying and EB certification and announcing a new EB in the same forging opportunity.

This PR adds a new pane to the `Proto DevNet - Throughput` Graphana dashboard that displays how much time has passed since the last EB certificate application and announcement.

<img width="2215" height="727" alt="announced-and-certified" src="https://github.com/user-attachments/assets/e0b8c159-5763-471a-a75f-d4645036213c" />
