### PR TITLE
Add Linux ARM64 release binaries

### DIFF
--- a/.github/workflows/cardano-node-leios.yaml
+++ b/.github/workflows/cardano-node-leios.yaml
@@ -4,8 +4,8 @@ name: "cardano-node-leios"
 # `cardano-node-leios` flake input) as:
 #
 #   1. Release tarballs `cardano-node-leios-<platform>.tar.gz` for
-#      x86_64-linux (static musl) and aarch64-darwin (upstream macOS
-#      release tarball with dylib paths rewritten).
+#      x86_64-linux and aarch64-linux (static musl), and aarch64-darwin
+#      (upstream macOS release tarball with dylib paths rewritten).
 #   2. A minimal `cardano-node-leios` docker image on GHCR.
 #   3. A derived `cardano-node-testnet` image (pinned testnet configs).
 #   4. A draft GitHub release (on tag pushes, or on a workflow_dispatch
@@ -199,6 +199,45 @@ jobs:
           cache-from: type=gha,scope=cardano-node-testnet
           cache-to: type=gha,mode=max,scope=cardano-node-testnet
 
+  build-linux-arm64:
+    name: "Build aarch64-linux binaries"
+    # Use a native ARM64 runner so Nix evaluates and builds the
+    # aarch64-linux musl jobs from the cardano-node input directly.
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Install nix
+        uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            substituters = https://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+
+      - name: Build aarch64-linux release tarball
+        run: |
+          set -euo pipefail
+          nix build .#cardano-node-release -o result-release
+
+          mkdir -p artifacts
+          cp -v result-release/cardano-node-leios-aarch64-linux.tar.gz artifacts/
+          (cd artifacts && sha256sum cardano-node-leios-aarch64-linux.tar.gz \
+            > cardano-node-leios-aarch64-linux.sha256)
+
+      - name: Upload aarch64-linux tarball as workflow artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: cardano-node-leios-aarch64-linux-${{ github.run_id }}
+          path: artifacts/
+          if-no-files-found: error
+
   build-macos:
     name: "Build aarch64-darwin binaries"
     # macos-14 = Apple Silicon (aarch64-darwin). macos-13 is Intel.
@@ -242,7 +281,7 @@ jobs:
 
   draft-release:
     name: "Draft GitHub release"
-    needs: [build, build-macos]
+    needs: [build, build-linux-arm64, build-macos]
     # Trigger on tag pushes, or on a workflow_dispatch that asks for a
     # specific ref (which may or may not be a tag — the job verifies).
     if: >-
@@ -310,6 +349,13 @@ jobs:
           name: cardano-node-leios-aarch64-darwin-${{ github.run_id }}
           path: artifacts/
 
+      - name: Download aarch64-linux artifact
+        if: steps.tag.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: cardano-node-leios-aarch64-linux-${{ github.run_id }}
+          path: artifacts/
+
       - name: Extract tag annotation body
         if: steps.tag.outputs.skip != 'true'
         run: |
@@ -342,5 +388,7 @@ jobs:
             --notes-file release-notes.md \
             artifacts/cardano-node-leios-x86_64-linux.tar.gz \
             artifacts/cardano-node-leios-x86_64-linux.sha256 \
+            artifacts/cardano-node-leios-aarch64-linux.tar.gz \
+            artifacts/cardano-node-leios-aarch64-linux.sha256 \
             artifacts/cardano-node-leios-aarch64-darwin.tar.gz \
             artifacts/cardano-node-leios-aarch64-darwin.sha256

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -3,7 +3,7 @@
 #   nix build .#cardano-node-static          # x86_64-linux
 #   nix build .#cardano-cli-static           # x86_64-linux
 #   nix build .#cardano-node-leios-image     # x86_64-linux; pipe into `docker load`
-#   nix build .#cardano-node-release         # x86_64-linux + aarch64-darwin tarball
+#   nix build .#cardano-node-release         # x86_64-linux, aarch64-linux, or aarch64-darwin tarball
 #
 # CI publishes the image to GHCR and attaches the release tarball to
 # draft releases on tag pushes. Scenario images (antithesis-*,
@@ -23,7 +23,7 @@
     let
       releaseName = "cardano-node-leios-${system}";
 
-      # Statically-linked x86_64-linux builds (musl, no glibc). `or null`
+      # Statically-linked Linux builds (musl, no glibc). `or null`
       # keeps it safe to reference on other systems; Nix is lazy and only
       # the linux branches below dereference it.
       muslJobs = inputs.cardano-node-leios.hydraJobs.${system}.musl or null;
