### PR TITLE
Fix a few bugs in the ./ui visualizer

### DIFF
--- a/demo/extras/x-ray/build.nix
+++ b/demo/extras/x-ray/build.nix
@@ -15,6 +15,7 @@
           packages = [
             pkgs.nettools
             pkgs.netcat
+            pkgs.caddy
             pkgs.grafana
             pkgs.grafana-alloy
             pkgs.grafana-loki

--- a/demo/extras/x-ray/env.sh
+++ b/demo/extras/x-ray/env.sh
@@ -11,8 +11,9 @@
 : "${ALLOY_CONFIG:=${XRAY_SOURCE_DIR}/alloy}"
 : "${PROMETHEUS_CONFIG:=${XRAY_SOURCE_DIR}/prometheus.yaml}"
 : "${LOKI_CONFIG:=${XRAY_SOURCE_DIR}/loki.yaml}"
+: "${CADDYFILE:=${XRAY_SOURCE_DIR}/Caddyfile}"
 : "${SS_FILTER:=( sport = 3001 and dport = 3002 ) or ( sport = 3002 and dport = 3001 ) or ( sport = 3002 and dport = 3003 ) or ( sport = 3003 and dport = 3002 )}"
 : "${DEMO_DASHBOARDS_DIR:=${WORKING_DIR}/demo-dashboards}"
 
 # shellcheck disable=SC2034
-XRAY_REQUIRED_COMMANDS=(prometheus loki grafana alloy ss_http_exporter process-compose)
+XRAY_REQUIRED_COMMANDS=(prometheus loki grafana alloy ss_http_exporter process-compose caddy)

--- a/demo/extras/x-ray/process-compose.yaml
+++ b/demo/extras/x-ray/process-compose.yaml
@@ -40,6 +40,28 @@ processes:
     availability:
       restart: "always"
 
+  # Using caddy server as CORS-enabled proxy of Loki
+  #
+  # The visualizer in ./ui needs CORS in order to use `query_range` endpoint
+  # instead of `tail`. The `tail` endpoint is known to sometimes drop messages,
+  # which leads to nonsensical visualizations such as more receives than sends.
+  LokiCORS:
+    namespace: x-ray
+    command: |
+      set -exuo pipefail;
+
+      # Caddy insists on writable data/config dirs; keep them in WORKING_DIR.
+      export XDG_DATA_HOME="$WORKING_DIR/caddy/data";
+      export XDG_CONFIG_HOME="$WORKING_DIR/caddy/config";
+      mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME";
+
+      caddy run --adapter caddyfile --config "$CADDYFILE";
+    depends_on:
+      Loki:
+        condition: "process_started"
+    availability:
+      restart: "always"
+
   Alloy:
     namespace: x-ray
     command: |

--- a/ui/public/scenarios.json
+++ b/ui/public/scenarios.json
@@ -25,13 +25,13 @@
       "name": "Demo Prototype Burst",
       "topology": "topologies/burst.yaml",
       "duration": 300,
-      "loki": "localhost:3100"
+      "loki": "localhost:3101"
     },
     {
       "name": "Demo Prototype Devnet",
       "topology": "topologies/proto-devnet.yaml",
       "duration": 300,
-      "loki": "localhost:3100"
+      "loki": "localhost:3101"
     }
   ]
 }

--- a/ui/src/components/Graph/hooks/useHandlers.ts
+++ b/ui/src/components/Graph/hooks/useHandlers.ts
@@ -162,7 +162,14 @@ export const useHandlers = () => {
       }
 
       context.lineWidth = Math.min((0.2 / canvasScale) * 6, 0.2);
+      // Dotted until a message has crossed this edge (in either direction),
+      // solid thereafter — so links that are never used stay visibly dashed.
+      if (!aggregatedData.traversedEdges.has(edgeKey)) {
+        const dash = context.lineWidth * 3;
+        context.setLineDash([dash, dash]);
+      }
       context.stroke();
+      context.setLineDash([]);
     });
 
     // Draw the nodes

