### PR TITLE
trace-verifier: fix validityCheckTime (4 -> 3) to match observed node vote timing

### DIFF
--- a/leios-trace-verifier/src/Defaults.agda
+++ b/leios-trace-verifier/src/Defaults.agda
@@ -367,5 +367,7 @@ d-SpecStructure = record
       ; KF                        = d-KeyRegistrationFunctionality
       ; va                        = d-VotingAbstract
       ; getEBCert                 = λ _ → []
-      ; validityCheckTime         = λ _ → 4
+      ; validityCheckTime         = λ _ → 3
+      -- 3 matches the w31 node: it votes at exactly ebSlot + 3 slots
+      -- (= 3·Lhdr ⊔ validityCheckTime with Lhdr = 1), observed on Musashi.
       }


### PR DESCRIPTION
Follow-up to the w31 fixes you rebased this morning — with votes visible, live
verification against our Musashi producer (NITEN, `pool1zf9z…dx4rer`) convicted
**every vote** with `Err-VT-Role-premises`. One-line root cause: `Defaults`
instantiates `validityCheckTime = 4`, putting the spec's voting deadline at
`ebSlot + (3·Lhdr ⊔ 4) = ebSlot + 4`, while the w31 node demonstrably votes at
`ebSlot + 3` (hundreds of live observations). This PR sets it to 3.

Two things we hit on the way that deserve your eyes:

1. **Spec-repo bug (will file there):** the `Err-VT-Role-premises` `errorMsg`
   cascade in `Leios/Linear/Trace/Verifier.lagda.md` tests the deadline as
   `slot ≡ ebSlot + validityCheckTime eb` — missing the rule's `3·Lhdr ⊔ …` —
   so its diagnosis can name the wrong conjunct. Cost us an hour.

2. **Finding for the design discussion — the residual convictions are a
   timing-semantics divergence, not a parameter bug.** After this fix, 40 min
   of live traffic still produced: 7× `¬ (slot' ≤ ebSlot + Lhdr)` (EBs received
   2–5 slots after announcement — real diffusion latency exceeds Lhdr = 1) and
   69× rejected `No-VT-Role` — which are the *same* late EBs double-convicted:
   the node votes when validation completes, so at the spec's exact deadline
   slot there is no vote yet (abstention rejected), and the actual vote lands a
   slot later (deadline `≡` fails). **No constant (Lhdr, vCT) satisfies a
   when-ready voter against a point-equality deadline.** Either the spec means
   a window (`≤`), or the node's late votes are non-conformant, or Musashi's
   effective Lhdr ≠ 1. We'd love your ruling — happy to run any experiment
   against NITEN; the auto-resuming verifier sessions on our VPS provide
   continuous data.

Also +1 to your main-merge hesitancy: the verifier's pins are inherently
per-testnet-release (it must decode the node's protocol state), so a split
cabal project for `leios-trace-verifier` — pinned per release, separate from
the simulator's stable stack — might dissolve the conflict.

Field notes with the full evidence trail available (Ramsay has them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
