### PR TITLE
Reduce Antithesis runtime log volume

### DIFF
--- a/antithesis/docker-compose.devnet.yaml
+++ b/antithesis/docker-compose.devnet.yaml
@@ -190,6 +190,7 @@ services:
 
   dingo1:
     image: ghcr.io/blinklabs-io/dingo:main-antithesis
+    command: ["serve", "--logging-level", "warn"]
     depends_on:
       init-dingo1:
         condition: service_completed_successfully

--- a/antithesis/scripts/run-cardano-node.sh
+++ b/antithesis/scripts/run-cardano-node.sh
@@ -32,7 +32,8 @@ echo "  PORT: $PORT"
 echo "  HOST_ADDR: $HOST_ADDR"
 echo "  LEIOS_DB_PATH: $LEIOS_DB_PATH"
 
-# Run cardano-node with tee to both stdout and log file
+# Keep the full node log on the shared volume. Emitting it on stdout makes
+# Antithesis retain every routine node event in the test-run log stream.
 exec cardano-node run \
     --config "$DATA_DIR/config.json" \
     --topology "$DATA_DIR/topology.json" \
@@ -40,4 +41,4 @@ exec cardano-node run \
     --socket-path "$DATA_DIR/socket" \
     --host-addr "$HOST_ADDR" \
     --port "$PORT" \
-    2>&1 | tee "$LOG_DIR/${NODE_NAME}.log"
+    >> "$LOG_DIR/${NODE_NAME}.log" 2>&1

--- a/antithesis/scripts/run-pool-node.sh
+++ b/antithesis/scripts/run-pool-node.sh
@@ -44,7 +44,8 @@ echo "  PORT: $PORT"
 echo "  HOST_ADDR: $HOST_ADDR"
 echo "  LEIOS_DB_PATH: $LEIOS_DB_PATH"
 
-# Run cardano-node as block producer with pool credentials
+# Keep the full node log on the shared volume. Emitting it on stdout makes
+# Antithesis retain every routine node event in the test-run log stream.
 exec cardano-node run \
 	--config "$DATA_DIR/config.yaml" \
 	--topology "$DATA_DIR/topology.json" \
@@ -55,4 +56,4 @@ exec cardano-node run \
 	--shelley-vrf-key "$DATA_DIR/keys/vrf.skey" \
 	--shelley-kes-key "$DATA_DIR/keys/kes.skey" \
 	--shelley-operational-certificate "$DATA_DIR/keys/opcert.cert" \
-	2>&1 | tee "$LOG_DIR/${POOL_NAME}.log"
+	>> "$LOG_DIR/${POOL_NAME}.log" 2>&1

--- a/antithesis/scripts/run-tx-centrifuge-loop.sh
+++ b/antithesis/scripts/run-tx-centrifuge-loop.sh
@@ -17,6 +17,7 @@ DATA_DIR="${DATA_DIR:-/data}"
 CONFIG_DIR="${CONFIG_DIR:-/app/config}"
 UTXO_KEYS_DIR="${UTXO_KEYS_DIR:-/app/utxo-keys}"
 SHARED_GENESIS_DIR="${SHARED_GENESIS_DIR:-/shared-genesis}"
+LOG_DIR="${LOG_DIR:-/logs}"
 
 # Node connection details (hostnames in Antithesis, IPs locally)
 IP_POOL1="${IP_POOL1:-pool1}"
@@ -46,6 +47,7 @@ echo "  COOLDOWN range: ${COOLDOWN_MIN}s - ${COOLDOWN_MAX}s"
 # --- One-time initialization (same as run-tx-centrifuge.sh) ---
 
 mkdir -p "$DATA_DIR"
+mkdir -p "$LOG_DIR"
 
 # Wait for genesis files from pool1
 echo "Waiting for genesis files..."
@@ -164,7 +166,7 @@ while true; do
     # Run tx-centrifuge for the randomized duration, then stop it
     echo "  Running tx-centrifuge for ${duration}s..."
     cd "$DATA_DIR"
-    tx-centrifuge centrifuge.json &
+    tx-centrifuge centrifuge.json >> "$LOG_DIR/tx-centrifuge.log" 2>&1 &
     CENTRIFUGE_PID=$!
 
     sleep "$duration"

--- a/antithesis/scripts/run-tx-centrifuge.sh
+++ b/antithesis/scripts/run-tx-centrifuge.sh
@@ -10,6 +10,7 @@ DATA_DIR="${DATA_DIR:-/data}"
 CONFIG_DIR="${CONFIG_DIR:-/app/config}"
 UTXO_KEYS_DIR="${UTXO_KEYS_DIR:-/app/utxo-keys}"
 SHARED_GENESIS_DIR="${SHARED_GENESIS_DIR:-/shared-genesis}"
+LOG_DIR="${LOG_DIR:-/logs}"
 
 # Node connection details
 IP_POOL1="${IP_POOL1:-172.28.0.10}"
@@ -27,6 +28,7 @@ echo "  Pool3: $IP_POOL3:$PORT_POOL3"
 
 # Create data directory
 mkdir -p "$DATA_DIR"
+mkdir -p "$LOG_DIR"
 
 # Wait for genesis files from pool1
 echo "Waiting for genesis files..."
@@ -129,4 +131,4 @@ fi
 
 echo "Starting tx-centrifuge..."
 cd "$DATA_DIR"
-exec tx-centrifuge centrifuge.json
+exec tx-centrifuge centrifuge.json >> "$LOG_DIR/tx-centrifuge.log" 2>&1

--- a/antithesis/scripts/run-upstream.sh
+++ b/antithesis/scripts/run-upstream.sh
@@ -29,7 +29,8 @@ echo "  PORT: $PORT"
 echo "  REF_SLOT: $REF_SLOT"
 echo "  ONSET_OF_REF_SLOT: $ONSET_OF_REF_SLOT"
 
-# Run immdb-server with tee to both stdout and log file
+# Keep the full server log on the shared volume instead of emitting every
+# routine event on the Antithesis test-run log stream.
 exec immdb-server \
     --db "$DATA_DIR/immutable/" \
     --config "$DATA_DIR/config.json" \
@@ -39,4 +40,4 @@ exec immdb-server \
     --leios-db "$DATA_DIR/leios.db" \
     --address "0.0.0.0" \
     --port "$PORT" \
-    2>&1 | tee "$LOG_DIR/upstream-node.log"
+    >> "$LOG_DIR/upstream-node.log" 2>&1

--- a/antithesis/testnets/leios-devnet/docker-compose.yaml
+++ b/antithesis/testnets/leios-devnet/docker-compose.yaml
@@ -27,6 +27,7 @@ x-node-image: &node-image
 
 x-dingo-image: &dingo-image
   image: ghcr.io/blinklabs-io/dingo:main-antithesis
+  command: ["serve", "--logging-level", "warn"]
 
 services:
   # ==========================================================================


### PR DESCRIPTION
## Summary

- Keep `cardano-node` and `immdb-server` output in the shared `/logs` volume instead of duplicating it to container stdout.
- Keep `tx-centrifuge` output in the shared log volume.
- Run the Antithesis Dingo services at warning level.

## Verification

- `bash -n` on all changed launcher scripts.
- Docker Compose config validation for devnet and leios-devnet with `INTERNAL_NETWORK=false`.
- `git diff --check`.