--- a/ui/src/components/Sim/hooks/lokiWorker.ts
+++ b/ui/src/components/Sim/hooks/lokiWorker.ts
@@ -1,9 +1,15 @@
-// Web Worker that owns the Loki tail WebSocket and runs the parser chain
-// off the main thread. The main thread's only job is to dispatch the
-// already-typed event batches into the reducer, which keeps the WebSocket
-// reader from falling behind Loki's internal tail buffer (the cause of the
-// silent `dropped_entries` losses we observed when this was all on the
-// main thread).
+// Web Worker that polls Loki's query_range HTTP API off the main thread.
+//
+// We poll query_range rather than the /tail WebSocket: /tail is best-effort
+// and silently omits entries (not counted in `dropped_entries`), whereas
+// query_range returns the complete window. A sliding window with overlap
+// tolerates Loki's ingestion latency, and the dedup below removes both the
+// re-scanned overlap and Loki's duplicate-ingested copies (the Alloy pipeline
+// stores each cardano line more than once).
+//
+// Loki serves no CORS headers, so the demo fronts it with a small CORS-adding
+// reverse proxy (see demo/extras/x-ray); the scenario's `loki` host points at
+// that proxy and the fetch below hits it directly.
 
 import { IServerMessage } from "@/components/Sim/types";
 import { parseStreamValue, resetPendingState } from "./lokiParsers";
@@ -24,130 +30,170 @@ export type LokiWorkerResponse =
 
 const QUERY =
   '{service="cardano-node"} |~ "BlockFetchServer|MsgBlock|CompletedBlockFetch|MsgLeiosBlock|MsgLeiosBlockTxs|LeiosBlockForged|TraceForgedBlock|TraceAdoptedBlock|LeiosBlockAnnounced|LeiosBlockCertified|MsgLeiosVotes|LeiosVoted"';
+
+const POLL_INTERVAL_MS = 1000;
+const MAX_ENTRIES = 5000;
+const NS_PER_SEC = 1_000_000_000n;
+// How far back the first poll reaches (backfill on connect).
+const INITIAL_LOOKBACK_NS = 1800n * NS_PER_SEC;
+// Overlap re-scanned each poll so entries ingested late (Alloy scrapes files
+// every 5s) are still picked up; dedup drops the repeats.
+const OVERLAP_NS = 15n * NS_PER_SEC;
 const MAX_RETRY_DELAY_MS = 30000;
 
-let ws: WebSocket | null = null;
-let cancelled = false;
-let retryCount = 0;
-let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-// Loki's tail can deliver the same entry more than once — even on a single
-// connection — via backfill/live overlap and overlapping poll windows. Each
-// entry is redelivered with its original timestamp, so (raw tsNs + message
-// identity) is a stable per-entry key. Bounded because redelivery only ever
-// repeats recent entries; a generous cap covers the overlap window without
-// unbounded growth over a long run.
+// Dedup: a stable per-entry key (raw tsNs + message identity). Loki redelivers
+// (double-writes) entries with their original timestamp, and the sliding
+// window re-scans an overlap, so the same entry is seen more than once.
 const seenEntryKeys = new Set<string>();
 const SEEN_ENTRY_CAP = 200_000;
 
+let cancelled = false;
+let connected = false;
+let host = "";
+let sinceNs = 0n;
+let retryCount = 0;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
 const post = (msg: LokiWorkerResponse) => postMessage(msg);
+const nowNs = (): bigint => BigInt(Date.now()) * 1_000_000n;
+const setState = (state: LokiConnectionState) =>
+  post({ type: "CONNECTION_STATE", state });
 