@@ -78,6 +78,7 @@
           lib.optionalAttrs
             (lib.elem system [
               "x86_64-linux"
+              "aarch64-linux"
               "aarch64-darwin"
             ])
             {
@@ -91,7 +92,7 @@
               cardano-node-release =
                 let
                   upstream =
-                    if system == "x86_64-linux" then
+                    if lib.elem system [ "x86_64-linux" "aarch64-linux" ] then
                       inputs.cardano-node-leios.hydraJobs.${system}.musl.cardano-node-linux
                     else
                       inputs.cardano-node-leios.hydraJobs.${system}.native.cardano-node-macos;

--- a/site/docs/testnet/getting-started.md
+++ b/site/docs/testnet/getting-started.md
@@ -97,7 +97,7 @@ requires a reasonably fast disk:
 
 |               |                                                    |
 |---------------|----------------------------------------------------|
-| **OS / arch** | Linux **x86-64** or macOS **aarch64** for prebuilt binaries |
+| **OS / arch** | Linux **x86-64**, Linux **aarch64**, or macOS **aarch64** for prebuilt binaries |
 | **CPU**       | 2 cores is fine; more only speeds the initial sync |
 | **RAM**       | 4 GB comfortable (the node uses ~2–2.5 GB)         |
 | **Disk**      | SSD, ~25 GB                                        |
@@ -123,8 +123,8 @@ A few ways to start one — pick whichever fits your setup:
 - **Nix** — one command builds, installs, and runs the node together
   with a Grafana + Loki + Prometheus stack. Every dependency is
   provided.
-- **Prebuilt binaries** — download the release tarball (Linux x86-64
-  or macOS aarch64) and run with the repository's launch script.
+- **Prebuilt binaries** — download the release tarball (Linux x86-64,
+  Linux aarch64, or macOS aarch64) and run with the repository's launch script.
   Compatible with the same observability stack if you install the
   extra tooling, or run the node on its own and bring your own tools.
 - **Docker** — the same binaries packaged as a container image, for
@@ -205,7 +205,7 @@ cardano-node --version   # expect: cardano-node x.y.z.164
 ### Prebuilt binaries
 
 The release ships a tarball per platform with `cardano-node` and
-`cardano-cli` under `bin/`. On Linux x86-64 the binaries are
+`cardano-cli` under `bin/`. On Linux x86-64 and aarch64 the binaries are
 statically linked; on macOS aarch64 the dylib paths are pre-rewritten
 so they run on a stock macOS host. Either way, nothing else needs
 installing.
@@ -226,9 +226,23 @@ mkdir -p "$WORKING_DIR"
 ```shell
 cd "$WORKING_DIR"
 
-BASE=https://github.com/input-output-hk/ouroboros-leios/releases/download/prototype-2026w27
+BASE=https://github.com/input-output-hk/ouroboros-leios/releases/download/prototype-2026w30
 ARCHIVE=cardano-node-leios-x86_64-linux.tar.gz
 CHECKSUM=cardano-node-leios-x86_64-linux.sha256
+curl -L -O "$BASE/$ARCHIVE"
+curl -L -O "$BASE/$CHECKSUM"
+sha256sum -c "$CHECKSUM"
+```
+
+</TabItem>
+<TabItem value="linux-arm64" label="Linux aarch64">
+
+```shell
+cd "$WORKING_DIR"
+
+BASE=https://github.com/input-output-hk/ouroboros-leios/releases/download/prototype-2026w30
+ARCHIVE=cardano-node-leios-aarch64-linux.tar.gz
+CHECKSUM=cardano-node-leios-aarch64-linux.sha256
 curl -L -O "$BASE/$ARCHIVE"
 curl -L -O "$BASE/$CHECKSUM"
 sha256sum -c "$CHECKSUM"
@@ -240,7 +254,7 @@ sha256sum -c "$CHECKSUM"
 ```shell
 cd "$WORKING_DIR"
 
-BASE=https://github.com/input-output-hk/ouroboros-leios/releases/download/prototype-2026w27
+BASE=https://github.com/input-output-hk/ouroboros-leios/releases/download/prototype-2026w30
 ARCHIVE=cardano-node-leios-aarch64-darwin.tar.gz
 CHECKSUM=cardano-node-leios-aarch64-darwin.sha256
 curl -L -O "$BASE/$ARCHIVE"
@@ -309,7 +323,7 @@ or wrap it into a systemd service.
 
 A prebuilt image carrying both `cardano-node` and `cardano-cli` is published for
 each leios prototype release at
-`ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w27`
+`ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w30`
 — useful if you already orchestrate nodes with containers. The image runs as a
 non-block-producing relay out of the box; no observability stack is included.
 
@@ -327,7 +341,7 @@ docker run -d --name leios-relay \
   -p 3010:3010 \
   -v "$WORKING_DIR:/data" \
   -v "$WORKING_DIR/config:/app/config:ro" \
-  ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w27
+  ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w30
 ```
 
 The `$WORKING_DIR` mount keeps the database, socket (`$WORKING_DIR/node.socket`),
@@ -413,7 +427,7 @@ The **Prebuilt binaries** and **Docker** paths bring only the node
 itself; observability there is whatever you wire up around it. If you
 want the same wrapped experience without going all-in on Nix, clone the
 repository and run its
-[`testnet/run.sh`](https://github.com/input-output-hk/ouroboros-leios/blob/prototype-2026w27/testnet/run.sh)
+[`testnet/run.sh`](https://github.com/input-output-hk/ouroboros-leios/blob/prototype-2026w30/testnet/run.sh)
 — a `process-compose` script that boots the node together with Grafana
 + Loki + Prometheus. It needs `process-compose`, `envsubst`, Grafana,
 Loki, and Prometheus on your `PATH`, all of which the `dev-testnet` Nix

--- a/site/docs/testnet/register-stake-pool.md
+++ b/site/docs/testnet/register-stake-pool.md
@@ -355,7 +355,7 @@ docker run -d --name leios-producer \
   -p 3010:3010 \
   -v "$WORKING_DIR:/data" \
   -w /data \
-  ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w27 \
+  ghcr.io/input-output-hk/ouroboros-leios/cardano-node-testnet:prototype-2026w30 \
   cardano-node run \
     --config config/config.json \
     --topology config/topology.json \

--- a/ui/schema/trace.ui.schema.json
+++ b/ui/schema/trace.ui.schema.json
@@ -21,6 +21,53 @@
       "required": ["eb"],
       "type": "object"
     },
+    "UIAnnouncementReceived": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "recipient": {
+          "type": "string"
+        },
+        "sender": {
+          "type": "string"
+        },
+        "slot": {
+          "type": "number"
+        },
+        "type": {
+          "const": "AnnouncementReceived",
+          "type": "string"
+        }
+      },
+      "required": ["id", "recipient", "slot", "type"],
+      "type": "object"
+    },
+    "UIAnnouncementSent": {
+      "description": "Sent event for a `MsgLeiosBlockAnnouncement` relay hop over LeiosNotify.\nThe message is an RB header; `id`/`slot` identify the EB it announces, so\nan announcement's diffusion can be linked to its endorser block.",
+      "properties": {
+        "id": {
+          "description": "Hash of the announced EB, extracted from the relayed RB header.",
+          "type": "string"
+        },
+        "recipient": {
+          "type": "string"
+        },
+        "sender": {
+          "type": "string"
+        },
+        "slot": {
+          "description": "Slot of the announced EB.",
+          "type": "number"
+        },
+        "type": {
+          "const": "AnnouncementSent",
+          "type": "string"
+        }
+      },
+      "required": ["id", "recipient", "sender", "slot", "type"],
+      "type": "object"
+    },
     "UIEBGenerated": {
       "properties": {
         "closure_size_bytes": {
@@ -148,6 +195,12 @@
         },
         {
           "$ref": "#/definitions/UITxsReceived"
+        },
+        {
+          "$ref": "#/definitions/UIAnnouncementSent"
+        },
+        {
+          "$ref": "#/definitions/UIAnnouncementReceived"
         }
       ],
       "description": "Union of every message shape the UI renders."

--- a/ui/schema/ui-message-types.json
+++ b/ui/schema/ui-message-types.json
@@ -1,4 +1,6 @@
 [
+  "AnnouncementReceived",
+  "AnnouncementSent",
   "EBGenerated",
   "EBReceived",
   "EBSent",


### PR DESCRIPTION
Closes #960 

## Summary

- add native Linux ARM64 release builds for cardano-node and cardano-cli
- publish the tarball and checksum as workflow artifacts and GitHub release assets
- update testnet documentation for Linux aarch64 and prototype-2026w30

## Validation

- actionlint .github/workflows/cardano-node-leios.yaml
- git diff --check

Nix builds were not run locally because Nix is unavailable in the development environment.