### PR TITLE
ci(antithesis): add ignore labels to support containers

### DIFF
--- a/antithesis/docker-compose.devnet.yaml
+++ b/antithesis/docker-compose.devnet.yaml
@@ -23,6 +23,9 @@ x-node-ips: &node-ips
   PORT_POOL3: "3003"
   PORT_DINGO: "3001"
 
+x-antithesis-exclude-labels: &antithesis-exclude-labels
+  com.antithesis.exclude_from_faults: "network,kill,pause,stop"
+
 services:
   # ==========================================================================
   # Init Containers
@@ -190,6 +193,7 @@ services:
 
   dingo1:
     image: ghcr.io/blinklabs-io/dingo:main-antithesis
+    labels: *antithesis-exclude-labels
     depends_on:
       init-dingo1:
         condition: service_completed_successfully
@@ -224,6 +228,7 @@ services:
   # ==========================================================================
   tx-centrifuge:
     image: ghcr.io/input-output-hk/ouroboros-leios/antithesis-cardano-node-devnet:${GIT_SHA:-latest}
+    labels: *antithesis-exclude-labels
     build:
       context: ..
       dockerfile: antithesis/Dockerfile.cardano-node-devnet
@@ -250,6 +255,7 @@ services:
   # ==========================================================================
   analysis:
     image: ghcr.io/input-output-hk/ouroboros-leios/antithesis-analysis:${GIT_SHA:-latest}
+    labels: *antithesis-exclude-labels
     build:
       context: ..
       dockerfile: antithesis/Dockerfile.analysis

--- a/antithesis/docker-compose.immdb.yaml
+++ b/antithesis/docker-compose.immdb.yaml
@@ -29,6 +29,9 @@ x-wan-env-downstream: &wan-env-downstream
   RATE: ${RATE_DOWN_TO_N0:-10Mbps}
   DELAY: ${DELAY_DOWN_TO_N0:-200ms}
 
+x-antithesis-exclude-labels: &antithesis-exclude-labels
+  com.antithesis.exclude_from_faults: "network,kill,pause,stop"
+
 services:
   # ==========================================================================
   # Init Containers
@@ -190,6 +193,7 @@ services:
 
   dingo:
     image: ghcr.io/blinklabs-io/dingo:${DINGO_VERSION:-0.24.1}
+    labels: *antithesis-exclude-labels
     depends_on:
       init-dingo:
         condition: service_completed_successfully
@@ -223,6 +227,7 @@ services:
   # ==========================================================================
   analysis-immdb:
     image: ghcr.io/input-output-hk/ouroboros-leios/antithesis-analysis:${GIT_SHA:-latest}
+    labels: *antithesis-exclude-labels
     build:
       context: ..
       dockerfile: antithesis/Dockerfile.analysis

--- a/antithesis/docker-compose.observability.yaml
+++ b/antithesis/docker-compose.observability.yaml
@@ -5,9 +5,13 @@
 #   docker compose -f docker-compose.devnet.yaml -f docker-compose.observability.yaml up
 #   docker compose -f docker-compose.immdb.yaml -f docker-compose.observability.yaml up
 
+x-antithesis-exclude-labels: &antithesis-exclude-labels
+  com.antithesis.exclude_from_faults: "network,kill,pause,stop"
+
 services:
   prometheus:
     image: prom/prometheus:latest
+    labels: *antithesis-exclude-labels
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -22,6 +26,7 @@ services:
 
   loki:
     image: grafana/loki:latest
+    labels: *antithesis-exclude-labels
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
       - ./config/loki.yml:/etc/loki/local-config.yaml:ro
@@ -33,6 +38,7 @@ services:
 
   alloy:
     image: grafana/alloy:latest
+    labels: *antithesis-exclude-labels
     command:
       - run
       - /etc/alloy/config.river
@@ -46,6 +52,7 @@ services:
 
   grafana:
     image: grafana/grafana:latest
+    labels: *antithesis-exclude-labels
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/antithesis/testnets/leios-devnet/docker-compose.yaml
+++ b/antithesis/testnets/leios-devnet/docker-compose.yaml
@@ -28,6 +28,9 @@ x-node-image: &node-image
 x-dingo-image: &dingo-image
   image: ghcr.io/blinklabs-io/dingo:main-antithesis
 
+x-antithesis-exclude-labels: &antithesis-exclude-labels
+  com.antithesis.exclude_from_faults: "network,kill,pause,stop"
+
 services:
   # ==========================================================================
   # Init Containers
@@ -189,6 +192,7 @@ services:
     container_name: dingo1
     hostname: dingo1
     init: true
+    labels: *antithesis-exclude-labels
     depends_on:
       init-dingo1:
         condition: service_completed_successfully
@@ -225,6 +229,7 @@ services:
     container_name: tx-centrifuge
     hostname: tx-centrifuge
     init: true
+    labels: *antithesis-exclude-labels
     command: ["/app/scripts/run-tx-centrifuge-loop.sh"]
     depends_on:
       pool1:
@@ -251,6 +256,7 @@ services:
     container_name: analysis
     hostname: analysis
     init: true
+    labels: *antithesis-exclude-labels
     depends_on:
       pool1:
         condition: service_healthy


### PR DESCRIPTION
This copies the ignore labels from CF's cardano-node-antithesis repo to prevent them from being killed via fault injection.