-const closeSocket = () => {
-  if (retryTimeoutId !== null) {
-    clearTimeout(retryTimeoutId);
-    retryTimeoutId = null;
-  }
-  if (ws) {
-    ws.close();
-    ws = null;
+const clearTimer = () => {
+  if (pollTimer !== null) {
+    clearTimeout(pollTimer);
+    pollTimer = null;
   }
 };
 
-const connect = (lokiHost: string) => {
+const schedule = (delayMs: number) => {
+  clearTimer();
+  if (!cancelled) pollTimer = setTimeout(() => void poll(), delayMs);
+};
+
+async function poll(): Promise<void> {
   if (cancelled) return;
-  const wsUrl = `ws://${lokiHost}/loki/api/v1/tail?query=${encodeURIComponent(QUERY)}&limit=5000`;
-  console.log(`[lokiWorker] Connecting (attempt ${retryCount + 1}):`, wsUrl);
-  post({ type: "CONNECTION_STATE", state: "Connecting" });
+  const end = nowNs();
+  const params = new URLSearchParams({
+    query: QUERY,
+    start: sinceNs.toString(),
+    end: end.toString(),
+    limit: String(MAX_ENTRIES),
+    direction: "forward",
+  });
 
-  ws = new WebSocket(wsUrl);
-
-  ws.onopen = () => {
-    retryCount = 0;
-    post({ type: "CONNECTION_STATE", state: "Connected" });
+  let json: {
+    data?: { result?: { stream: unknown; values?: [string, string][] }[] };
   };
-
-  ws.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data);
-
-      // Loki signals tail-buffer drops via this array. Surfacing the count
-      // lets the UI tell apart "no event ever fired" from "event fired but
-      // we lost it on the consumer side."
-      if (Array.isArray(data.dropped_entries) && data.dropped_entries.length) {
-        post({ type: "DROPPED", count: data.dropped_entries.length });
-      }
-
-      if (!Array.isArray(data.streams)) return;
-      const events: IServerMessage[] = [];
-
-      for (const stream of data.streams) {
-        if (!Array.isArray(stream.values)) continue;
-        for (const [tsNs, logLine] of stream.values as [string, string][]) {
-          const ts = parseFloat(tsNs) / 1_000_000_000;
-          const parsed = parseStreamValue(stream.stream, ts, logLine);
-          if (!parsed) continue;
-          const m = parsed.message as {
-            type: string;
-            id?: string;
-            sender?: string;
-            recipient?: string;
-          };
-          // Key on the RAW tsNs string (not the lossy float) + message identity.
-          const key = `${tsNs}|${m.type}|${m.id ?? ""}|${m.sender ?? ""}|${m.recipient ?? ""}`;
-          if (seenEntryKeys.has(key)) continue; // redelivered entry — drop
-          if (seenEntryKeys.size >= SEEN_ENTRY_CAP) {
-            seenEntryKeys.delete(seenEntryKeys.values().next().value as string);
-          }
-          seenEntryKeys.add(key);
-          events.push(parsed);
-        }
-      }
-
-      if (events.length > 0) {
-        post({ type: "EVENTS", events });
-      }
-    } catch (error) {
-      console.error("[lokiWorker] Error processing Loki message:", error);
-    }
-  };
-
-  const scheduleRetry = () => {
-    if (cancelled) return;
+  try {
+    const resp = await fetch(
+      `http://${host}/loki/api/v1/query_range?${params.toString()}`,
+    );
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    json = await resp.json();
+  } catch (error) {
+    console.error("[lokiWorker] query_range failed:", error);
+    connected = false;
     retryCount++;
-    const delay = Math.min(1000 * Math.pow(2, retryCount - 1), MAX_RETRY_DELAY_MS);
-    console.log(`[lokiWorker] Retrying in ${delay}ms (attempt ${retryCount})`);
-    retryTimeoutId = setTimeout(() => {
-      if (!cancelled) connect(lokiHost);
-    }, delay);
-  };
+    setState("Connecting");
+    schedule(Math.min(1000 * 2 ** (retryCount - 1), MAX_RETRY_DELAY_MS));
+    return;
+  }
+  retryCount = 0;
+  if (!connected) {
+    connected = true;
+    setState("Connected");
+  }
 
-  ws.onerror = (error) => {
-    console.error("[lokiWorker] WebSocket error:", error);
-    scheduleRetry();
-  };
+  const events: IServerMessage[] = [];
+  let count = 0;
+  let maxTs = 0n;
 
-  ws.onclose = (event) => {
-    console.log("[lokiWorker] WebSocket closed:", event.code, event.reason);
-    if (!cancelled) {
-      scheduleRetry();
-    } else {
-      post({ type: "CONNECTION_STATE", state: "NotConnected" });
+  // query_range groups the response by stream (one per distinct label set), so
+  // entries are ordered within a stream but not globally. The parser correlates
+  // events that live in different streams via module-level pending maps
+  // (ForgedBlock -> AdoptedBlock for the RB's parent/endorsement, cert -> forge,
+  // announcement -> forge), and that only works if it sees them in timestamp
+  // order. Flatten every stream and sort by tsNs before parsing.
+  const entries: Array<{
+    tsNs: string;
+    labels: Record<string, string>;
+    logLine: string;
+  }> = [];
+  for (const stream of json?.data?.result ?? []) {
+    for (const [tsNs, logLine] of stream.values ?? []) {
+      entries.push({
+        tsNs,
+        labels: stream.stream as Record<string, string>,
+        logLine,
+      });
     }
-  };
-};
+  }
+  entries.sort((a, b) => {
+    const x = BigInt(a.tsNs);
+    const y = BigInt(b.tsNs);
+    return x < y ? -1 : x > y ? 1 : 0;
+  });
+
+  for (const { tsNs, labels, logLine } of entries) {
+    count++;
+    const tsBig = BigInt(tsNs);
+    if (tsBig > maxTs) maxTs = tsBig;
+    const parsed = parseStreamValue(
+      labels,
+      Number(tsNs) / 1_000_000_000,
+      logLine,
+    );
+    if (!parsed) continue;
+    const m = parsed.message as {
+      type: string;
+      id?: string;
+      sender?: string;
+      recipient?: string;
+    };
+    const key = `${tsNs}|${m.type}|${m.id ?? ""}|${m.sender ?? ""}|${m.recipient ?? ""}`;
+    if (seenEntryKeys.has(key)) continue;
+    if (seenEntryKeys.size >= SEEN_ENTRY_CAP) {
+      seenEntryKeys.delete(seenEntryKeys.values().next().value as string);
+    }
+    seenEntryKeys.add(key);
+    events.push(parsed);
+  }
+
+  if (events.length > 0) {
+    post({ type: "EVENTS", events });
+  }
+
+  if (count >= MAX_ENTRIES && maxTs > 0n) {
+    // Window hit the entry cap; direction=forward gave us the oldest
+    // MAX_ENTRIES. Advance to the newest we saw (inclusive re-fetch; dedup
+    // covers it) and poll again promptly to drain the rest without a gap.
+    console.warn(`[lokiWorker] query_range hit ${MAX_ENTRIES} entries; paginating`);
+    sinceNs = maxTs;
+    schedule(0);
+  } else {
+    const next = end - OVERLAP_NS;
+    sinceNs = next > sinceNs ? next : sinceNs;
+    schedule(POLL_INTERVAL_MS);
+  }
+}
 
 self.onmessage = (e: MessageEvent<LokiWorkerRequest>) => {
   const req = e.data;
   if (req.type === "CONNECT") {
     cancelled = false;
+    connected = false;
+    host = req.lokiHost;
     retryCount = 0;
     resetPendingState();
     seenEntryKeys.clear();
-    closeSocket();
-    connect(req.lokiHost);
+    sinceNs = nowNs() - INITIAL_LOOKBACK_NS;
+    clearTimer();
+    setState("Connecting");
+    void poll();
   } else if (req.type === "DISCONNECT") {
     cancelled = true;
-    closeSocket();
-    post({ type: "CONNECTION_STATE", state: "NotConnected" });
+    clearTimer();
+    setState("NotConnected");
   }
 };

--- a/ui/src/components/Sim/hooks/lokiWorker.ts
+++ b/ui/src/components/Sim/hooks/lokiWorker.ts
@@ -28,8 +28,18 @@ export type LokiWorkerResponse =
   | { type: "EVENTS"; events: IServerMessage[] }
   | { type: "DROPPED"; count: number };
 
+// Alloy writes each cardano-node line to Loki twice: once before it promotes
+// the JSON `kind` to a stream label and once after, so every event exists in
+// both a `kind=""` stream and a `kind="..."` stream with byte-identical content.
+// The `kind=""` set is the complete one (the labelled set omits events whose
+// kind is nested, e.g. TraceSendRecv, so it never gets the label); selecting it
+// here delivers every event exactly once. That keeps the parser's stateful
+// correlation (cert -> forge -> adopt, which populates an RB's parent and
+// certified EB) from being corrupted by a duplicate forge. NB: this couples us
+// to that Alloy behaviour — if the pipeline stops emitting the pre-label copy,
+// this selector must change.
 const QUERY =
-  '{service="cardano-node"} |~ "BlockFetchServer|MsgBlock|CompletedBlockFetch|MsgLeiosBlock|MsgLeiosBlockTxs|LeiosBlockForged|TraceForgedBlock|TraceAdoptedBlock|LeiosBlockAnnounced|LeiosBlockCertified|MsgLeiosVotes|LeiosVoted"';
+  '{service="cardano-node", kind=""} |~ "BlockFetchServer|MsgBlock|CompletedBlockFetch|MsgLeiosBlock|MsgLeiosBlockTxs|LeiosBlockForged|TraceForgedBlock|TraceAdoptedBlock|LeiosBlockAnnounced|LeiosBlockCertified|MsgLeiosVotes|LeiosVoted"';
 
 const POLL_INTERVAL_MS = 1000;
 const MAX_ENTRIES = 5000;
@@ -41,9 +51,10 @@ const INITIAL_LOOKBACK_NS = 1800n * NS_PER_SEC;
 const OVERLAP_NS = 15n * NS_PER_SEC;
 const MAX_RETRY_DELAY_MS = 30000;
 
-// Dedup: a stable per-entry key (raw tsNs + message identity). Loki redelivers
-// (double-writes) entries with their original timestamp, and the sliding
-// window re-scans an overlap, so the same entry is seen more than once.
+// Dedup the sliding-window overlap: the same entry is re-fetched on consecutive
+// polls (with its original tsNs), so drop repeats keyed by (tsNs + message
+// identity). The Alloy double-write is handled upstream by the QUERY selector,
+// not here.
 const seenEntryKeys = new Set<string>();
 const SEEN_ENTRY_CAP = 200_000;
 

--- a/ui/src/components/Sim/hooks/lokiWorker.ts
+++ b/ui/src/components/Sim/hooks/lokiWorker.ts
@@ -31,6 +31,15 @@ let cancelled = false;
 let retryCount = 0;
 let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
+// Loki's tail can deliver the same entry more than once — even on a single
+// connection — via backfill/live overlap and overlapping poll windows. Each
+// entry is redelivered with its original timestamp, so (raw tsNs + message
+// identity) is a stable per-entry key. Bounded because redelivery only ever
+// repeats recent entries; a generous cap covers the overlap window without
+// unbounded growth over a long run.
+const seenEntryKeys = new Set<string>();
+const SEEN_ENTRY_CAP = 200_000;
+
 const post = (msg: LokiWorkerResponse) => postMessage(msg);
 
 const closeSocket = () => {
@@ -76,7 +85,21 @@ const connect = (lokiHost: string) => {
         for (const [tsNs, logLine] of stream.values as [string, string][]) {
           const ts = parseFloat(tsNs) / 1_000_000_000;
           const parsed = parseStreamValue(stream.stream, ts, logLine);
-          if (parsed) events.push(parsed);
+          if (!parsed) continue;
+          const m = parsed.message as {
+            type: string;
+            id?: string;
+            sender?: string;
+            recipient?: string;
+          };
+          // Key on the RAW tsNs string (not the lossy float) + message identity.
+          const key = `${tsNs}|${m.type}|${m.id ?? ""}|${m.sender ?? ""}|${m.recipient ?? ""}`;
+          if (seenEntryKeys.has(key)) continue; // redelivered entry — drop
+          if (seenEntryKeys.size >= SEEN_ENTRY_CAP) {
+            seenEntryKeys.delete(seenEntryKeys.values().next().value as string);
+          }
+          seenEntryKeys.add(key);
+          events.push(parsed);
         }
       }
 
@@ -119,6 +142,7 @@ self.onmessage = (e: MessageEvent<LokiWorkerRequest>) => {
     cancelled = false;
     retryCount = 0;
     resetPendingState();
+    seenEntryKeys.clear();
     closeSocket();
     connect(req.lokiHost);
   } else if (req.type === "DISCONNECT") {

--- a/ui/src/contexts/SimContext/context.ts
+++ b/ui/src/contexts/SimContext/context.ts
@@ -15,6 +15,7 @@ export const defaultAggregatedData: ISimulationAggregatedDataState = {
   },
   messages: [],
   edges: new Map(),
+  traversedEdges: new Set(),
   nodeActivity: new Map(),
   eventCounts: {
     total: 0,

--- a/ui/src/contexts/SimContext/reducer.ts
+++ b/ui/src/contexts/SimContext/reducer.ts
@@ -131,7 +131,30 @@ export const reducer = (
       };
 
     case "ADD_TIMELINE_EVENT_BATCH": {
-      const newEvents = [...state.events, ...action.payload];
+      // Keep `events` ordered by `time_s`. The aggregator relies on this: it
+      // stops scanning at the first event past the current time, so an
+      // out-of-order event would truncate the scan and silently drop later
+      // events from every count. The live Loki path interleaves
+      // independently-delivered per-direction streams, so batches arrive out
+      // of order. Merge-insert the (small) sorted batch into the already-sorted
+      // list in O(n + m); a full re-sort each batch would be O(n log n),
+      // untenable once a demo reaches hundreds of thousands of events.
+      const incoming = [...action.payload].sort((a, b) => a.time_s - b.time_s);
+      const prev = state.events;
+      const merged: typeof prev = new Array(prev.length + incoming.length);
+      let pi = 0;
+      let ii = 0;
+      let mi = 0;
+      while (pi < prev.length && ii < incoming.length) {
+        if (prev[pi].time_s <= incoming[ii].time_s) {
+          merged[mi++] = prev[pi++];
+        } else {
+          merged[mi++] = incoming[ii++];
+        }
+      }
+      while (pi < prev.length) merged[mi++] = prev[pi++];
+      while (ii < incoming.length) merged[mi++] = incoming[ii++];
+      const newEvents = merged;
 
       if (newEvents.length === 0) {
         return {
@@ -140,10 +163,11 @@ export const reducer = (
         };
       }
 
-      // Calculate timeline bounds
-      const timestamps = newEvents.map((event) => event.time_s);
-      const minEventTime = Math.min(...timestamps);
-      const maxEventTime = Math.max(...timestamps);
+      // `newEvents` is sorted, so the bounds are its endpoints — O(1), and
+      // avoids `Math.min(...timestamps)` overflowing the call stack at large
+      // event counts.
+      const minEventTime = newEvents[0].time_s;
+      const maxEventTime = newEvents[newEvents.length - 1].time_s;
 
       // Update timeline bounds and clamp current time
       const newMinTime =

--- a/ui/src/contexts/SimContext/types.ts
+++ b/ui/src/contexts/SimContext/types.ts
@@ -112,6 +112,7 @@ export interface ISimulationAggregatedDataState {
   global: ISimulationGlobalData;
   messages: IMessageAnimation[]; // Active messages traveling on the graph
   edges: Map<string, IEdgeState>; // Edge state for coloring based on message priority
+  traversedEdges: Set<string>; // Edge keys that have carried a message (either direction) up to currentTime
   nodeActivity: Map<string, INodeActivityState>; // Node activity state for priority-based coloring
   eventCounts: {
     total: number;

--- a/ui/src/utils/timelineAggregation.ts
+++ b/ui/src/utils/timelineAggregation.ts
@@ -184,6 +184,11 @@ const createMessageAnimation = (
   const edgeIds = [sender, recipient].sort();
   const edgeKey = `${edgeIds[0]}|${edgeIds[1]}`;
 
+  // Mark the edge as traversed regardless of whether the message is still in
+  // transit at targetTime: an edge that has ever carried a message is drawn
+  // solid rather than dotted.
+  result.traversedEdges.add(edgeKey);
+
   // Check if message is currently in transit
   const isInTransit =
     targetTime >= sentTime && targetTime < estimatedReceiveTime;
@@ -283,6 +288,7 @@ export const computeAggregatedDataAtTime = (
     },
     messages: [],
     edges: new Map(),
+    traversedEdges: new Set(),
     nodeActivity: new Map(),
     // Add event counts for the UI
     eventCounts: {


### PR DESCRIPTION
Claude wrote all of this, I just guided it through the debugging process.

- I was frequently seeing disparities in the number of sends/recvs despite seeing perfect balance in the logs.
- Claude eventually brainstormed a promising explanation: using `/tail` to "live stream" from Loki is known to be incomplete (especially if some messages are big, which we've seen).
- So: this PR switches from `/tail` to `/query_range`.
- But that requires CORS, which Loki can't support, so we added a `caddy` proxy to compensate.

Deduping was one of the early brainstormed mitigations, but now it's necessary since the `/query_range` intentionally overlaps in order to pick up events that arrived to Loki after our previous poll.

~There was also a discovery that Alloy is sending things to Loki in duplicate---but I decided not to mess with that because it wasn't trivial.~

-----

I just expanded this PR with a couple more fixes.

- a bugfix to my first "./ui: switch Loki from /tail to /query_range to stop dropping events" commit, b42a23eb66cd9e95cf6e292ce4ab8ff95130eead---`/query_range` delivers events bundled by streams, where as `/tail` was in chrono-order. So the patched commit now merges the streams by chrono order. There are various parts of the visualizer that depend on the events being chrono-ordered, eg the `Parent` field in the `Chain` View.
- I also noticed the `Certifies EB` field was broken in the `Chain` View, but I suspect this wasn't due to my changes? Similar problem: parser had side-effects that assumed some ordering, but it _also_ assumed no-dups/idempotency, which is not the case. Alloy sents events multiple times, unannotated and also annotated. The fix here was to filter out annotated events, so we only process each even once (not for _all_ of the parsers, but for some of them).
- I also accidentally included a tiny but generic feature: draw edges as dashed lines until they're utilized for the first time (my demo of announcements uses a linear topology to have multi-hop paths, so one edge of the triangle remains dashed throughout the whole visualization in that case).