### PR TITLE
Trace verifier: Fixes to issues found on devnet and testnet

### DIFF
--- a/leios-trace-hs/src/ChainEvents.hs
+++ b/leios-trace-hs/src/ChainEvents.hs
@@ -32,7 +32,7 @@ import Data.Aeson.Types (Parser, parseMaybe)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.List (mapAccumL)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as TR
@@ -78,6 +78,13 @@ data ChainEvent
     --   advances past an announced EB that EB can no longer be certified — the
     --   verifier uses this to close the EB's voting window.
     CChainExtended !Word64
+  | -- | The (min, max) mempool size in bytes observed during one slot, aggregated
+    --   from @Mempool.AddedTx@ / @Mempool.RemoveTxs@ (both report the resulting size
+    --   absolutely, not as a delta). A range rather than a point because the node
+    --   decides from a snapshot taken at an instant the log does not pin down, so a
+    --   single reading would be a guess at what it saw. Emitted immediately before
+    --   the slot tick that closes the slot it describes.
+    CMempoolRange !Word64 !Word64
   deriving (Eq, Show, Generic)
 
 -- | Internal: one parsed line — a directly-emittable event, a linkage fact
@@ -93,41 +100,71 @@ data Raw
     RawVote !Bool !Text
   | -- | deliberate abstention: ebHash, election slot, reason. EB-keyed.
     RawNotVoted !Text !Word64 !Text
+  | -- | a mempool size reading in bytes, absolute rather than a delta.
+    RawMempool !Word64
 
--- | Vote-resolution state.
+-- | Vote-resolution state, plus the mempool readings accumulated for the slot
+--   currently in progress.
 data LinkState = LinkState
   { lsEbBySlot :: !(Map.Map Word64 Text)
   , lsSlotByRb :: !(Map.Map Text Word64)
+  , lsMemRange :: !(Maybe (Word64, Word64))
+  -- ^ (min, max) of the readings seen since the last slot tick.
+  , lsMemLast :: !(Maybe Word64)
+  -- ^ Most recent reading, which seeds the next slot's range: the mempool as it
+  --   stood when that slot began counts as one of its readings.
   }
 
 emptyLinkState :: LinkState
-emptyLinkState = LinkState Map.empty Map.empty
+emptyLinkState = LinkState Map.empty Map.empty Nothing Nothing
 
 -- | Parse a whole node.log, keeping only the Leios events and preserving order.
+--
+--   Mempool readings are aggregated rather than passed through. A busy node emits
+--   tens of thousands of them — 76,767 in one 1,000-slot run — and the verifier
+--   needs only the range per slot, so each slot tick is preceded by a single
+--   'CMempoolRange' summarising the slot just ending. Emitting it /before/ the tick
+--   matters: a tick is what closes the previous slot downstream, so the range has
+--   to arrive while that slot is still open.
 parseNodeLog :: BSL8.ByteString -> [ChainEvent]
 parseNodeLog =
-  catMaybes . snd . mapAccumL step emptyLinkState . mapMaybe parseRaw . BSL8.lines
+  concat . snd . mapAccumL step emptyLinkState . mapMaybe parseRaw . BSL8.lines
  where
-  step :: LinkState -> Raw -> (LinkState, Maybe ChainEvent)
+  step :: LinkState -> Raw -> (LinkState, [ChainEvent])
   step !st raw = case raw of
-    RawEvent ev -> (st, Just ev)
+    -- A slot tick closes the slot just ending, so flush its mempool range first,
+    -- then seed the new slot's range with the mempool as it now stands.
+    RawEvent ev@(CSlot _) ->
+      ( st{lsMemRange = (\l -> (l, l)) <$> lsMemLast st}
+      , maybe [] (\(mn, mx) -> [CMempoolRange mn mx]) (lsMemRange st) <> [ev]
+      )
+    RawEvent ev -> (st, [ev])
+    RawMempool b ->
+      ( st
+          { lsMemLast = Just b
+          , lsMemRange = Just $ case lsMemRange st of
+              Nothing -> (b, b)
+              Just (mn, mx) -> (min mn b, max mx b)
+          }
+      , []
+      )
     RawAnn slot ebHash ->
       ( st{lsEbBySlot = Map.insert slot ebHash (lsEbBySlot st)}
-      , Just (CAnnouncementAccepted ebHash slot)
+      , [CAnnouncementAccepted ebHash slot]
       )
     RawRb rbHash slot ->
       ( st{lsSlotByRb = Map.insert rbHash slot (lsSlotByRb st)}
-      , Just (CChainExtended slot)
+      , [CChainExtended slot]
       )
     RawVote ours rbHash ->
       ( st
-      , do
+      , maybeToList $ do
           slot <- Map.lookup rbHash (lsSlotByRb st)
           ebHash <- Map.lookup slot (lsEbBySlot st)
           pure $ (if ours then CVoted else CVoteAcquired) ebHash slot
       )
     RawNotVoted ebHash slot reason ->
-      (st, Just (CNotVoted ebHash slot reason))
+      (st, [CNotVoted ebHash slot reason])
 
 -- | Parse a single log line; @Nothing@ for non-JSON banners and unrelated events.
 parseRaw :: BSL8.ByteString -> Maybe Raw
@@ -157,6 +194,8 @@ pRaw = withObject "logline" $ \o -> do
       RawVote False <$> v .: "rbHash"
     "Consensus.LeiosKernel.NotVoted" ->
       RawNotVoted <$> d .: "ebHash" <*> d .: "ebSlot" <*> d .: "reason"
+    "Mempool.AddedTx" -> mempoolBytes d
+    "Mempool.RemoveTxs" -> mempoolBytes d
     -- Extending the current chain and switching to a fork are the two ways
     -- ChainDB reports adopting a new tip, and both matter twice over: the tip
     -- advance retires any EB the superseded announcer carried, and the adopted
@@ -178,6 +217,12 @@ pRaw = withObject "logline" $ \o -> do
           RawEvent <$> (CVoteAcquired <$> v .: "ebHash" <*> v .: "slot")
         _ -> fail "unhandled LeiosKernel kind"
     _ -> fail "unhandled ns"
+
+-- | The mempool size after a change, shared by the two Mempool traces.
+mempoolBytes :: Object -> Parser Raw
+mempoolBytes d = do
+  ms <- d .: "mempoolSize"
+  RawMempool <$> ms .: "bytes"
 
 -- | The newly adopted tip, shared by ChainDB's two selection-change events.
 newtip :: Object -> Parser Raw

--- a/leios-trace-hs/src/ChainEvents.hs
+++ b/leios-trace-hs/src/ChainEvents.hs
@@ -51,6 +51,13 @@ data ChainEvent
     CVoteAcquired !Text !Word64
   | -- | @Forge.Loop.ForgedBlock@: the SUT forged a ranking (Praos) block (hash, slot).
     CRBForged !Text !Word64
+  | -- | @Forge.Loop.NodeIsLeader@: the SUT won the Praos slot lottery (slot).
+    --   Emitted by consensus independently of anything Leios does, so it is a
+    --   non-circular record of EB-production eligibility — the spec assumes
+    --   @canProduceEB@ holds exactly when the node can make a ranking block. Unlike
+    --   the cardano-api schedule it covers every epoch the log spans, which makes it
+    --   usable as a fallback when the query cannot supply a schedule for an epoch.
+    CNodeIsLeader !Word64
   deriving (Eq, Show, Generic)
 
 -- | Internal: one parsed line — a directly-emittable event, a linkage fact
@@ -105,6 +112,7 @@ pRaw = withObject "logline" $ \o -> do
     "Forge.Loop.StartLeadershipCheck" -> RawEvent . CSlot <$> d .: "slot"
     "Forge.Loop.ForgedBlock" ->
       RawEvent <$> (CRBForged <$> d .: "block" <*> d .: "slot")
+    "Forge.Loop.NodeIsLeader" -> RawEvent . CNodeIsLeader <$> d .: "slot"
     -- w31+ per-event namespaces
     "Consensus.LeiosKernel.BlockForged" ->
       RawEvent <$> (CEBForged <$> d .: "hash" <*> d .: "slot")

--- a/leios-trace-hs/src/ChainEvents.hs
+++ b/leios-trace-hs/src/ChainEvents.hs
@@ -66,6 +66,18 @@ data ChainEvent
     --   makes an EB votable, so it is what the verifier must key voting obligations
     --   on. Also retained internally as vote-resolution linkage.
     CAnnouncementAccepted !Text !Word64
+  | -- | @Consensus.LeiosKernel.NotVoted@: the SUT deliberately abstained from
+    --   voting on an EB (ebHash, EB's election slot, reason). In Linear Leios an
+    --   abstention is not a fault: the reason enumerates protocol-legal causes
+    --   (@chainTipDoesNotAnnounce@ once the chain has extended past the announcer,
+    --   @tooLate@, @notOnCommittee@). Corroborates a closed voting window.
+    CNotVoted !Text !Word64 !Text
+  | -- | @ChainDB.AddBlockEvent.AddedToCurrentChain@ / @SwitchedToAFork@: the SUT's
+    --   selected chain now has this tip slot. In Linear Leios a cert is valid only
+    --   in the ranking block that directly extends the announcer, so once the tip
+    --   advances past an announced EB that EB can no longer be certified — the
+    --   verifier uses this to close the EB's voting window.
+    CChainExtended !Word64
   deriving (Eq, Show, Generic)
 
 -- | Internal: one parsed line — a directly-emittable event, a linkage fact
@@ -74,10 +86,13 @@ data Raw
   = RawEvent !ChainEvent
   | -- | announcement accepted: election slot, ebHash
     RawAnn !Word64 !Text
-  | -- | chain linkage: rbHash, slot
+  | -- | chain linkage: rbHash, new tip slot. Records rbHash -> slot for vote
+    --   resolution AND surfaces the tip advance as 'CChainExtended'.
     RawRb !Text !Word64
   | -- | vote (True = cast by the SUT, False = acquired from a peer): rbHash
     RawVote !Bool !Text
+  | -- | deliberate abstention: ebHash, election slot, reason. EB-keyed.
+    RawNotVoted !Text !Word64 !Text
 
 -- | Vote-resolution state.
 data LinkState = LinkState
@@ -101,7 +116,9 @@ parseNodeLog =
       , Just (CAnnouncementAccepted ebHash slot)
       )
     RawRb rbHash slot ->
-      (st{lsSlotByRb = Map.insert rbHash slot (lsSlotByRb st)}, Nothing)
+      ( st{lsSlotByRb = Map.insert rbHash slot (lsSlotByRb st)}
+      , Just (CChainExtended slot)
+      )
     RawVote ours rbHash ->
       ( st
       , do
@@ -109,6 +126,8 @@ parseNodeLog =
           ebHash <- Map.lookup slot (lsEbBySlot st)
           pure $ (if ours then CVoted else CVoteAcquired) ebHash slot
       )
+    RawNotVoted ebHash slot reason ->
+      (st, Just (CNotVoted ebHash slot reason))
 
 -- | Parse a single log line; @Nothing@ for non-JSON banners and unrelated events.
 parseRaw :: BSL8.ByteString -> Maybe Raw
@@ -136,9 +155,13 @@ pRaw = withObject "logline" $ \o -> do
     "Consensus.LeiosKernel.VoteAcquired" -> do
       v <- d .: "vote"
       RawVote False <$> v .: "rbHash"
+    "Consensus.LeiosKernel.NotVoted" ->
+      RawNotVoted <$> d .: "ebHash" <*> d .: "ebSlot" <*> d .: "reason"
     -- Extending the current chain and switching to a fork are the two ways
-    -- ChainDB reports adopting a new tip. Ignoring the latter silently drops
-    -- every vote for an RB that arrived on a fork.
+    -- ChainDB reports adopting a new tip, and both matter twice over: the tip
+    -- advance retires any EB the superseded announcer carried, and the adopted
+    -- RB is what a vote is keyed on. Ignoring the fork-switch case silently
+    -- drops every vote for an RB that arrived on a fork.
     "ChainDB.AddBlockEvent.AddedToCurrentChain" -> newtip d
     "ChainDB.AddBlockEvent.SwitchedToAFork" -> newtip d
     -- pre-w31 envelope (kept for older logs)

--- a/leios-trace-hs/src/ChainEvents.hs
+++ b/leios-trace-hs/src/ChainEvents.hs
@@ -17,14 +17,17 @@
 --
 --     * election slot -> ebHash            (from @AnnouncementAccepted@; in
 --       Linear Leios the announcing RB and its EB share the election slot)
---     * rbHash -> slot                     (from @AddedToCurrentChain@)
+--     * rbHash -> slot                     (from @AddedToCurrentChain@ and
+--       @SwitchedToAFork@, the two ways ChainDB reports a new selection; both
+--       carry the adopted tip in @newtip@, and a node votes on the RB it
+--       selected however it came to select it)
 --
 --   composed at each vote event to resolve rbHash -> (ebHash, ebSlot).
 --   Unresolvable votes (linkage missing, e.g. truncated log prefix) are
 --   dropped rather than guessed.
 module ChainEvents where
 
-import Data.Aeson (Value, decode, withObject, (.:))
+import Data.Aeson (Object, Value, decode, withObject, (.:))
 import Data.Aeson.Types (Parser, parseMaybe)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.List (mapAccumL)
@@ -133,9 +136,11 @@ pRaw = withObject "logline" $ \o -> do
     "Consensus.LeiosKernel.VoteAcquired" -> do
       v <- d .: "vote"
       RawVote False <$> v .: "rbHash"
-    "ChainDB.AddBlockEvent.AddedToCurrentChain" -> do
-      tip <- d .: "newtip"
-      maybe (fail "unparseable newtip") (pure . uncurry RawRb) (parseTip tip)
+    -- Extending the current chain and switching to a fork are the two ways
+    -- ChainDB reports adopting a new tip. Ignoring the latter silently drops
+    -- every vote for an RB that arrived on a fork.
+    "ChainDB.AddBlockEvent.AddedToCurrentChain" -> newtip d
+    "ChainDB.AddBlockEvent.SwitchedToAFork" -> newtip d
     -- pre-w31 envelope (kept for older logs)
     "Consensus.LeiosKernel.TraceLeiosKernel" -> do
       kind <- d .: "kind"
@@ -150,6 +155,12 @@ pRaw = withObject "logline" $ \o -> do
           RawEvent <$> (CVoteAcquired <$> v .: "ebHash" <*> v .: "slot")
         _ -> fail "unhandled LeiosKernel kind"
     _ -> fail "unhandled ns"
+
+-- | The newly adopted tip, shared by ChainDB's two selection-change events.
+newtip :: Object -> Parser Raw
+newtip d = do
+  tip <- d .: "newtip"
+  maybe (fail "unparseable newtip") (pure . uncurry RawRb) (parseTip tip)
 
 -- | @"\<64 hex chars\>@\<decimal slot\>"@ from ChainDB's @newtip@ field.
 parseTip :: Text -> Maybe (Text, Word64)

--- a/leios-trace-hs/src/ChainEvents.hs
+++ b/leios-trace-hs/src/ChainEvents.hs
@@ -58,6 +58,11 @@ data ChainEvent
     --   the cardano-api schedule it covers every epoch the log spans, which makes it
     --   usable as a fallback when the query cannot supply a schedule for an epoch.
     CNodeIsLeader !Word64
+  | -- | @Consensus.LeiosKernel.AnnouncementAccepted@: the chain head now announces
+    --   this EB (ebHash, election slot). This — not acquiring the body — is what
+    --   makes an EB votable, so it is what the verifier must key voting obligations
+    --   on. Also retained internally as vote-resolution linkage.
+    CAnnouncementAccepted !Text !Word64
   deriving (Eq, Show, Generic)
 
 -- | Internal: one parsed line — a directly-emittable event, a linkage fact
@@ -89,7 +94,9 @@ parseNodeLog =
   step !st raw = case raw of
     RawEvent ev -> (st, Just ev)
     RawAnn slot ebHash ->
-      (st{lsEbBySlot = Map.insert slot ebHash (lsEbBySlot st)}, Nothing)
+      ( st{lsEbBySlot = Map.insert slot ebHash (lsEbBySlot st)}
+      , Just (CAnnouncementAccepted ebHash slot)
+      )
     RawRb rbHash slot ->
       (st{lsSlotByRb = Map.insert rbHash slot (lsSlotByRb st)}, Nothing)
     RawVote ours rbHash ->

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -323,6 +323,11 @@ queryChainOnce LeadershipOpts{..} = do
     Left err -> die ("local state query failed: " <> show err)
     Right (eSlots, stakeDistr, nodeEpoch) ->
       let mSlots = case eSlots of
+            -- No active stake is a state, not a fault: the schedule is KNOWN
+            -- empty (every production obligation is vacuous), unlike other
+            -- leadership errors, where it is unknown and we fall back to the
+            -- node log for EB eligibility.
+            Left (Api.LeaderErrStakePoolHasNoStake _) -> Just []
             Left _ -> Nothing
             Right slots -> Just (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots))
           mErr = case eSlots of
@@ -350,7 +355,13 @@ buildChainData ::
   Map.Map (Api.Hash Api.StakePoolKey) Rational ->
   ChainData
 buildChainData sutPool epochLength nodeEpoch winning m =
-  let pairs = Map.toList m -- sorted by pool-id, deterministic
+  -- A SUT absent from the distribution (no stake at all) joins as a
+  -- zero-stake party at the end: keeps the party set total for the spec
+  -- side, and the committee arithmetic correctly excludes it.
+  let pairs0 = Map.toList m -- sorted by pool-id, deterministic
+      pairs
+        | Prelude.any ((== sutPool) . fst) pairs0 = pairs0
+        | otherwise = pairs0 <> [(sutPool, 0)]
       nodeName i = T.pack ("node-" <> show (i :: Int))
       scaleStake r = floor (r * 1000000000) :: Integer
       stakeDist = [(nodeName i, scaleStake r) | (i, (_, r)) <- Prelude.zip [0 ..] pairs]

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -80,6 +80,13 @@ render = \case
     -- that slot's obligations.
     hPutStrLn stderr "stream ended: ok (slot in progress at end of input left unverified)"
     printActions acts
+  LeiosInactive led ->
+    hPutStrLn stderr $
+      "warning: the log shows no Leios activity — no EB forged, acquired, announced "
+        <> "or voted — so EB-role enforcement is suppressed for the "
+        <> show led
+        <> " slot(s) the node led. NodeIsLeader alone is Praos leadership, and only "
+        <> "implies EB eligibility while Leios is actually running."
   Summary entries -> summarize entries
 
 reportSchedule :: Segment -> Bool -> IO ()

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -18,8 +18,9 @@ module Main where
 import ChainEvents (ChainEvent (..), parseNodeLog)
 import Control.Monad (when)
 import Data.ByteString.Lazy as BSL
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.Maybe (fromMaybe)
 import Data.Yaml (FromJSON (..), decodeEither', withObject, (.:))
-import LeadershipSchedule (setLeadershipSchedule)
 import LinearLeiosLib
 import Options.Applicative
 import System.Exit (exitFailure)
@@ -63,26 +64,41 @@ data Segment = Segment
   , segStart :: Integer
   -- ^ first leadership-check slot of the segment
   , segCD :: ChainData
+  , segAuthoritative :: Bool
+  -- ^ Whether the queried leadership schedule applies to this epoch: obtained at
+  --   all, and for this very epoch. Pool stake takes two epochs to become active
+  --   (before that the query fails with @LeaderErrStakePoolHasNoStake@) and a node
+  --   answers only for its own current epoch, which in practice trails the epoch
+  --   being verified. When it does not apply, eligibility is taken from the node's
+  --   own leadership record in the log instead, so the segment is still verified.
   }
 
 -- | Verify the node.log stream one epoch-segment at a time. At each epoch
 --   boundary the node is re-queried for that epoch's leadership schedule and
 --   stake distribution, and a fresh segment is started from the boundary slot —
 --   so no process restart is needed and re-verification cost stays bounded per
---   epoch rather than growing over the whole run. This assumes the verifier
---   roughly keeps up with the live node, since a node reports only the current
---   epoch's schedule. Votes that straddle a boundary (an EB from the previous
---   epoch voted in the next) are a known limitation of the hard reset.
+--   epoch rather than growing over the whole run. Votes that straddle a boundary
+--   (an EB from the previous epoch voted in the next) are a known limitation of the
+--   hard reset.
+--
+--   A node can only answer for its own current epoch, and not at all until pool
+--   stake has activated two epochs in. A log that starts at genesis therefore
+--   always contains epochs whose schedule is unobtainable; those segments are
+--   skipped and named rather than verified against the wrong lottery, and the run
+--   ends with a summary of which epochs were verified and which were skipped.
 runSegmented ::
   LeadershipOpts ->
   (Integer, Integer, Integer, Integer) ->
   [ChainEvent] ->
   IO ()
-runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
+runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) evs = do
+  tally <- newIORef []
+  loop tally Nothing [] evs
+  summarize tally
  where
-  loop :: Maybe Segment -> [ChainEvent] -> [ChainEvent] -> IO ()
-  loop mseg seen [] = finishSeg mseg (Prelude.reverse seen)
-  loop mseg seen (ev : rest) = do
+  loop :: IORef [(Integer, Bool)] -> Maybe Segment -> [ChainEvent] -> [ChainEvent] -> IO ()
+  loop _ mseg seen [] = finishSeg mseg (Prelude.reverse seen)
+  loop tally mseg seen (ev : rest) = do
     hPutStrLn stderr $ "event: " <> show ev
     case ev of
       CSlot s -> case mseg of
@@ -90,7 +106,7 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
           -- same epoch: extend and re-check the current segment
           let seen' = ev : seen
           checkSeg seg (Prelude.reverse seen')
-          loop mseg seen' rest
+          loop tally mseg seen' rest
         _ -> do
           -- First segment, or an epoch boundary. This CSlot is what completes the
           -- outgoing segment's last slot, so give that segment one final check
@@ -102,29 +118,97 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
             Nothing -> pure ()
           -- (re-)query and start fresh. No check here: a lone CSlot closes no
           -- slot, so there would be nothing to verify yet.
-          seg <- newSegment (toInteger s)
-          loop (Just seg) [ev] rest
-      _ -> loop mseg (ev : seen) rest
+          seg <- newSegment tally (toInteger s)
+          loop tally (Just seg) [ev] rest
+      _ -> loop tally mseg (ev : seen) rest
 
-  newSegment :: Integer -> IO Segment
-  newSegment s = do
+  newSegment :: IORef [(Integer, Bool)] -> Integer -> IO Segment
+  newSegment tally s = do
     cd <- queryChain opts
-    setLeadershipSchedule (cdWinningSlots cd)
     let ep = s `div` cdEpochLength cd
+        -- Authoritative only if a schedule was obtained and it describes this very
+        -- epoch. Otherwise the log supplies eligibility and the segment is still
+        -- verified — an unusable schedule is no longer a reason to skip an epoch.
+        authoritative = maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
+    reportSchedule cd ep s authoritative
+    modifyIORef' tally ((ep, authoritative) :)
+    pure Segment{segEpoch = ep, segStart = s, segCD = cd, segAuthoritative = authoritative}
+
+  reportSchedule :: ChainData -> Integer -> Integer -> Bool -> IO ()
+  reportSchedule cd ep s authoritative = do
     hPutStrLn stderr $
       "epoch "
         <> show ep
         <> " (from slot "
         <> show s
         <> "): "
-        <> show (Prelude.length (cdWinningSlots cd))
-        <> " winning slots "
-        <> show (cdWinningSlots cd)
-        <> ", "
         <> show (cdNumParties cd)
         <> " parties, SUT at index "
         <> show (cdSutIndex cd)
-    pure Segment{segEpoch = ep, segStart = s, segCD = cd}
+        <> ", eligibility from "
+        <> source
+    when authoritative (warnSlotsOutsideEpoch cd ep)
+   where
+    source = case cdWinningSlots cd of
+      Nothing -> "the log (the node could supply no schedule)"
+      Just slots
+        | authoritative ->
+            "the node schedule: "
+              <> show (Prelude.length slots)
+              <> " winning slots "
+              <> show slots
+        | otherwise ->
+            "the log (the node answered for epoch "
+              <> show (cdNodeEpoch cd)
+              <> ", so its schedule "
+              <> show slots
+              <> " does not apply here)"
+
+  -- The node claims this epoch, so its winning slots ought to lie inside it. If any
+  -- do not, an assumption is wrong — epochLength, or which epoch the schedule is
+  -- computed for — and this segment is being verified unsoundly. Report loudly
+  -- rather than refuse: refusing has already proved too blunt, and this is precisely
+  -- the diagnostic needed to tell which assumption is off.
+  warnSlotsOutsideEpoch :: ChainData -> Integer -> IO ()
+  warnSlotsOutsideEpoch cd ep =
+    case Prelude.filter (not . inEpoch) (fromMaybe [] (cdWinningSlots cd)) of
+      [] -> pure ()
+      out ->
+        hPutStrLn stderr $
+          "warning: node reported epoch "
+            <> show ep
+            <> " but winning slots "
+            <> show out
+            <> " fall outside its slot range "
+            <> show (ep * len)
+            <> ".."
+            <> show ((ep + 1) * len - 1)
+            <> " (they lie in epoch(s) "
+            <> show (Prelude.map (`div` len) out)
+            <> "); verification of this segment is unsound"
+   where
+    len = cdEpochLength cd
+    inEpoch sl = sl >= ep * len && sl < (ep + 1) * len
+
+  -- Every segment is verified now, so the interesting distinction is which
+  -- eligibility source each epoch used. A log-derived one cannot catch an EB forged
+  -- in a slot the node never recorded winning, so it is worth knowing where the
+  -- guarantee is weaker.
+  summarize :: IORef [(Integer, Bool)] -> IO ()
+  summarize tally = do
+    entries <- Prelude.reverse <$> readIORef tally
+    let fromSchedule = [ep | (ep, True) <- entries]
+        fromLog = [ep | (ep, False) <- entries]
+    if Prelude.null entries
+      then hPutStrLn stderr "summary: no segment was verified"
+      else
+        hPutStrLn stderr $
+          "summary: verified epoch(s) "
+            <> show (Prelude.map fst entries)
+            <> "; eligibility from the node schedule for "
+            <> (if Prelude.null fromSchedule then "none" else show fromSchedule)
+            <> ", from the log for "
+            <> (if Prelude.null fromLog then "none" else show fromLog)
 
   verifySeg :: Segment -> [ChainEvent] -> ([T.Text], (T.Text, T.Text))
   verifySeg seg prefix =
@@ -137,6 +221,8 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
           lvote
           ldiff
           validityCheckTime
+          (fromMaybe [] (cdWinningSlots cd))
+          (segAuthoritative seg)
           prefix
           (segStart seg)
 
@@ -206,8 +292,11 @@ data LeadershipOpts = LeadershipOpts
 
 -- | Everything we read from the chain for verification.
 data ChainData = ChainData
-  { cdWinningSlots :: [Integer]
+  { cdWinningSlots :: Maybe [Integer]
   -- ^ The SUT's leadership schedule, as plain naturals for the Agda oracle.
+  --   'Nothing' when the node could not supply one at all — chiefly on a young
+  --   network, where pool stake has not activated yet. Not fatal: eligibility then
+  --   comes from the node's own leadership record in the log.
   , cdNumParties :: Integer
   -- ^ Number of parties (= number of stake pools).
   , cdStakeDistribution :: [(T.Text, Integer)]
@@ -217,15 +306,60 @@ data ChainData = ChainData
   , cdEpochLength :: Integer
   -- ^ Slots per epoch (from the Shelley genesis), used to detect epoch
   --   boundaries so the schedule and stake distribution can be re-queried.
+  , cdNodeEpoch :: Integer
+  -- ^ The epoch the node itself reported when queried, i.e. the epoch the
+  --   returned schedule belongs to. This is the epoch of the /chain tip/ (the
+  --   query runs at 'Api.VolatileTip'), not of the wall clock, so it lags
+  --   whenever block production is sparse — which is one way the schedule ends
+  --   up describing a different epoch than the one being verified.
   }
 
--- | Query a running node (via the cardano-api local-state-query protocol) for
---   the SUT's leadership schedule (the slots in which its pool is an eligible
---   leader) and the on-chain stake distribution, over a single connection.
---   Mirrors cardano-cli's @runQueryLeadershipScheduleCmd@ /
---   @runQueryStakeDistributionCmd@.
+-- | Query the chain for the leadership schedule, stake distribution and party count.
+--
+-- A missing schedule is not fatal: eligibility falls back to the node's own
+-- leadership record in the log, so every epoch is still verified. It is reported
+-- anyway, because that fallback is the SUT's self-report rather than an independent
+-- oracle and so cannot catch the node's leadership logging itself being wrong.
+--
+-- No waiting: retrying until the query succeeds would not help. Success is not the
+-- same as applicability — the node answers for the epoch of its chain tip, which
+-- trails the epoch being verified, so a schedule fetched after a wait is usually
+-- still for the wrong epoch. Waiting would also let the log accumulate, leaving the
+-- verifier further behind and the mismatch more likely.
 queryChain :: LeadershipOpts -> IO ChainData
-queryChain LeadershipOpts{..} = do
+queryChain opts = do
+  (cd, mlerr) <- queryChainOnce opts
+  case mlerr of
+    Nothing -> pure ()
+    Just lerr -> hPutStrLn stderr (scheduleUnavailable opts lerr)
+  pure cd
+
+-- | Explain why no authoritative schedule could be had. Two quite different
+-- situations produce it and they call for different responses, so name both.
+scheduleUnavailable :: LeadershipOpts -> Api.LeadershipError -> String
+scheduleUnavailable LeadershipOpts{..} lerr =
+  "no leadership schedule for pool "
+    <> T.unpack (Api.serialiseToRawBytesHexText loStakePoolId)
+    <> ": "
+    <> show lerr
+    <> ".\n"
+    <> "  (a) The network may be too young: pool stake takes two epochs to become\n"
+    <> "      active, so no schedule exists until the third epoch is under way.\n"
+    <> "  (b) That pool may have no stake at all — not registered, nothing\n"
+    <> "      delegated, or the wrong --stake-pool-id. Compare the id above with\n"
+    <> "      'cardano-cli query stake-pools'.\n"
+    <> "  Continuing with eligibility taken from the log instead, which cannot catch\n"
+    <> "  an EB forged in a slot the node never recorded winning."
+
+-- | One attempt at the chain query (via the cardano-api local-state-query protocol):
+--   the SUT's leadership schedule (the slots in which its pool is an eligible
+--   leader) and the on-chain stake distribution, over a single connection. Mirrors
+--   cardano-cli's @runQueryLeadershipScheduleCmd@ / @runQueryStakeDistributionCmd@.
+--   Returns the data alongside the leadership error, if any: only the schedule part
+--   can fail this way, and it is recoverable, so the stake distribution and party
+--   count are still delivered. Anything else is fatal here.
+queryChainOnce :: LeadershipOpts -> IO (ChainData, Maybe Api.LeadershipError)
+queryChainOnce LeadershipOpts{..} = do
   vrfSkey <-
     Api.readFileTextEnvelope @(Api.SigningKey Api.VrfKey) (Api.File loVrfSkeyFile)
       >>= orDie "reading VRF signing key"
@@ -245,6 +379,7 @@ queryChain LeadershipOpts{..} = do
         Api.AcquiringFailure
         ( Either Api.LeadershipError (Set.Set Api.SlotNo)
         , Map.Map (Api.Hash Api.StakePoolKey) Rational
+        , Api.EpochNo
         )
     ) <-
     Api.executeLocalStateQueryExpr connInfo Api.VolatileTip $ do
@@ -280,14 +415,27 @@ queryChain LeadershipOpts{..} = do
                         currentEpoch
                     NextEpoch ->
                       error "next-epoch schedule not yet implemented"
-            pure (schedule, stakeDistr)
+            pure (schedule, stakeDistr, currentEpoch)
         )
         era
   case result of
     Left err -> die ("local state query failed: " <> show err)
-    Right (Left lerr, _) -> die ("leadership schedule error: " <> show lerr)
-    Right (Right slots, stakeDistr) ->
-      pure $ buildChainData loStakePoolId epochLength (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots)) stakeDistr
+    Right (eSlots, stakeDistr, nodeEpoch) ->
+      let mSlots = case eSlots of
+            Left _ -> Nothing
+            Right slots -> Just (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots))
+          mErr = case eSlots of
+            Left lerr -> Just lerr
+            Right _ -> Nothing
+       in pure
+            ( buildChainData
+                loStakePoolId
+                epochLength
+                (toInteger (Api.unEpochNo nodeEpoch))
+                mSlots
+                stakeDistr
+            , mErr
+            )
 
 -- | Turn the on-chain stake distribution (pool-id → relative stake) into the
 --   verifier's view: parties are the pools in chain (Map) order, keyed
@@ -296,23 +444,31 @@ queryChain LeadershipOpts{..} = do
 buildChainData ::
   (Api.Hash Api.StakePoolKey) ->
   Integer ->
-  [Integer] ->
+  Integer ->
+  Maybe [Integer] ->
   Map.Map (Api.Hash Api.StakePoolKey) Rational ->
   ChainData
-buildChainData sutPool epochLength winning m =
+buildChainData sutPool epochLength nodeEpoch winning m =
   let pairs = Map.toList m -- sorted by pool-id, deterministic
       nodeName i = T.pack ("node-" <> show (i :: Int))
       scaleStake r = floor (r * 1000000000) :: Integer
       stakeDist = [(nodeName i, scaleStake r) | (i, (_, r)) <- Prelude.zip [0 ..] pairs]
       sutIdx =
-        maybe (error "SUT stake pool not found in chain stake distribution") toInteger $
+        maybe (error sutNotFound) toInteger $
           List.findIndex ((== sutPool) . fst) pairs
+      sutNotFound =
+        "SUT stake pool not found in the chain stake distribution, which lists "
+          <> show (Prelude.length pairs)
+          <> " pool(s). On a young network the distribution can still be empty, "
+          <> "since pool stake takes two epochs to activate; otherwise check "
+          <> "--stake-pool-id."
    in ChainData
         { cdWinningSlots = winning
         , cdNumParties = toInteger (Prelude.length pairs)
         , cdStakeDistribution = stakeDist
         , cdSutIndex = sutIdx
         , cdEpochLength = epochLength
+        , cdNodeEpoch = nodeEpoch
         }
 
 expectQuery ::

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -92,9 +92,17 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
           checkSeg seg (Prelude.reverse seen')
           loop mseg seen' rest
         _ -> do
-          -- first segment, or an epoch boundary: (re-)query and start fresh
+          -- First segment, or an epoch boundary. This CSlot is what completes the
+          -- outgoing segment's last slot, so give that segment one final check
+          -- with the boundary event appended before discarding its events —
+          -- otherwise the last slot of every epoch would go unverified, since a
+          -- streaming check never adjudicates the slot still in progress.
+          case mseg of
+            Just old -> checkSeg old (Prelude.reverse (ev : seen))
+            Nothing -> pure ()
+          -- (re-)query and start fresh. No check here: a lone CSlot closes no
+          -- slot, so there would be nothing to verify yet.
           seg <- newSegment (toInteger s)
-          checkSeg seg [ev]
           loop (Just seg) [ev] rest
       _ -> loop mseg (ev : seen) rest
 
@@ -144,7 +152,12 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) = loop Nothing []
   finishSeg (Just seg) prefix =
     let (acts, (status, detail)) = verifySeg seg prefix
      in if status == "ok"
-          then hPutStrLn stderr "stream ended: ok" >> printActions acts
+          then
+            -- The slot in progress when the input ended is deliberately not
+            -- adjudicated: a stream truncated mid-slot has not yet shown the
+            -- events that would discharge that slot's obligations.
+            hPutStrLn stderr "stream ended: ok (slot in progress at end of input left unverified)"
+              >> printActions acts
           else failOut prefix acts status detail
 
   printActions = mapM_ (\a -> hPutStrLn stderr ("  action: " <> T.unpack a))

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -77,9 +77,11 @@ data Segment = Segment
 --   boundary the node is re-queried for that epoch's leadership schedule and
 --   stake distribution, and a fresh segment is started from the boundary slot —
 --   so no process restart is needed and re-verification cost stays bounded per
---   epoch rather than growing over the whole run. Votes that straddle a boundary
---   (an EB from the previous epoch voted in the next) are a known limitation of the
---   hard reset.
+--   epoch rather than growing over the whole run. A segment does not begin exactly
+--   at the boundary, though: it carries 'overlapSlots' of the outgoing epoch with it,
+--   so an obligation raised there but falling due after the boundary is still
+--   checked. A clean cut would clear EBs' and curEB, and such a vote would then pass
+--   vacuously.
 --
 --   A node can only answer for its own current epoch, and not at all until pool
 --   stake has activated two epochs in. A log that starts at genesis therefore
@@ -116,31 +118,58 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) evs = do
           case mseg of
             Just old -> checkSeg old (Prelude.reverse (ev : seen))
             Nothing -> pure ()
-          -- (re-)query and start fresh. No check here: a lone CSlot closes no
-          -- slot, so there would be nothing to verify yet.
-          seg <- newSegment tally (toInteger s)
-          loop tally (Just seg) [ev] rest
+          -- Carry the tail of the outgoing epoch into the new segment, so that an
+          -- obligation raised before the boundary and falling due after it is still
+          -- checked. No check here: the carried slots were just adjudicated by the
+          -- outgoing segment, and the boundary slot itself is still in progress.
+          let carried = Prelude.takeWhile (notBefore (toInteger s - overlapSlots)) seen
+              seen' = ev : carried
+              start = earliestSlot (toInteger s) seen'
+          seg <- newSegment tally (toInteger s) start (not (Prelude.null carried))
+          loop tally (Just seg) seen' rest
       _ -> loop tally mseg (ev : seen) rest
 
-  newSegment :: IORef [(Integer, Bool)] -> Integer -> IO Segment
-  newSegment tally s = do
-    cd <- queryChain opts
-    let ep = s `div` cdEpochLength cd
-        -- Authoritative only if a schedule was obtained and it describes this very
-        -- epoch. Otherwise the log supplies eligibility and the segment is still
-        -- verified — an unusable schedule is no longer a reason to skip an epoch.
-        authoritative = maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
-    reportSchedule cd ep s authoritative
-    modifyIORef' tally ((ep, authoritative) :)
-    pure Segment{segEpoch = ep, segStart = s, segCD = cd, segAuthoritative = authoritative}
+  -- How far back an obligation can reach. An EB with election slot e becomes votable
+  -- in slot e + (3 * Lhdr `max` validityCheckTime), and its acquisition may lag the
+  -- election by up to Lhdr, so carrying that many slots covers every obligation able
+  -- to straddle a boundary.
+  overlapSlots :: Integer
+  overlapSlots = Prelude.max (3 * lhdr) validityCheckTime + lhdr
 
-  reportSchedule :: ChainData -> Integer -> Integer -> Bool -> IO ()
-  reportSchedule cd ep s authoritative = do
+  notBefore :: Integer -> ChainEvent -> Bool
+  notBefore cutoff (CSlot sl) = toInteger sl >= cutoff
+  notBefore _ _ = True
+
+  -- Earliest slot tick among a segment's events, which is where verification starts.
+  earliestSlot :: Integer -> [ChainEvent] -> Integer
+  earliestSlot dflt es = case [toInteger sl | CSlot sl <- es] of
+    [] -> dflt
+    ss -> Prelude.minimum ss
+
+  newSegment :: IORef [(Integer, Bool)] -> Integer -> Integer -> Bool -> IO Segment
+  newSegment tally boundary start spansEpochs = do
+    cd <- queryChain opts
+    let ep = boundary `div` cdEpochLength cd
+        -- Authoritative only if a schedule was obtained, it describes this very
+        -- epoch, and this segment lies wholly inside that epoch. A segment carrying
+        -- an overlap spans two, so no single epoch's schedule governs all of it and
+        -- eligibility has to come from the log. Otherwise an EB forged in the carried
+        -- tail would be judged against the following epoch's lottery.
+        authoritative =
+          not spansEpochs
+            && maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
+    reportSchedule cd ep start spansEpochs authoritative
+    modifyIORef' tally ((ep, authoritative) :)
+    pure Segment{segEpoch = ep, segStart = start, segCD = cd, segAuthoritative = authoritative}
+
+  reportSchedule :: ChainData -> Integer -> Integer -> Bool -> Bool -> IO ()
+  reportSchedule cd ep s spansEpochs authoritative = do
     hPutStrLn stderr $
       "epoch "
         <> show ep
         <> " (from slot "
         <> show s
+        <> (if spansEpochs then ", carrying the tail of the previous epoch" else "")
         <> "): "
         <> show (cdNumParties cd)
         <> " parties, SUT at index "
@@ -157,6 +186,12 @@ runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) evs = do
               <> show (Prelude.length slots)
               <> " winning slots "
               <> show slots
+        | spansEpochs ->
+            "the log (this segment spans two epochs, so the schedule "
+              <> show slots
+              <> " for epoch "
+              <> show (cdNodeEpoch cd)
+              <> " cannot govern all of it)"
         | otherwise ->
             "the log (the node answered for epoch "
               <> show (cdNodeEpoch cd)

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -87,6 +87,20 @@ render = \case
         <> show led
         <> " slot(s) the node led. NodeIsLeader alone is Praos leadership, and only "
         <> "implies EB eligibility while Leios is actually running."
+  EBOwedUndecided n ->
+    hPutStrLn stderr $
+      "note: for "
+        <> show n
+        <> " slot(s) the mempool reading straddled the ranking block's capacity, so "
+        <> "whether an EB was owed could not be settled; those slots were excused. "
+        <> "The node decides from a snapshot the log does not pin down, so this is "
+        <> "the cost of never flagging a slot we cannot show was in breach."
+  NoMempoolReadings ->
+    hPutStrLn stderr $
+      "warning: no mempool readings in this prefix, so EB-role enforcement lapses "
+        <> "for slots without a forge — an EB can only be shown to be owed when the "
+        <> "mempool is known not to have fitted in the ranking block. Expected for "
+        <> "logs predating the Mempool traces."
   Summary entries -> summarize entries
 
 reportSchedule :: Segment -> Bool -> IO ()
@@ -196,11 +210,22 @@ failOut nEvents acts status detail = do
 
 -- * Reading from the chain via cardano-api
 
--- | Minimal view of the Shelley genesis: just the epoch length (slots/epoch).
-newtype GenesisEL = GenesisEL Integer
+-- | Minimal view of the Shelley genesis: the epoch length (slots/epoch) and the
+--   ranking block's body capacity.
+--
+--   'maxBlockBodySize' is taken from genesis rather than from the protocol-params
+--   query, so it is the network's initial value; an on-chain parameter update would
+--   leave it stale. Acceptable for now because it is used only to decide whether the
+--   mempool could have fitted in an RB, and the comparison is deliberately one-sided,
+--   but it is the value to source from 'pparams' if that ever matters.
+data GenesisEL = GenesisEL Integer Integer
 
 instance FromJSON GenesisEL where
-  parseJSON = withObject "ShelleyGenesis" $ \o -> GenesisEL <$> o .: "epochLength"
+  parseJSON = withObject "ShelleyGenesis" $ \o -> do
+    el <- o .: "epochLength"
+    pp <- o .: "protocolParams"
+    mb <- pp .: "maxBlockBodySize"
+    pure (GenesisEL el mb)
 
 -- | Which epoch's leadership schedule to query.
 data WhichEpoch = CurrentEpoch | NextEpoch
@@ -282,8 +307,10 @@ queryChainOnce LeadershipOpts{..} = do
   genesisBytes <- BS.readFile loGenesisFile
   (shelleyGenesis :: Api.ShelleyGenesis) <-
     orDie "decoding Shelley genesis" (eitherDecodeStrictText genesisBytes)
-  GenesisEL epochLength <-
-    orDie "reading epochLength from Shelley genesis" (eitherDecodeStrictText genesisBytes)
+  GenesisEL epochLength maxRBBody <-
+    orDie
+      "reading epochLength and maxBlockBodySize from Shelley genesis"
+      (eitherDecodeStrictText genesisBytes)
   let connInfo =
         Api.LocalNodeConnectInfo
           { Api.localConsensusModeParams = Api.CardanoModeParams (Api.EpochSlots 21600)
@@ -361,6 +388,7 @@ queryChainOnce LeadershipOpts{..} = do
             ( buildChainData
                 loStakePoolId
                 epochLength
+                maxRBBody
                 (toInteger (Api.unEpochNo nodeEpoch))
                 mSlots
                 stakeDistr
@@ -375,10 +403,11 @@ buildChainData ::
   (Api.Hash Api.StakePoolKey) ->
   Integer ->
   Integer ->
+  Integer ->
   Maybe [Integer] ->
   Map.Map (Api.Hash Api.StakePoolKey) Rational ->
   ChainData
-buildChainData sutPool epochLength nodeEpoch winning m =
+buildChainData sutPool epochLength maxRBBody nodeEpoch winning m =
   -- A SUT absent from the distribution (no stake at all) joins as a
   -- zero-stake party at the end: keeps the party set total for the spec
   -- side, and the committee arithmetic correctly excludes it.
@@ -404,6 +433,7 @@ buildChainData sutPool epochLength nodeEpoch winning m =
         , cdStakeDistribution = stakeDist
         , cdSutIndex = sutIdx
         , cdEpochLength = epochLength
+        , cdMaxRBBody = maxRBBody
         , cdNodeEpoch = nodeEpoch
         }
 

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -258,6 +258,7 @@ data LeadershipOpts = LeadershipOpts
   , loVrfSkeyFile :: FilePath
   , loWhich :: WhichEpoch
   }
+
 --
 -- A missing schedule is not fatal: eligibility falls back to the node's own
 -- leadership record in the log, so every epoch is still verified. It is reported
@@ -391,36 +392,38 @@ queryChainOnce LeadershipOpts{..} = do
   case result of
     Left err -> die ("local state query failed: " <> show err)
     Right (eSlots, stakeDistr, nodeEpoch) ->
-      let -- Stake registered in epoch e becomes active in epoch e+2, so before
-          -- epoch 2 a pool that will have stake still reports as having none. The
-          -- error cannot tell the two apart, so the epoch decides which reading is
-          -- safe.
-          stakeCanHaveActivated = toInteger (Api.unEpochNo nodeEpoch) >= 2
-          mSlots = case eSlots of
-            -- From epoch 2 on, no active stake is a state rather than a fault: the
-            -- schedule is KNOWN empty, every production obligation is vacuous, and
-            -- an EB forge would be a genuine violation. Earlier than that the same
-            -- error means only "not snapshotted yet", so it is an unknown schedule
-            -- like any other leadership error and eligibility comes from the log —
-            -- otherwise a devnet pool forging on genesis stake in epoch 0 is
-            -- reported as violating EB-Role.
-            Left (Api.LeaderErrStakePoolHasNoStake _)
-              | stakeCanHaveActivated -> Just []
-            Left _ -> Nothing
-            Right slots -> Just (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots))
-          mErr = case eSlots of
-            Left lerr -> Just lerr
-            Right _ -> Nothing
-       in pure
-            ( buildChainData
-                loStakePoolId
-                epochLength
-                maxRBBody
-                (toInteger (Api.unEpochNo nodeEpoch))
-                mSlots
-                stakeDistr
-            , mErr
-            )
+      let
+        -- Stake registered in epoch e becomes active in epoch e+2, so before
+        -- epoch 2 a pool that will have stake still reports as having none. The
+        -- error cannot tell the two apart, so the epoch decides which reading is
+        -- safe.
+        stakeCanHaveActivated = toInteger (Api.unEpochNo nodeEpoch) >= 2
+        mSlots = case eSlots of
+          -- From epoch 2 on, no active stake is a state rather than a fault: the
+          -- schedule is KNOWN empty, every production obligation is vacuous, and
+          -- an EB forge would be a genuine violation. Earlier than that the same
+          -- error means only "not snapshotted yet", so it is an unknown schedule
+          -- like any other leadership error and eligibility comes from the log —
+          -- otherwise a devnet pool forging on genesis stake in epoch 0 is
+          -- reported as violating EB-Role.
+          Left (Api.LeaderErrStakePoolHasNoStake _)
+            | stakeCanHaveActivated -> Just []
+          Left _ -> Nothing
+          Right slots -> Just (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots))
+        mErr = case eSlots of
+          Left lerr -> Just lerr
+          Right _ -> Nothing
+       in
+        pure
+          ( buildChainData
+              loStakePoolId
+              epochLength
+              maxRBBody
+              (toInteger (Api.unEpochNo nodeEpoch))
+              mSlots
+              stakeDistr
+          , mErr
+          )
 
 -- | Turn the on-chain stake distribution (pool-id → relative stake) into the
 --   verifier's view: parties are the pools in chain (Map) order, keyed

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -87,6 +87,16 @@ render = \case
         <> show led
         <> " slot(s) the node led. NodeIsLeader alone is Praos leadership, and only "
         <> "implies EB eligibility while Leios is actually running."
+  SlotGap from to ->
+    hPutStrLn stderr $
+      "note: no leadership check logged for slot(s) "
+        <> show (from + 1)
+        <> ".."
+        <> show (to - 1)
+        <> " — verification restarts at "
+        <> show to
+        <> ". The spec advances one slot at a time, so a slot with no record cannot "
+        <> "be verified across; obligations straddling the gap are not checked."
   EBOwedUndecided n ->
     hPutStrLn stderr $
       "note: for "

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -104,6 +104,21 @@ render = \case
         <> show to
         <> ". The spec advances one slot at a time, so a slot with no record cannot "
         <> "be verified across; obligations straddling the gap are not checked."
+  SurplusVotesInSlot n ->
+    hPutStrLn stderr $
+      "note: "
+        <> show n
+        <> " vote(s) fell in a slot that already had one. Only one vote per slot can "
+        <> "be adjudicated, the spec recording VT-Role upkeep once per slot, so the "
+        <> "first is checked and these were not."
+  NonMonotonicSlot lastSeen s ->
+    hPutStrLn stderr $
+      "warning: leadership check for slot "
+        <> show s
+        <> " arrived after slot "
+        <> show lastSeen
+        <> " — a duplicate or out-of-order tick, as concatenated or overlapping logs "
+        <> "produce. Dropped: there is nothing to verify backwards."
   EBOwedUndecided n ->
     hPutStrLn stderr $
       "note: for "

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -221,6 +221,9 @@ data LeadershipOpts = LeadershipOpts
 -- leadership record in the log, so every epoch is still verified. It is reported
 -- anyway, because that fallback is the SUT's self-report rather than an independent
 -- oracle and so cannot catch the node's leadership logging itself being wrong.
+-- One leadership error does not fall back at all — no stake, once the chain is past
+-- the two-epoch activation delay, is a known-empty schedule and stronger than the
+-- log — so the message is chosen from the resulting schedule, not from the error.
 --
 -- No waiting: retrying until the query succeeds would not help. Success is not the
 -- same as applicability — the node answers for the epoch of its chain tip, which
@@ -232,25 +235,37 @@ queryChain opts = do
   (cd, mlerr) <- queryChainOnce opts
   case mlerr of
     Nothing -> pure ()
-    Just lerr -> hPutStrLn stderr (scheduleUnavailable opts lerr)
+    Just lerr -> hPutStrLn stderr (scheduleUnavailable opts lerr (cdWinningSlots cd))
   pure cd
 
--- | Explain why no authoritative schedule could be had. Two quite different
--- situations produce it and they call for different responses, so name both.
-scheduleUnavailable :: LeadershipOpts -> Api.LeadershipError -> String
-scheduleUnavailable LeadershipOpts{..} lerr =
+-- | Explain what the leadership error means and, crucially, what was done about it.
+-- Not every such error causes a fallback: past the stake activation delay, no stake
+-- is a known-empty schedule rather than a missing one, and saying "continuing from
+-- the log" there would contradict the epoch line printed immediately afterwards.
+-- The resulting schedule therefore decides which explanation is the true one.
+scheduleUnavailable :: LeadershipOpts -> Api.LeadershipError -> Maybe [Integer] -> String
+scheduleUnavailable LeadershipOpts{..} lerr mSlots =
   "no leadership schedule for pool "
     <> T.unpack (Api.serialiseToRawBytesHexText loStakePoolId)
     <> ": "
     <> show lerr
     <> ".\n"
-    <> "  (a) The network may be too young: pool stake takes two epochs to become\n"
-    <> "      active, so no schedule exists until the third epoch is under way.\n"
-    <> "  (b) That pool may have no stake at all — not registered, nothing\n"
-    <> "      delegated, or the wrong --stake-pool-id. Compare the id above with\n"
-    <> "      'cardano-cli query stake-pools'.\n"
-    <> "  Continuing with eligibility taken from the log instead, which cannot catch\n"
-    <> "  an EB forged in a slot the node never recorded winning."
+    <> case mSlots of
+      -- Past the activation delay: "no stake" is the answer, not a gap in it.
+      Just _ ->
+        "  The chain is past the two-epoch stake activation delay, so this pool\n"
+          <> "  genuinely has no stake — not registered, nothing delegated, or the wrong\n"
+          <> "  --stake-pool-id. Compare the id above with 'cardano-cli query stake-pools'.\n"
+          <> "  Taking the schedule as known-empty, which is stronger than the log: every\n"
+          <> "  production obligation is vacuous, so an EB forged here is a real violation."
+      Nothing ->
+        "  (a) The network may be too young: pool stake takes two epochs to become\n"
+          <> "      active, so no schedule exists until the third epoch is under way.\n"
+          <> "  (b) That pool may have no stake at all — not registered, nothing\n"
+          <> "      delegated, or the wrong --stake-pool-id. Compare the id above with\n"
+          <> "      'cardano-cli query stake-pools'.\n"
+          <> "  Continuing with eligibility taken from the log instead, which cannot catch\n"
+          <> "  an EB forged in a slot the node never recorded winning."
 
 -- | One attempt at the chain query (via the cardano-api local-state-query protocol):
 --   the SUT's leadership schedule (the slots in which its pool is an eligible
@@ -322,12 +337,21 @@ queryChainOnce LeadershipOpts{..} = do
   case result of
     Left err -> die ("local state query failed: " <> show err)
     Right (eSlots, stakeDistr, nodeEpoch) ->
-      let mSlots = case eSlots of
-            -- No active stake is a state, not a fault: the schedule is KNOWN
-            -- empty (every production obligation is vacuous), unlike other
-            -- leadership errors, where it is unknown and we fall back to the
-            -- node log for EB eligibility.
-            Left (Api.LeaderErrStakePoolHasNoStake _) -> Just []
+      let -- Stake registered in epoch e becomes active in epoch e+2, so before
+          -- epoch 2 a pool that will have stake still reports as having none. The
+          -- error cannot tell the two apart, so the epoch decides which reading is
+          -- safe.
+          stakeCanHaveActivated = toInteger (Api.unEpochNo nodeEpoch) >= 2
+          mSlots = case eSlots of
+            -- From epoch 2 on, no active stake is a state rather than a fault: the
+            -- schedule is KNOWN empty, every production obligation is vacuous, and
+            -- an EB forge would be a genuine violation. Earlier than that the same
+            -- error means only "not snapshotted yet", so it is an unknown schedule
+            -- like any other leadership error and eligibility comes from the log —
+            -- otherwise a devnet pool forging on genesis stake in epoch 0 is
+            -- reported as violating EB-Role.
+            Left (Api.LeaderErrStakePoolHasNoStake _)
+              | stakeCanHaveActivated -> Just []
             Left _ -> Nothing
             Right slots -> Just (Prelude.map (toInteger . Api.unSlotNo) (Set.toList slots))
           mErr = case eSlots of

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -15,13 +15,19 @@
 --   is needed.
 module Main where
 
-import ChainEvents (ChainEvent (..), parseNodeLog)
+import ChainEvents (parseNodeLog)
 import Control.Monad (when)
 import Data.ByteString.Lazy as BSL
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Maybe (fromMaybe)
 import Data.Yaml (FromJSON (..), decodeEither', withObject, (.:))
-import LinearLeiosLib
+import LinearLeiosChain (
+  ChainData (..),
+  Progress (..),
+  Segment (..),
+  Timings (..),
+  isCSlot,
+  runSegmented,
+ )
 import Options.Applicative
 import System.Exit (exitFailure)
 import System.IO (BufferMode (LineBuffering), hPutStrLn, hSetBuffering, stderr, stdout)
@@ -40,10 +46,7 @@ main :: IO ()
 main = do
   ChainCommand{..} <- execParser commandParser
 
-  let lhdr = 1
-      lvote = 4
-      ldiff = 7
-      validityCheckTime = 3
+  let timings = Timings{tLhdr = 1, tLvote = 4, tLdiff = 7, tValidityCheckTime = 3}
 
   hSetBuffering stdout LineBuffering
   evs <- parseNodeLog <$> BSL.getContents
@@ -55,252 +58,134 @@ main = do
     "skipped "
       <> show (Prelude.length preSlot)
       <> " pre-slot events (node sync/replay backlog, before the first leadership-check slot)"
-  runSegmented leadershipOpts (lhdr, lvote, ldiff, validityCheckTime) rest
+  runSegmented render timings (const (queryChain leadershipOpts)) rest
 
--- | A verification segment: the part of the trace within one epoch, verified
---   against the schedule and stake distribution queried for that epoch.
-data Segment = Segment
-  { segEpoch :: Integer
-  , segStart :: Integer
-  -- ^ first leadership-check slot of the segment
-  , segCD :: ChainData
-  , segAuthoritative :: Bool
-  -- ^ Whether the queried leadership schedule applies to this epoch: obtained at
-  --   all, and for this very epoch. Pool stake takes two epochs to become active
-  --   (before that the query fails with @LeaderErrStakePoolHasNoStake@) and a node
-  --   answers only for its own current epoch, which in practice trails the epoch
-  --   being verified. When it does not apply, eligibility is taken from the node's
-  --   own leadership record in the log instead, so the segment is still verified.
-  }
+-- * Rendering
 
--- | Verify the node.log stream one epoch-segment at a time. At each epoch
---   boundary the node is re-queried for that epoch's leadership schedule and
---   stake distribution, and a fresh segment is started from the boundary slot —
---   so no process restart is needed and re-verification cost stays bounded per
---   epoch rather than growing over the whole run. A segment does not begin exactly
---   at the boundary, though: it carries 'overlapSlots' of the outgoing epoch with it,
---   so an obligation raised there but falling due after the boundary is still
---   checked. A clean cut would clear EBs' and curEB, and such a vote would then pass
---   vacuously.
---
---   A node can only answer for its own current epoch, and not at all until pool
---   stake has activated two epochs in. A log that starts at genesis therefore
---   always contains epochs whose schedule is unobtainable; those segments are
---   skipped and named rather than verified against the wrong lottery, and the run
---   ends with a summary of which epochs were verified and which were skipped.
-runSegmented ::
-  LeadershipOpts ->
-  (Integer, Integer, Integer, Integer) ->
-  [ChainEvent] ->
-  IO ()
-runSegmented opts (lhdr, lvote, ldiff, validityCheckTime) evs = do
-  tally <- newIORef []
-  loop tally Nothing [] evs
-  summarize tally
+-- | Render the driver's progress, and abort on a violation. Kept out of
+--   "LinearLeiosChain" so the driver stays testable with a collecting reporter.
+render :: Progress -> IO ()
+render = \case
+  Saw ev -> hPutStrLn stderr $ "event: " <> show ev
+  SegmentStarted seg spans -> reportSchedule seg spans
+  Verified nEvents nActions ->
+    hPutStrLn stderr $
+      "ok @ " <> show nEvents <> " events, " <> show nActions <> " actions"
+  Violation nEvents acts status detail -> failOut nEvents acts status detail
+  NothingToVerify ->
+    hPutStrLn stderr "no leadership-check slot found in input — nothing to verify"
+  StreamEnded acts -> do
+    -- The slot in progress when the input ended is deliberately not adjudicated: a
+    -- stream truncated mid-slot has not yet shown the events that would discharge
+    -- that slot's obligations.
+    hPutStrLn stderr "stream ended: ok (slot in progress at end of input left unverified)"
+    printActions acts
+  Summary entries -> summarize entries
+
+reportSchedule :: Segment -> Bool -> IO ()
+reportSchedule seg spansEpochs = do
+  hPutStrLn stderr $
+    "epoch "
+      <> show ep
+      <> " (from slot "
+      <> show (segStart seg)
+      <> (if spansEpochs then ", carrying the tail of the previous epoch" else "")
+      <> "): "
+      <> show (cdNumParties cd)
+      <> " parties, SUT at index "
+      <> show (cdSutIndex cd)
+      <> ", eligibility from "
+      <> source
+  when (segAuthoritative seg) (warnSlotsOutsideEpoch cd ep)
  where
-  loop :: IORef [(Integer, Bool)] -> Maybe Segment -> [ChainEvent] -> [ChainEvent] -> IO ()
-  loop _ mseg seen [] = finishSeg mseg (Prelude.reverse seen)
-  loop tally mseg seen (ev : rest) = do
-    hPutStrLn stderr $ "event: " <> show ev
-    case ev of
-      CSlot s -> case mseg of
-        Just seg | toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg -> do
-          -- same epoch: extend and re-check the current segment
-          let seen' = ev : seen
-          checkSeg seg (Prelude.reverse seen')
-          loop tally mseg seen' rest
-        _ -> do
-          -- First segment, or an epoch boundary. This CSlot is what completes the
-          -- outgoing segment's last slot, so give that segment one final check
-          -- with the boundary event appended before discarding its events —
-          -- otherwise the last slot of every epoch would go unverified, since a
-          -- streaming check never adjudicates the slot still in progress.
-          case mseg of
-            Just old -> checkSeg old (Prelude.reverse (ev : seen))
-            Nothing -> pure ()
-          -- Carry the tail of the outgoing epoch into the new segment, so that an
-          -- obligation raised before the boundary and falling due after it is still
-          -- checked. No check here: the carried slots were just adjudicated by the
-          -- outgoing segment, and the boundary slot itself is still in progress.
-          let carried = Prelude.takeWhile (notBefore (toInteger s - overlapSlots)) seen
-              seen' = ev : carried
-              start = earliestSlot (toInteger s) seen'
-          seg <- newSegment tally (toInteger s) start (not (Prelude.null carried))
-          loop tally (Just seg) seen' rest
-      _ -> loop tally mseg (ev : seen) rest
+  cd = segCD seg
+  ep = segEpoch seg
+  source = case cdWinningSlots cd of
+    Nothing -> "the log (the node could supply no schedule)"
+    Just slots
+      | segAuthoritative seg ->
+          "the node schedule: "
+            <> show (Prelude.length slots)
+            <> " winning slots "
+            <> show slots
+      | spansEpochs ->
+          "the log (this segment spans two epochs, so the schedule "
+            <> show slots
+            <> " for epoch "
+            <> show (cdNodeEpoch cd)
+            <> " cannot govern all of it)"
+      | otherwise ->
+          "the log (the node answered for epoch "
+            <> show (cdNodeEpoch cd)
+            <> ", so its schedule "
+            <> show slots
+            <> " does not apply here)"
 
-  -- How far back an obligation can reach. An EB with election slot e becomes votable
-  -- in slot e + (3 * Lhdr `max` validityCheckTime), and its acquisition may lag the
-  -- election by up to Lhdr, so carrying that many slots covers every obligation able
-  -- to straddle a boundary.
-  overlapSlots :: Integer
-  overlapSlots = Prelude.max (3 * lhdr) validityCheckTime + lhdr
-
-  notBefore :: Integer -> ChainEvent -> Bool
-  notBefore cutoff (CSlot sl) = toInteger sl >= cutoff
-  notBefore _ _ = True
-
-  -- Earliest slot tick among a segment's events, which is where verification starts.
-  earliestSlot :: Integer -> [ChainEvent] -> Integer
-  earliestSlot dflt es = case [toInteger sl | CSlot sl <- es] of
-    [] -> dflt
-    ss -> Prelude.minimum ss
-
-  newSegment :: IORef [(Integer, Bool)] -> Integer -> Integer -> Bool -> IO Segment
-  newSegment tally boundary start spansEpochs = do
-    cd <- queryChain opts
-    let ep = boundary `div` cdEpochLength cd
-        -- Authoritative only if a schedule was obtained, it describes this very
-        -- epoch, and this segment lies wholly inside that epoch. A segment carrying
-        -- an overlap spans two, so no single epoch's schedule governs all of it and
-        -- eligibility has to come from the log. Otherwise an EB forged in the carried
-        -- tail would be judged against the following epoch's lottery.
-        authoritative =
-          not spansEpochs
-            && maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
-    reportSchedule cd ep start spansEpochs authoritative
-    modifyIORef' tally ((ep, authoritative) :)
-    pure Segment{segEpoch = ep, segStart = start, segCD = cd, segAuthoritative = authoritative}
-
-  reportSchedule :: ChainData -> Integer -> Integer -> Bool -> Bool -> IO ()
-  reportSchedule cd ep s spansEpochs authoritative = do
-    hPutStrLn stderr $
-      "epoch "
-        <> show ep
-        <> " (from slot "
-        <> show s
-        <> (if spansEpochs then ", carrying the tail of the previous epoch" else "")
-        <> "): "
-        <> show (cdNumParties cd)
-        <> " parties, SUT at index "
-        <> show (cdSutIndex cd)
-        <> ", eligibility from "
-        <> source
-    when authoritative (warnSlotsOutsideEpoch cd ep)
-   where
-    source = case cdWinningSlots cd of
-      Nothing -> "the log (the node could supply no schedule)"
-      Just slots
-        | authoritative ->
-            "the node schedule: "
-              <> show (Prelude.length slots)
-              <> " winning slots "
-              <> show slots
-        | spansEpochs ->
-            "the log (this segment spans two epochs, so the schedule "
-              <> show slots
-              <> " for epoch "
-              <> show (cdNodeEpoch cd)
-              <> " cannot govern all of it)"
-        | otherwise ->
-            "the log (the node answered for epoch "
-              <> show (cdNodeEpoch cd)
-              <> ", so its schedule "
-              <> show slots
-              <> " does not apply here)"
-
-  -- The node claims this epoch, so its winning slots ought to lie inside it. If any
-  -- do not, an assumption is wrong — epochLength, or which epoch the schedule is
-  -- computed for — and this segment is being verified unsoundly. Report loudly
-  -- rather than refuse: refusing has already proved too blunt, and this is precisely
-  -- the diagnostic needed to tell which assumption is off.
-  warnSlotsOutsideEpoch :: ChainData -> Integer -> IO ()
-  warnSlotsOutsideEpoch cd ep =
-    case Prelude.filter (not . inEpoch) (fromMaybe [] (cdWinningSlots cd)) of
-      [] -> pure ()
-      out ->
-        hPutStrLn stderr $
-          "warning: node reported epoch "
-            <> show ep
-            <> " but winning slots "
-            <> show out
-            <> " fall outside its slot range "
-            <> show (ep * len)
-            <> ".."
-            <> show ((ep + 1) * len - 1)
-            <> " (they lie in epoch(s) "
-            <> show (Prelude.map (`div` len) out)
-            <> "); verification of this segment is unsound"
-   where
-    len = cdEpochLength cd
-    inEpoch sl = sl >= ep * len && sl < (ep + 1) * len
-
-  -- Every segment is verified now, so the interesting distinction is which
-  -- eligibility source each epoch used. A log-derived one cannot catch an EB forged
-  -- in a slot the node never recorded winning, so it is worth knowing where the
-  -- guarantee is weaker.
-  summarize :: IORef [(Integer, Bool)] -> IO ()
-  summarize tally = do
-    entries <- Prelude.reverse <$> readIORef tally
-    let fromSchedule = [ep | (ep, True) <- entries]
-        fromLog = [ep | (ep, False) <- entries]
-    if Prelude.null entries
-      then hPutStrLn stderr "summary: no segment was verified"
-      else
-        hPutStrLn stderr $
-          "summary: verified epoch(s) "
-            <> show (Prelude.map fst entries)
-            <> "; eligibility from the node schedule for "
-            <> (if Prelude.null fromSchedule then "none" else show fromSchedule)
-            <> ", from the log for "
-            <> (if Prelude.null fromLog then "none" else show fromLog)
-
-  verifySeg :: Segment -> [ChainEvent] -> ([T.Text], (T.Text, T.Text))
-  verifySeg seg prefix =
-    let cd = segCD seg
-     in verifyChainTraceFromSlot
-          (cdNumParties cd)
-          (cdSutIndex cd)
-          (cdStakeDistribution cd)
-          lhdr
-          lvote
-          ldiff
-          validityCheckTime
-          (fromMaybe [] (cdWinningSlots cd))
-          (segAuthoritative seg)
-          prefix
-          (segStart seg)
-
-  checkSeg :: Segment -> [ChainEvent] -> IO ()
-  checkSeg seg prefix =
-    let (acts, (status, detail)) = verifySeg seg prefix
-     in if status == "ok"
-          then hPutStrLn stderr $ "ok @ " <> show (Prelude.length prefix) <> " events, " <> show (Prelude.length acts) <> " actions"
-          else failOut prefix acts status detail
-
-  finishSeg :: Maybe Segment -> [ChainEvent] -> IO ()
-  finishSeg Nothing _ = hPutStrLn stderr "no leadership-check slot found in input — nothing to verify"
-  finishSeg (Just seg) prefix =
-    let (acts, (status, detail)) = verifySeg seg prefix
-     in if status == "ok"
-          then
-            -- The slot in progress when the input ended is deliberately not
-            -- adjudicated: a stream truncated mid-slot has not yet shown the
-            -- events that would discharge that slot's obligations.
-            hPutStrLn stderr "stream ended: ok (slot in progress at end of input left unverified)"
-              >> printActions acts
-          else failOut prefix acts status detail
-
-  printActions = mapM_ (\a -> hPutStrLn stderr ("  action: " <> T.unpack a))
-  -- The slot an action or error status belongs to.
-  slotOfAction a = T.takeWhile (/= ' ') (T.drop 1 (T.dropWhile (/= '@') a))
-  failOut prefix acts status detail = do
-    hPutStrLn stderr $
-      "VIOLATION after " <> show (Prelude.length prefix) <> " events: " <> T.unpack status
-    hPutStrLn stderr $ T.unpack detail
-    when ("Err-Invalid" `T.isInfixOf` status) $
+-- The node claims this epoch, so its winning slots ought to lie inside it. If any do
+-- not, an assumption is wrong — epochLength, or which epoch the schedule is computed
+-- for — and this segment is being verified unsoundly. Report loudly rather than
+-- refuse: refusing has already proved too blunt, and this is precisely the diagnostic
+-- needed to tell which assumption is off.
+warnSlotsOutsideEpoch :: ChainData -> Integer -> IO ()
+warnSlotsOutsideEpoch cd ep =
+  case Prelude.filter (not . inEpoch) (fromMaybe [] (cdWinningSlots cd)) of
+    [] -> pure ()
+    out ->
       hPutStrLn stderr $
-        "  (Err-Invalid: a No-EB-Role/No-VT-Role abstention was rejected — the spec "
-          <> "permits abstaining only when the role cannot be performed this slot.)"
-    -- Only the actions in the failing slot.
-    let failSlot = T.takeWhile (/= ' ') status
-    printActions (Prelude.filter ((== failSlot) . slotOfAction) acts)
-    exitFailure
+        "warning: node reported epoch "
+          <> show ep
+          <> " but winning slots "
+          <> show out
+          <> " fall outside its slot range "
+          <> show (ep * len)
+          <> ".."
+          <> show ((ep + 1) * len - 1)
+          <> " (they lie in epoch(s) "
+          <> show (Prelude.map (`div` len) out)
+          <> "); verification of this segment is unsound"
+ where
+  len = cdEpochLength cd
+  inEpoch sl = sl >= ep * len && sl < (ep + 1) * len
 
--- | True iff the event is a slot tick (used as a re-verification checkpoint).
-isCSlot :: ChainEvent -> Bool
-isCSlot (CSlot _) = True
-isCSlot _ = False
+-- Every segment is verified, so the interesting distinction is which eligibility
+-- source each epoch used. A log-derived one is the SUT's self-report, so it cannot
+-- catch the node's own leadership logging being wrong; it is worth knowing where the
+-- guarantee is weaker.
+summarize :: [(Integer, Bool)] -> IO ()
+summarize entries
+  | Prelude.null entries = hPutStrLn stderr "summary: no segment was verified"
+  | otherwise =
+      hPutStrLn stderr $
+        "summary: verified epoch(s) "
+          <> show (Prelude.map fst entries)
+          <> "; eligibility from the node schedule for "
+          <> (if Prelude.null fromSchedule then "none" else show fromSchedule)
+          <> ", from the log for "
+          <> (if Prelude.null fromLog then "none" else show fromLog)
+ where
+  fromSchedule = [ep | (ep, True) <- entries]
+  fromLog = [ep | (ep, False) <- entries]
+
+printActions :: [T.Text] -> IO ()
+printActions = mapM_ (\a -> hPutStrLn stderr ("  action: " <> T.unpack a))
+
+-- | The slot an action or error status belongs to.
+slotOfAction :: T.Text -> T.Text
+slotOfAction a = T.takeWhile (/= ' ') (T.drop 1 (T.dropWhile (/= '@') a))
+
+failOut :: Int -> [T.Text] -> T.Text -> T.Text -> IO ()
+failOut nEvents acts status detail = do
+  hPutStrLn stderr $
+    "VIOLATION after " <> show nEvents <> " events: " <> T.unpack status
+  hPutStrLn stderr $ T.unpack detail
+  when ("Err-Invalid" `T.isInfixOf` status) $
+    hPutStrLn stderr $
+      "  (Err-Invalid: a No-EB-Role/No-VT-Role abstention was rejected — the spec "
+        <> "permits abstaining only when the role cannot be performed this slot.)"
+  -- Only the actions in the failing slot.
+  let failSlot = T.takeWhile (/= ' ') status
+  printActions (Prelude.filter ((== failSlot) . slotOfAction) acts)
+  exitFailure
 
 -- * Reading from the chain via cardano-api
 
@@ -324,32 +209,6 @@ data LeadershipOpts = LeadershipOpts
   , loVrfSkeyFile :: FilePath
   , loWhich :: WhichEpoch
   }
-
--- | Everything we read from the chain for verification.
-data ChainData = ChainData
-  { cdWinningSlots :: Maybe [Integer]
-  -- ^ The SUT's leadership schedule, as plain naturals for the Agda oracle.
-  --   'Nothing' when the node could not supply one at all — chiefly on a young
-  --   network, where pool stake has not activated yet. Not fatal: eligibility then
-  --   comes from the node's own leadership record in the log.
-  , cdNumParties :: Integer
-  -- ^ Number of parties (= number of stake pools).
-  , cdStakeDistribution :: [(T.Text, Integer)]
-  -- ^ Per-party stake, keyed @node-i@ (pool i in chain order).
-  , cdSutIndex :: Integer
-  -- ^ The SUT's party index (position of --stake-pool-id in chain order).
-  , cdEpochLength :: Integer
-  -- ^ Slots per epoch (from the Shelley genesis), used to detect epoch
-  --   boundaries so the schedule and stake distribution can be re-queried.
-  , cdNodeEpoch :: Integer
-  -- ^ The epoch the node itself reported when queried, i.e. the epoch the
-  --   returned schedule belongs to. This is the epoch of the /chain tip/ (the
-  --   query runs at 'Api.VolatileTip'), not of the wall clock, so it lags
-  --   whenever block production is sparse — which is one way the schedule ends
-  --   up describing a different epoch than the one being verified.
-  }
-
--- | Query the chain for the leadership schedule, stake distribution and party count.
 --
 -- A missing schedule is not fatal: eligibility falls back to the node's own
 -- leadership record in the log, so every epoch is still verified. It is reported

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -18,6 +18,7 @@ module Main where
 import ChainEvents (parseNodeLog)
 import Control.Monad (when)
 import Data.ByteString.Lazy as BSL
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Yaml (FromJSON (..), decodeEither', withObject, (.:))
 import LinearLeiosChain (
@@ -58,7 +59,10 @@ main = do
     "skipped "
       <> show (Prelude.length preSlot)
       <> " pre-slot events (node sync/replay backlog, before the first leadership-check slot)"
-  runSegmented render timings (const (queryChain leadershipOpts)) rest
+  -- The schedule explanation is the same every segment, and a run with frequent
+  -- slot gaps starts many, so say it in full once and abbreviate after that.
+  explained <- newIORef False
+  runSegmented render timings (const (queryChain explained leadershipOpts)) rest
 
 -- * Rendering
 
@@ -265,12 +269,22 @@ data LeadershipOpts = LeadershipOpts
 -- trails the epoch being verified, so a schedule fetched after a wait is usually
 -- still for the wrong epoch. Waiting would also let the log accumulate, leaving the
 -- verifier further behind and the mismatch more likely.
-queryChain :: LeadershipOpts -> IO ChainData
-queryChain opts = do
+queryChain :: IORef Bool -> LeadershipOpts -> IO ChainData
+queryChain explained opts = do
   (cd, mlerr) <- queryChainOnce opts
   case mlerr of
     Nothing -> pure ()
-    Just lerr -> hPutStrLn stderr (scheduleUnavailable opts lerr (cdWinningSlots cd))
+    Just lerr -> do
+      said <- readIORef explained
+      if said
+        then
+          hPutStrLn stderr $
+            "no leadership schedule for this epoch either ("
+              <> show lerr
+              <> "); as above."
+        else do
+          hPutStrLn stderr (scheduleUnavailable opts lerr (cdWinningSlots cd))
+          writeIORef explained True
   pure cd
 
 -- | Explain what the leadership error means and, crucially, what was done about it.

--- a/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
+++ b/leios-trace-verifier/hs-src/app/linear-chain/Main.hs
@@ -89,8 +89,11 @@ render = \case
       "warning: the log shows no Leios activity — no EB forged, acquired, announced "
         <> "or voted — so EB-role enforcement is suppressed for the "
         <> show led
-        <> " slot(s) the node led. NodeIsLeader alone is Praos leadership, and only "
-        <> "implies EB eligibility while Leios is actually running."
+        <> " slot(s) the node led, and at least one of those had a mempool too large "
+        <> "for its ranking block, so an EB was owed there. NodeIsLeader alone is "
+        <> "Praos leadership, and only implies EB eligibility while Leios is actually "
+        <> "running — but a node with an oversized mempool doing nothing Leios-side "
+        <> "at all is worth looking into."
   SlotGap from to ->
     hPutStrLn stderr $
       "note: no leadership check logged for slot(s) "

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -19,6 +19,7 @@ module LinearLeiosChain (
   overlapSlots,
   carryAcross,
   segmentAuthoritative,
+  gateSuppressesAnObligation,
   verifySegment,
   runSegmented,
 ) where
@@ -86,9 +87,11 @@ data Progress
     NothingToVerify
   | -- | Input ended with the final check passing; the actions adjudicated.
     StreamEnded [Text]
-  | -- | The segment holds slots the node led, but the log shows no Leios activity
-    --   at all, so EB-role enforcement is suppressed for them. Carries how many
-    --   such leader slots were seen.
+  | -- | The segment holds slots the node led where the mempool rule would have
+    --   demanded an EB, but the log shows no Leios activity at all, so EB-role
+    --   enforcement is suppressed for them. Carries how many leader slots were seen.
+    --   Not reported when the rule would have excused those slots anyway — the gate
+    --   costs nothing then, and claiming otherwise buries the notes that matter.
     LeiosInactive Int
   | -- | The slot ticks jumped: the node emitted no leadership check for the slots
     --   between these two. Carries (last seen, next seen). Not a violation — a
@@ -198,6 +201,39 @@ segmentAuthoritative :: Bool -> Integer -> ChainData -> Bool
 segmentAuthoritative spans ep cd =
   not spans && maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
 
+-- | Whether the EB-role gate actually costs anything on this prefix: some slot the
+--   node led where the mempool rule would have demanded an EB.
+--
+--   Without this the gate reports "enforcement suppressed" whenever Leios is quiet,
+--   which on a low-traffic network is every led slot — while the mempool rule had
+--   already excused those same slots on its own terms, the mempool being far below
+--   the ranking block's capacity. Saying "suppressed" there overstates the loss: the
+--   verifier did look, and found nothing owed. The gate is only worth reporting when
+--   it hides an obligation the rule would have raised.
+--
+--   Mirrors the translator's 'ebOwed': the maximum of the slot's mempool range where
+--   the node forged (its own block drained the mempool after deciding), the minimum
+--   otherwise.
+gateSuppressesAnObligation :: Integer -> [ChainEvent] -> Bool
+gateSuppressesAnObligation cap = any owed . slotGroups
+ where
+  -- A slot owns the events from its tick up to the next one, which is the grouping
+  -- the translator uses — hence a mempool range emitted just ahead of a tick belongs
+  -- to the slot then ending.
+  slotGroups [] = []
+  slotGroups (e : es) = let (g, rest) = break isCSlot es in (e : g) : slotGroups rest
+  owed g =
+    any isLeader g
+      && case [(toInteger mn, toInteger mx) | CMempoolRange mn mx <- g] of
+        [] -> False
+        rs
+          | any isRBForged g -> cap < maximum (map snd rs)
+          | otherwise -> cap < minimum (map fst rs)
+  isLeader (CNodeIsLeader _) = True
+  isLeader _ = False
+  isRBForged (CRBForged _ _) = True
+  isRBForged _ = False
+
 -- | Verify one segment's prefix against the spec.
 verifySegment :: Timings -> Segment -> [ChainEvent] -> ([Text], (Text, Text))
 verifySegment ts seg prefix =
@@ -296,14 +332,24 @@ runSegmented report ts query = loop [] Nothing Nothing []
     report (SegmentStarted seg (carrySpans carry))
     pure (seg, (ep, segAuthoritative seg) : tally)
 
-  -- The EB-role gate lives in the translator, which cannot report. Say so wherever
-  -- a prefix is verified, rather than letting leader slots be silently exempted.
-  -- Both verification sites need this: a run too short to reach a periodic
-  -- checkpoint is verified only at end of input.
-  reportIfLeiosInactive prefix = do
+  -- The EB-role gate lives in the translator, which cannot report. Say so wherever a
+  -- prefix is verified, rather than letting leader slots be silently exempted. Both
+  -- verification sites need this: a run too short to reach a periodic checkpoint is
+  -- verified only at end of input.
+  --
+  -- Only when the gate actually hides an obligation, though — see
+  -- 'gateSuppressesAnObligation'. On a quiet network the mempool rule excuses those
+  -- slots on its own terms, and reporting suppression there claims a loss that was
+  -- not incurred.
+  reportIfLeiosInactive seg prefix = do
     let led = length [() | CNodeIsLeader _ <- prefix]
-    when (led > 0 && not (any isLeiosActivity prefix)) $
-      report (LeiosInactive led)
+        cap = cdMaxRBBody (segCD seg)
+    when
+      ( led > 0
+          && not (any isLeiosActivity prefix)
+          && gateSuppressesAnObligation cap prefix
+      )
+      $ report (LeiosInactive led)
 
   -- An EB is owed only when the mempool could not have fitted in the ranking block,
   -- and the reading is a range, so a range straddling the capacity leaves the
@@ -318,7 +364,7 @@ runSegmented report ts query = loop [] Nothing Nothing []
       else when (straddling > 0) $ report (EBOwedUndecided straddling)
 
   checkSeg seg prefix = do
-    reportIfLeiosInactive prefix
+    reportIfLeiosInactive seg prefix
     reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"
@@ -327,7 +373,7 @@ runSegmented report ts query = loop [] Nothing Nothing []
 
   finishSeg Nothing _ = report NothingToVerify
   finishSeg (Just seg) prefix = do
-    reportIfLeiosInactive prefix
+    reportIfLeiosInactive seg prefix
     reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -20,6 +20,7 @@ module LinearLeiosChain (
   carryAcross,
   segmentAuthoritative,
   gateSuppressesAnObligation,
+  surplusVotesPerSlot,
   verifySegment,
   runSegmented,
 ) where
@@ -98,6 +99,12 @@ data Progress
     --   CPU load has been observed causing it, so blaming the node would be
     --   circular. Verification restarts after the gap instead.
     SlotGap Integer Integer
+  | -- | Votes beyond the first within a single slot, summed over the prefix. Only
+    --   one vote per slot can be adjudicated, so these went unexamined.
+    SurplusVotesInSlot Int
+  | -- | A slot tick that did not advance: a duplicate or out-of-order leadership
+    --   check. Carries (last seen, the tick). Dropped rather than verified across.
+    NonMonotonicSlot Integer Integer
   | -- | Slots whose mempool range straddled the RB capacity, so whether an EB was
     --   owed could not be settled and the slot was excused. This count is the
     --   measure of what the rule's one-sidedness costs on a given run: small means
@@ -242,6 +249,16 @@ gateSuppressesAnObligation cap = any owed . slotGroups
   isRBForged (CRBForged _ _) = True
   isRBForged _ = False
 
+-- | How many votes beyond the first fall in the same slot, summed over the prefix.
+--   Only one vote per slot can be adjudicated (VT-Role upkeep is per slot), so any
+--   surplus goes unexamined; this counts it so the loss is visible rather than silent.
+surplusVotesPerSlot :: [ChainEvent] -> Int
+surplusVotesPerSlot = sum . map surplus . slotGroups
+ where
+  slotGroups [] = []
+  slotGroups (e : es) = let (g, rest) = break isCSlot es in (e : g) : slotGroups rest
+  surplus g = max 0 (length [() | CVoted _ _ <- g] - 1)
+
 -- | Verify one segment's prefix against the spec.
 verifySegment :: Timings -> Segment -> [ChainEvent] -> ([Text], (Text, Text))
 verifySegment ts seg prefix =
@@ -289,6 +306,16 @@ runSegmented report ts query = loop [] Nothing Nothing []
   loop tally mseg mlast seen (ev : rest) = do
     report (Saw ev)
     case ev of
+      -- A tick that does not advance — a duplicate, or out of order, as concatenated
+      -- or overlapping logs produce. It is neither a continuation nor a gap, and
+      -- without this it fell through to the boundary path and silently restarted a
+      -- segment mid-epoch. There is nothing to verify backwards, so drop it and say
+      -- so; the segment state is left exactly as it was.
+      CSlot s
+        | Just l <- mlast
+        , toInteger s <= l -> do
+            report (NonMonotonicSlot l (toInteger s))
+            loop tally mseg mlast seen rest
       CSlot s
         | Just seg <- mseg
         , toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg
@@ -315,7 +342,8 @@ runSegmented report ts query = loop [] Nothing Nothing []
             -- lost, unavoidably: there is no record of the slot to verify against.
             let gapped = maybe False (\l -> toInteger s > l + 1) mlast
                 carry
-                  | gapped = Carry{carryEvents = [], carryStart = toInteger s, carrySpans = False}
+                  -- Carrying nothing is exactly 'carryAcross' over no events.
+                  | gapped = carryAcross overlap (toInteger s) []
                   | otherwise = carryAcross overlap (toInteger s) seen
             case mlast of
               Just l | gapped -> report (SlotGap l (toInteger s))
@@ -353,10 +381,22 @@ runSegmented report ts query = loop [] Nothing Nothing []
         cap = cdMaxRBBody (segCD seg)
     when
       ( led > 0
+          -- The gate only exists on the log-derived branch: where the queried
+          -- schedule governs, eligibility never consults 'leaderSlots' at all, so
+          -- nothing is being suppressed and saying so would be simply untrue.
+          && not (segAuthoritative seg)
           && not (any isLeiosActivity prefix)
           && gateSuppressesAnObligation cap prefix
       )
       $ report (LeiosInactive led)
+
+  -- A slot can hold more than one CVoted, but the spec records VT-Role upkeep once
+  -- per slot, so only one vote per slot can ever be adjudicated. The translator keeps
+  -- the first; this counts what that leaves unexamined. Purely syntactic over the
+  -- event stream — it mirrors no spec rule.
+  reportSurplusVotes prefix = do
+    let perSlot = surplusVotesPerSlot prefix
+    when (perSlot > 0) $ report (SurplusVotesInSlot perSlot)
 
   -- An EB is owed only when the mempool could not have fitted in the ranking block,
   -- and the reading is a range, so a range straddling the capacity leaves the
@@ -372,6 +412,7 @@ runSegmented report ts query = loop [] Nothing Nothing []
 
   checkSeg seg prefix = do
     reportIfLeiosInactive seg prefix
+    reportSurplusVotes prefix
     reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"
@@ -381,6 +422,7 @@ runSegmented report ts query = loop [] Nothing Nothing []
   finishSeg Nothing _ = report NothingToVerify
   finishSeg (Just seg) prefix = do
     reportIfLeiosInactive seg prefix
+    reportSurplusVotes prefix
     reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -50,6 +50,10 @@ data ChainData = ChainData
   --   eligibility is the CIP-0164 committee, computed from these figures.
   , cdSutIndex :: Integer
   , cdEpochLength :: Integer
+  , cdMaxRBBody :: Integer
+  -- ^ The ranking block's body capacity in bytes. Decides whether a forge without an
+  --   EB was owed one: an EB is required only when the mempool could not have fitted
+  --   into the RB.
   , cdNodeEpoch :: Integer
   -- ^ The epoch the node itself answered for. This is the epoch of the /chain tip/,
   --   not of the wall clock, so it lags whenever block production is sparse — which
@@ -86,6 +90,15 @@ data Progress
     --   at all, so EB-role enforcement is suppressed for them. Carries how many
     --   such leader slots were seen.
     LeiosInactive Int
+  | -- | Slots whose mempool range straddled the RB capacity, so whether an EB was
+    --   owed could not be settled and the slot was excused. This count is the
+    --   measure of what the rule's one-sidedness costs on a given run: small means
+    --   the EB-role check has teeth, large means it is mostly declining to look.
+    EBOwedUndecided Int
+  | -- | The prefix carried no mempool readings at all, so EB-role enforcement in
+    --   non-forging slots lapsed entirely. Expected for logs predating the Mempool
+    --   traces; on a current log it means the check is silently inactive.
+    NoMempoolReadings
   | -- | Per epoch, whether eligibility came from the queried schedule.
     Summary [(Integer, Bool)]
 
@@ -193,6 +206,7 @@ verifySegment ts seg prefix =
         (tValidityCheckTime ts)
         (fromMaybe [] (cdWinningSlots cd))
         (segAuthoritative seg)
+        (cdMaxRBBody cd)
         prefix
         (segStart seg)
 
@@ -273,8 +287,21 @@ runSegmented report ts query = loop [] Nothing []
     when (led > 0 && not (any isLeiosActivity prefix)) $
       report (LeiosInactive led)
 
+  -- An EB is owed only when the mempool could not have fitted in the ranking block,
+  -- and the reading is a range, so a range straddling the capacity leaves the
+  -- question open. Those slots are excused, which is the safe direction but is also
+  -- lost coverage — so say how much of it there is rather than let it go unseen.
+  reportMempoolGaps seg prefix = do
+    let cap = cdMaxRBBody (segCD seg)
+        ranges = [(toInteger mn, toInteger mx) | CMempoolRange mn mx <- prefix]
+        straddling = length [() | (mn, mx) <- ranges, mn <= cap, cap < mx]
+    if null ranges
+      then report NoMempoolReadings
+      else when (straddling > 0) $ report (EBOwedUndecided straddling)
+
   checkSeg seg prefix = do
     reportIfLeiosInactive prefix
+    reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"
       then report (Verified (length prefix) (length acts))
@@ -283,6 +310,7 @@ runSegmented report ts query = loop [] Nothing []
   finishSeg Nothing _ = report NothingToVerify
   finishSeg (Just seg) prefix = do
     reportIfLeiosInactive prefix
+    reportMempoolGaps seg prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
     if status == "ok"
       then report (StreamEnded acts)

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -90,6 +90,12 @@ data Progress
     --   at all, so EB-role enforcement is suppressed for them. Carries how many
     --   such leader slots were seen.
     LeiosInactive Int
+  | -- | The slot ticks jumped: the node emitted no leadership check for the slots
+    --   between these two. Carries (last seen, next seen). Not a violation — a
+    --   missing tick is usually the node being descheduled, and the verifier's own
+    --   CPU load has been observed causing it, so blaming the node would be
+    --   circular. Verification restarts after the gap instead.
+    SlotGap Integer Integer
   | -- | Slots whose mempool range straddled the RB capacity, so whether an EB was
     --   owed could not be settled and the slot was excused. This count is the
     --   measure of what the rule's one-sidedness costs on a given run: small means
@@ -230,40 +236,52 @@ runSegmented ::
   (Integer -> IO ChainData) ->
   [ChainEvent] ->
   IO ()
-runSegmented report ts query = loop [] Nothing []
+runSegmented report ts query = loop [] Nothing Nothing []
  where
   overlap = overlapSlots ts
 
-  loop tally mseg seen [] = do
+  loop tally mseg mlast seen [] = do
     finishSeg mseg (reverse seen)
     report (Summary (reverse tally))
-  loop tally mseg seen (ev : rest) = do
+  loop tally mseg mlast seen (ev : rest) = do
     report (Saw ev)
     case ev of
       CSlot s
         | Just seg <- mseg
-        , toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg -> do
-            -- Same epoch: extend the segment, and periodically re-check it. Not at
-            -- every tick — see 'checkpointEvery'.
+        , toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg
+        , maybe True (\l -> toInteger s == l + 1) mlast -> do
+            -- Same epoch and the next slot in sequence: extend the segment, and
+            -- periodically re-check it. Not at every tick — see 'checkpointEvery'.
             let seen' = ev : seen
             when (toInteger s `mod` checkpointEvery == 0) $
               checkSeg seg (reverse seen')
-            loop tally mseg seen' rest
+            loop tally mseg (Just (toInteger s)) seen' rest
         | otherwise -> do
-            -- First segment, or an epoch boundary. This tick is what completes the
-            -- outgoing segment's last slot, so give that segment one final check
-            -- with the tick appended; otherwise the last slot of every epoch would
-            -- go unverified, a streaming check never adjudicating the slot still in
-            -- progress.
+            -- First segment, an epoch boundary, or a gap in the slot ticks. This tick
+            -- is what completes the outgoing segment's last slot, so give that
+            -- segment one final check with the tick appended; otherwise the last slot
+            -- before every boundary would go unverified, a streaming check never
+            -- adjudicating the slot still in progress.
             case mseg of
               Just old -> checkSeg old (reverse (ev : seen))
               Nothing -> pure ()
+            -- A gap carries nothing. The spec advances one slot at a time, so a
+            -- carried tail from before the gap would still contain it and the verifier
+            -- would reject the jump — which is what a missing tick looked like before
+            -- this: "8 : Err-Slot / Base₁-Action". Obligations straddling the gap are
+            -- lost, unavoidably: there is no record of the slot to verify against.
+            let gapped = maybe False (\l -> toInteger s > l + 1) mlast
+                carry
+                  | gapped = Carry{carryEvents = [], carryStart = toInteger s, carrySpans = False}
+                  | otherwise = carryAcross overlap (toInteger s) seen
+            case mlast of
+              Just l | gapped -> report (SlotGap l (toInteger s))
+              _ -> pure ()
             -- No check on the new segment yet: its carried slots were just
             -- adjudicated by the outgoing one, and the boundary slot is in progress.
-            let carry = carryAcross overlap (toInteger s) seen
             (seg, tally') <- newSegment tally (toInteger s) carry
-            loop tally' (Just seg) (ev : carryEvents carry) rest
-      _ -> loop tally mseg (ev : seen) rest
+            loop tally' (Just seg) (Just (toInteger s)) (ev : carryEvents carry) rest
+      _ -> loop tally mseg mlast (ev : seen) rest
 
   newSegment tally boundary carry = do
     cd <- query boundary

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -14,6 +14,7 @@ module LinearLeiosChain (
   Progress (..),
   Carry (..),
   isCSlot,
+  checkpointEvery,
   overlapSlots,
   carryAcross,
   segmentAuthoritative,
@@ -22,6 +23,7 @@ module LinearLeiosChain (
 ) where
 
 import ChainEvents (ChainEvent (..))
+import Control.Monad (when)
 import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -86,6 +88,25 @@ data Progress
 isCSlot :: ChainEvent -> Bool
 isCSlot (CSlot _) = True
 isCSlot _ = False
+
+-- | How many slots pass between periodic re-verifications within a segment.
+--
+--   A segment is re-verified from its start, so checking at every tick costs
+--   O(n²) across an epoch. That is not merely slow: measured against a devnet at
+--   @slotLength = 1@, by slot 370 each checkpoint was re-verifying ~2200 actions,
+--   and the node — sharing the machine — began missing its own leadership checks,
+--   stalling for 535 slots. The verifier was starving the node it observes and
+--   then reporting the damage as a conformance violation. Checking every 20th slot
+--   cuts that cost twentyfold.
+--
+--   Correctness is unaffected. A prefix check at tick n adjudicates every slot
+--   below n, so no slot is skipped, only reported later; and the check at an epoch
+--   boundary, plus the one at end of input, are never throttled. Re-verification
+--   was once load-bearing, because a checkpoint's verdict on the slot still in
+--   progress was provisional — but slots have been adjudicated only once complete
+--   since the closeLast split, so redoing the prefix is now pure waste.
+checkpointEvery :: Integer
+checkpointEvery = 20
 
 -- | How far back an obligation can reach. An EB with election slot @e@ becomes
 --   votable in slot @e + (3 * Lhdr `max` validityCheckTime)@, and its acquisition may
@@ -191,9 +212,11 @@ runSegmented report ts query = loop [] Nothing []
       CSlot s
         | Just seg <- mseg
         , toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg -> do
-            -- Same epoch: extend the segment and re-check it.
+            -- Same epoch: extend the segment, and periodically re-check it. Not at
+            -- every tick — see 'checkpointEvery'.
             let seen' = ev : seen
-            checkSeg seg (reverse seen')
+            when (toInteger s `mod` checkpointEvery == 0) $
+              checkSeg seg (reverse seen')
             loop tally mseg seen' rest
         | otherwise -> do
             -- First segment, or an epoch boundary. This tick is what completes the

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Segmented verification of a Leios node.log stream.
+--
+--   This is the driver: it splits the event stream at epoch boundaries, verifies each
+--   segment against the Agda spec, and reports progress. It deliberately holds no
+--   cardano-api dependency — the per-epoch chain data is supplied as an action, and
+--   all output goes through a 'Progress' callback — so that the segmentation logic
+--   can be exercised from tests with a stubbed query and a collecting reporter.
+module LinearLeiosChain (
+  Timings (..),
+  ChainData (..),
+  Segment (..),
+  Progress (..),
+  Carry (..),
+  isCSlot,
+  overlapSlots,
+  carryAcross,
+  segmentAuthoritative,
+  verifySegment,
+  runSegmented,
+) where
+
+import ChainEvents (ChainEvent (..))
+import Data.List (dropWhileEnd)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import LinearLeiosLib (verifyChainTraceFromSlot)
+
+-- | Protocol timings, as the spec parameterises them.
+data Timings = Timings
+  { tLhdr :: Integer
+  , tLvote :: Integer
+  , tLdiff :: Integer
+  , tValidityCheckTime :: Integer
+  }
+
+-- | Everything read from the chain for one epoch.
+data ChainData = ChainData
+  { cdWinningSlots :: Maybe [Integer]
+  -- ^ The SUT's leadership schedule. 'Nothing' when the node could supply none at
+  --   all — chiefly on a young network, where pool stake has not activated yet. Not
+  --   fatal: eligibility then comes from the node's leadership record in the log.
+  , cdNumParties :: Integer
+  , cdStakeDistribution :: [(Text, Integer)]
+  -- ^ Per-party stake, keyed @node-i@. Load-bearing beyond block production: vote
+  --   eligibility is the CIP-0164 committee, computed from these figures.
+  , cdSutIndex :: Integer
+  , cdEpochLength :: Integer
+  , cdNodeEpoch :: Integer
+  -- ^ The epoch the node itself answered for. This is the epoch of the /chain tip/,
+  --   not of the wall clock, so it lags whenever block production is sparse — which
+  --   is why a queried schedule so often fails to describe the epoch under test.
+  }
+
+-- | A verification segment: one epoch, plus a carried tail of the previous one.
+data Segment = Segment
+  { segEpoch :: Integer
+  , segStart :: Integer
+  -- ^ First slot verification runs from, which is before the epoch boundary
+  --   whenever a tail is carried across.
+  , segCD :: ChainData
+  , segAuthoritative :: Bool
+  -- ^ Whether the queried schedule governs this segment. When it does not,
+  --   eligibility comes from the log and the segment is still verified.
+  }
+
+-- | Everything the driver reports. Rendering, and the decision to abort on a
+--   violation, belong to the caller.
+data Progress
+  = Saw ChainEvent
+  | -- | A segment started, and whether it carries a tail of the previous epoch.
+    SegmentStarted Segment Bool
+  | -- | A segment verified: events in the prefix, actions adjudicated.
+    Verified Int Int
+  | -- | Events in the prefix, all actions, status, detail.
+    Violation Int [Text] Text Text
+  | -- | The input held no slot tick, so there was nothing to verify.
+    NothingToVerify
+  | -- | Input ended with the final check passing; the actions adjudicated.
+    StreamEnded [Text]
+  | -- | Per epoch, whether eligibility came from the queried schedule.
+    Summary [(Integer, Bool)]
+
+-- | True iff the event is a slot tick, which is what bounds a verification step.
+isCSlot :: ChainEvent -> Bool
+isCSlot (CSlot _) = True
+isCSlot _ = False
+
+-- | How far back an obligation can reach. An EB with election slot @e@ becomes
+--   votable in slot @e + (3 * Lhdr `max` validityCheckTime)@, and its acquisition may
+--   lag the election by up to @Lhdr@, so carrying this many slots of the outgoing
+--   epoch covers every obligation able to straddle a boundary.
+overlapSlots :: Timings -> Integer
+overlapSlots ts = max (3 * tLhdr ts) (tValidityCheckTime ts) + tLhdr ts
+
+-- | The tail of the outgoing epoch that a new segment carries across a boundary.
+data Carry = Carry
+  { carryEvents :: [ChainEvent]
+  -- ^ Newest first, matching how the driver accumulates events.
+  , carryStart :: Integer
+  -- ^ Slot the new segment starts verifying from.
+  , carrySpans :: Bool
+  -- ^ Whether anything was carried, i.e. whether the segment spans two epochs.
+  }
+
+-- | Decide what to carry across an epoch boundary.
+--
+--   Without this a segment would begin on a fresh state, and an obligation raised
+--   before the boundary but falling due after it would be invisible: the vote would
+--   pass vacuously. The carried tail is trimmed so that it begins with a slot tick,
+--   since an event ahead of the first tick would be attributed to the segment start
+--   slot rather than to its own.
+carryAcross :: Integer -> Integer -> [ChainEvent] -> Carry
+carryAcross overlap boundary seen =
+  Carry
+    { carryEvents = carried
+    , carryStart = earliestSlot boundary carried
+    , carrySpans = not (null carried)
+    }
+ where
+  carried = dropWhileEnd (not . isCSlot) (takeWhile notBefore seen)
+  notBefore (CSlot sl) = toInteger sl >= boundary - overlap
+  notBefore _ = True
+
+-- | Earliest slot tick among a segment's events, or the given default if it has none.
+earliestSlot :: Integer -> [ChainEvent] -> Integer
+earliestSlot dflt es = case [toInteger sl | CSlot sl <- es] of
+  [] -> dflt
+  ss -> minimum ss
+
+-- | Whether a queried schedule governs a segment: obtained at all, describing this
+--   very epoch, and the segment lying wholly inside it.
+--
+--   A segment carrying an overlap spans two epochs, so no single epoch's schedule can
+--   govern all of it — left authoritative, an EB forged in the carried tail would be
+--   judged against the following epoch's lottery. An empty schedule is a legitimate
+--   authoritative answer, which is why this cannot be inferred from the slot list
+--   being empty.
+segmentAuthoritative :: Bool -> Integer -> ChainData -> Bool
+segmentAuthoritative spans ep cd =
+  not spans && maybe False (const (ep == cdNodeEpoch cd)) (cdWinningSlots cd)
+
+-- | Verify one segment's prefix against the spec.
+verifySegment :: Timings -> Segment -> [ChainEvent] -> ([Text], (Text, Text))
+verifySegment ts seg prefix =
+  let cd = segCD seg
+   in verifyChainTraceFromSlot
+        (cdNumParties cd)
+        (cdSutIndex cd)
+        (cdStakeDistribution cd)
+        (tLhdr ts)
+        (tLvote ts)
+        (tLdiff ts)
+        (tValidityCheckTime ts)
+        (fromMaybe [] (cdWinningSlots cd))
+        (segAuthoritative seg)
+        prefix
+        (segStart seg)
+
+-- | Verify a node.log event stream one epoch-segment at a time.
+--
+--   At each boundary the chain data is re-fetched, since the schedule and stake
+--   distribution are per-epoch, and a fresh segment is started — carrying
+--   'overlapSlots' of the outgoing epoch so obligations crossing the seam are still
+--   checked. Re-verification cost therefore stays bounded per epoch rather than
+--   growing over the whole run.
+--
+--   A segment is re-verified from its start at every slot tick. That is quadratic
+--   within an epoch, and load-bearing: the trailing slot is still in progress at a
+--   checkpoint, so a conclusion drawn about it is provisional and only corrected by
+--   redoing the prefix once its events have arrived.
+runSegmented ::
+  -- | Report progress; rendering and aborting are the caller's business.
+  (Progress -> IO ()) ->
+  Timings ->
+  -- | Fetch chain data for the epoch containing the given boundary slot.
+  (Integer -> IO ChainData) ->
+  [ChainEvent] ->
+  IO ()
+runSegmented report ts query = loop [] Nothing []
+ where
+  overlap = overlapSlots ts
+
+  loop tally mseg seen [] = do
+    finishSeg mseg (reverse seen)
+    report (Summary (reverse tally))
+  loop tally mseg seen (ev : rest) = do
+    report (Saw ev)
+    case ev of
+      CSlot s
+        | Just seg <- mseg
+        , toInteger s `div` cdEpochLength (segCD seg) == segEpoch seg -> do
+            -- Same epoch: extend the segment and re-check it.
+            let seen' = ev : seen
+            checkSeg seg (reverse seen')
+            loop tally mseg seen' rest
+        | otherwise -> do
+            -- First segment, or an epoch boundary. This tick is what completes the
+            -- outgoing segment's last slot, so give that segment one final check
+            -- with the tick appended; otherwise the last slot of every epoch would
+            -- go unverified, a streaming check never adjudicating the slot still in
+            -- progress.
+            case mseg of
+              Just old -> checkSeg old (reverse (ev : seen))
+              Nothing -> pure ()
+            -- No check on the new segment yet: its carried slots were just
+            -- adjudicated by the outgoing one, and the boundary slot is in progress.
+            let carry = carryAcross overlap (toInteger s) seen
+            (seg, tally') <- newSegment tally (toInteger s) carry
+            loop tally' (Just seg) (ev : carryEvents carry) rest
+      _ -> loop tally mseg (ev : seen) rest
+
+  newSegment tally boundary carry = do
+    cd <- query boundary
+    let ep = boundary `div` cdEpochLength cd
+        seg =
+          Segment
+            { segEpoch = ep
+            , segStart = carryStart carry
+            , segCD = cd
+            , segAuthoritative = segmentAuthoritative (carrySpans carry) ep cd
+            }
+    report (SegmentStarted seg (carrySpans carry))
+    pure (seg, (ep, segAuthoritative seg) : tally)
+
+  checkSeg seg prefix =
+    let (acts, (status, detail)) = verifySegment ts seg prefix
+     in if status == "ok"
+          then report (Verified (length prefix) (length acts))
+          else report (Violation (length prefix) acts status detail)
+
+  finishSeg Nothing _ = report NothingToVerify
+  finishSeg (Just seg) prefix =
+    let (acts, (status, detail)) = verifySegment ts seg prefix
+     in if status == "ok"
+          then report (StreamEnded acts)
+          else report (Violation (length prefix) acts status detail)

--- a/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosChain.hs
@@ -14,6 +14,7 @@ module LinearLeiosChain (
   Progress (..),
   Carry (..),
   isCSlot,
+  isLeiosActivity,
   checkpointEvery,
   overlapSlots,
   carryAcross,
@@ -81,6 +82,10 @@ data Progress
     NothingToVerify
   | -- | Input ended with the final check passing; the actions adjudicated.
     StreamEnded [Text]
+  | -- | The segment holds slots the node led, but the log shows no Leios activity
+    --   at all, so EB-role enforcement is suppressed for them. Carries how many
+    --   such leader slots were seen.
+    LeiosInactive Int
   | -- | Per epoch, whether eligibility came from the queried schedule.
     Summary [(Integer, Bool)]
 
@@ -88,6 +93,18 @@ data Progress
 isCSlot :: ChainEvent -> Bool
 isCSlot (CSlot _) = True
 isCSlot _ = False
+
+-- | True iff the event shows the Leios subsystem itself doing something. Praos
+--   events — 'CNodeIsLeader', 'CRBForged' — deliberately do not count, since the
+--   point is to tell whether Leios is running at all.
+isLeiosActivity :: ChainEvent -> Bool
+isLeiosActivity ev = case ev of
+  CEBForged{} -> True
+  CEBAcquired{} -> True
+  CAnnouncementAccepted{} -> True
+  CVoted{} -> True
+  CVoteAcquired{} -> True
+  _ -> False
 
 -- | How many slots pass between periodic re-verifications within a segment.
 --
@@ -247,15 +264,26 @@ runSegmented report ts query = loop [] Nothing []
     report (SegmentStarted seg (carrySpans carry))
     pure (seg, (ep, segAuthoritative seg) : tally)
 
-  checkSeg seg prefix =
+  -- The EB-role gate lives in the translator, which cannot report. Say so wherever
+  -- a prefix is verified, rather than letting leader slots be silently exempted.
+  -- Both verification sites need this: a run too short to reach a periodic
+  -- checkpoint is verified only at end of input.
+  reportIfLeiosInactive prefix = do
+    let led = length [() | CNodeIsLeader _ <- prefix]
+    when (led > 0 && not (any isLeiosActivity prefix)) $
+      report (LeiosInactive led)
+
+  checkSeg seg prefix = do
+    reportIfLeiosInactive prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
-     in if status == "ok"
-          then report (Verified (length prefix) (length acts))
-          else report (Violation (length prefix) acts status detail)
+    if status == "ok"
+      then report (Verified (length prefix) (length acts))
+      else report (Violation (length prefix) acts status detail)
 
   finishSeg Nothing _ = report NothingToVerify
-  finishSeg (Just seg) prefix =
+  finishSeg (Just seg) prefix = do
+    reportIfLeiosInactive prefix
     let (acts, (status, detail)) = verifySegment ts seg prefix
-     in if status == "ok"
-          then report (StreamEnded acts)
-          else report (Violation (length prefix) acts status detail)
+    if status == "ok"
+      then report (StreamEnded acts)
+      else report (Violation (length prefix) acts status detail)

--- a/leios-trace-verifier/hs-src/src/LinearLeiosLib.hs
+++ b/leios-trace-verifier/hs-src/src/LinearLeiosLib.hs
@@ -3,9 +3,10 @@ module LinearLeiosLib (
   module P,
   module V,
   verifyChainTraceFromSlot,
+  verifyChainTraceFinalFromSlot,
   module LinearLeiosLib,
 ) where
 
 import MAlonzo.Code.LinearLeiosVerifier as V
-import MAlonzo.Code.LinearLeiosVerifierChain (verifyChainTraceFromSlot)
+import MAlonzo.Code.LinearLeiosVerifierChain (verifyChainTraceFinalFromSlot, verifyChainTraceFromSlot)
 import MAlonzo.Code.Parser as P

--- a/leios-trace-verifier/hs-src/test/Spec.hs
+++ b/leios-trace-verifier/hs-src/test/Spec.hs
@@ -3,6 +3,7 @@ module Main where
 
 -- import Spec.Generated (generated)
 import Spec.ChainEvents (chainEvents)
+import Spec.ChainVerifier (chainVerifier)
 import Spec.Golden (golden)
 import Test.Hspec (describe, hspec)
 
@@ -14,3 +15,4 @@ main =
     -- describe "Generated traces" generated
     describe "Golden traces" golden
     describe "node.log chain events" chainEvents
+    describe "chain verifier" chainVerifier

--- a/leios-trace-verifier/hs-src/test/Spec.hs
+++ b/leios-trace-verifier/hs-src/test/Spec.hs
@@ -3,6 +3,7 @@ module Main where
 
 -- import Spec.Generated (generated)
 import Spec.ChainEvents (chainEvents)
+import Spec.ChainSegments (chainSegments)
 import Spec.ChainVerifier (chainVerifier)
 import Spec.Golden (golden)
 import Test.Hspec (describe, hspec)
@@ -16,3 +17,4 @@ main =
     describe "Golden traces" golden
     describe "node.log chain events" chainEvents
     describe "chain verifier" chainVerifier
+    describe "chain segments" chainSegments

--- a/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
@@ -59,7 +59,13 @@ chainEvents = do
         , "{\"ns\":\"Consensus.LeiosKernel.Voted\",\"data\":{\"kind\":\"LeiosVoted\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":20},\"weight\":1.22e-2}}"
         , "{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":32}}}"
         ]
-        `shouldBe` [CVoted "eb05" 300, CVoteAcquired "eb05" 300]
+        `shouldBe` [CAnnouncementAccepted "eb05" 300, CVoted "eb05" 300, CVoteAcquired "eb05" 300]
+    it "emits AnnouncementAccepted, which is what makes an EB votable" $
+      parse ["{\"ns\":\"Consensus.LeiosKernel.AnnouncementAccepted\",\"data\":{\"kind\":\"LeiosAnnouncementAccepted\",\"ebHash\":\"eb06\",\"electionSlot\":301,\"ebBodySize\":1,\"equivocation\":false}}"]
+        `shouldBe` [CAnnouncementAccepted "eb06" 301]
+    it "parses NodeIsLeader" $
+      parse ["{\"ns\":\"Forge.Loop.NodeIsLeader\",\"data\":{\"kind\":\"TraceNodeIsLeader\",\"slot\":7}}"]
+        `shouldBe` [CNodeIsLeader 7]
     it "drops votes whose linkage is missing (truncated log prefix)" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":1}}}"]
         `shouldBe` []

--- a/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
@@ -90,6 +90,26 @@ chainEvents = do
     it "maps NotVoted (a deliberate, protocol-legal abstention) with its reason" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.NotVoted\",\"data\":{\"kind\":\"LeiosNotVoted\",\"ebHash\":\"eb07\",\"ebSlot\":540,\"reason\":\"chainTipDoesNotAnnounce\"}}"]
         `shouldBe` [CNotVoted "eb07" 540 "chainTipDoesNotAnnounce"]
+    -- Mempool readings are far too voluminous to pass through one per event, so they
+    -- are aggregated to one range per slot, emitted just ahead of the tick that
+    -- closes that slot. The range also carries forward: the mempool as it stood when
+    -- a slot began is one of that slot's readings, which is why slot 2's range starts
+    -- at 300 rather than at its own first reading.
+    it "aggregates mempool readings into one range per slot" $
+      parse
+        [ "{\"ns\":\"Forge.Loop.StartLeadershipCheck\",\"data\":{\"slot\":1}}"
+        , "{\"ns\":\"Mempool.AddedTx\",\"data\":{\"kind\":\"TraceMempoolAddedTx\",\"mempoolSize\":{\"bytes\":100,\"numTxs\":1},\"tx\":{\"txid\":\"a\"}}}"
+        , "{\"ns\":\"Mempool.AddedTx\",\"data\":{\"kind\":\"TraceMempoolAddedTx\",\"mempoolSize\":{\"bytes\":300,\"numTxs\":2},\"tx\":{\"txid\":\"b\"}}}"
+        , "{\"ns\":\"Forge.Loop.StartLeadershipCheck\",\"data\":{\"slot\":2}}"
+        , "{\"ns\":\"Mempool.RemoveTxs\",\"data\":{\"kind\":\"TraceMempoolRemoveTxs\",\"mempoolSize\":{\"bytes\":40,\"numTxs\":0},\"txs\":[]}}"
+        , "{\"ns\":\"Forge.Loop.StartLeadershipCheck\",\"data\":{\"slot\":3}}"
+        ]
+        `shouldBe` [ CSlot 1
+                   , CMempoolRange 100 300
+                   , CSlot 2
+                   , CMempoolRange 40 300
+                   , CSlot 3
+                   ]
     it "drops votes whose linkage is missing (truncated log prefix)" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":1}}}"]
         `shouldBe` []

--- a/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
@@ -60,25 +60,36 @@ chainEvents = do
         , "{\"ns\":\"Consensus.LeiosKernel.Voted\",\"data\":{\"kind\":\"LeiosVoted\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":20},\"weight\":1.22e-2}}"
         , "{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":32}}}"
         ]
-        `shouldBe` [CAnnouncementAccepted "eb05" 300, CVoted "eb05" 300, CVoteAcquired "eb05" 300]
+        `shouldBe` [CAnnouncementAccepted "eb05" 300, CChainExtended 300, CVoted "eb05" 300, CVoteAcquired "eb05" 300]
     -- An RB can be adopted by switching to a fork rather than by extending the
     -- current chain. Both report the adopted tip in 'newtip', and the node votes
     -- on whatever it selected, so both must feed the linkage map. Listening only
     -- to AddedToCurrentChain silently drops the vote, which reads downstream as
-    -- an unexplained abstention.
+    -- an unexplained abstention. Distinct from the CChainExtended cases below:
+    -- this pins the vote *resolving* through a fork switch, not merely the tip
+    -- advance being reported.
     it "resolves votes for an RB adopted by switching to a fork" $
       parse
         [ "{\"ns\":\"Consensus.LeiosKernel.AnnouncementAccepted\",\"data\":{\"kind\":\"LeiosAnnouncementAccepted\",\"ebHash\":\"eb07\",\"electionSlot\":699,\"ebBodySize\":70347,\"equivocation\":false}}"
         , "{\"ns\":\"ChainDB.AddBlockEvent.SwitchedToAFork\",\"data\":{\"kind\":\"TraceAddBlockEvent.SwitchedToAFork\",\"newSuffixSelectView\":{\"blockNo\":32,\"kind\":\"PraosTiebreakerView\",\"slotNo\":699},\"newtip\":\"" <> rb64 <> "@699\"}}"
         , "{\"ns\":\"Consensus.LeiosKernel.Voted\",\"data\":{\"kind\":\"LeiosVoted\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":2},\"weight\":0.333333333333}}"
         ]
-        `shouldBe` [CAnnouncementAccepted "eb07" 699, CVoted "eb07" 699]
+        `shouldBe` [CAnnouncementAccepted "eb07" 699, CChainExtended 699, CVoted "eb07" 699]
     it "emits AnnouncementAccepted, which is what makes an EB votable" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.AnnouncementAccepted\",\"data\":{\"kind\":\"LeiosAnnouncementAccepted\",\"ebHash\":\"eb06\",\"electionSlot\":301,\"ebBodySize\":1,\"equivocation\":false}}"]
         `shouldBe` [CAnnouncementAccepted "eb06" 301]
     it "parses NodeIsLeader" $
       parse ["{\"ns\":\"Forge.Loop.NodeIsLeader\",\"data\":{\"kind\":\"TraceNodeIsLeader\",\"slot\":7}}"]
         `shouldBe` [CNodeIsLeader 7]
+    it "emits CChainExtended when the tip advances (AddedToCurrentChain)" $
+      parse ["{\"ns\":\"ChainDB.AddBlockEvent.AddedToCurrentChain\",\"data\":{\"kind\":\"AddedToCurrentChain\",\"newtip\":\"" <> rb64 <> "@432\"}}"]
+        `shouldBe` [CChainExtended 432]
+    it "emits CChainExtended on a fork switch too (SwitchedToAFork)" $
+      parse ["{\"ns\":\"ChainDB.AddBlockEvent.SwitchedToAFork\",\"data\":{\"kind\":\"TraceAddBlockEvent.SwitchedToAFork\",\"newtip\":\"" <> rb64 <> "@433\"}}"]
+        `shouldBe` [CChainExtended 433]
+    it "maps NotVoted (a deliberate, protocol-legal abstention) with its reason" $
+      parse ["{\"ns\":\"Consensus.LeiosKernel.NotVoted\",\"data\":{\"kind\":\"LeiosNotVoted\",\"ebHash\":\"eb07\",\"ebSlot\":540,\"reason\":\"chainTipDoesNotAnnounce\"}}"]
+        `shouldBe` [CNotVoted "eb07" 540 "chainTipDoesNotAnnounce"]
     it "drops votes whose linkage is missing (truncated log prefix)" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":1}}}"]
         `shouldBe` []

--- a/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainEvents.hs
@@ -4,7 +4,8 @@
 --   node trace schemas: the pre-w31 combined @TraceLeiosKernel@ namespace and
 --   the w31+ per-event namespaces with RB-keyed votes. w31+ votes are
 --   resolved via two linkage facts: @AnnouncementAccepted@ (election slot →
---   ebHash) composed with ChainDB @AddedToCurrentChain@ (rbHash → slot).
+--   ebHash) composed with ChainDB's selection-change events,
+--   @AddedToCurrentChain@ and @SwitchedToAFork@ (rbHash → slot).
 --   Payload shapes mirror real node.log lines.
 module Spec.ChainEvents (
   chainEvents,
@@ -60,6 +61,18 @@ chainEvents = do
         , "{\"ns\":\"Consensus.LeiosKernel.VoteAcquired\",\"data\":{\"kind\":\"LeiosVoteAcquired\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":32}}}"
         ]
         `shouldBe` [CAnnouncementAccepted "eb05" 300, CVoted "eb05" 300, CVoteAcquired "eb05" 300]
+    -- An RB can be adopted by switching to a fork rather than by extending the
+    -- current chain. Both report the adopted tip in 'newtip', and the node votes
+    -- on whatever it selected, so both must feed the linkage map. Listening only
+    -- to AddedToCurrentChain silently drops the vote, which reads downstream as
+    -- an unexplained abstention.
+    it "resolves votes for an RB adopted by switching to a fork" $
+      parse
+        [ "{\"ns\":\"Consensus.LeiosKernel.AnnouncementAccepted\",\"data\":{\"kind\":\"LeiosAnnouncementAccepted\",\"ebHash\":\"eb07\",\"electionSlot\":699,\"ebBodySize\":70347,\"equivocation\":false}}"
+        , "{\"ns\":\"ChainDB.AddBlockEvent.SwitchedToAFork\",\"data\":{\"kind\":\"TraceAddBlockEvent.SwitchedToAFork\",\"newSuffixSelectView\":{\"blockNo\":32,\"kind\":\"PraosTiebreakerView\",\"slotNo\":699},\"newtip\":\"" <> rb64 <> "@699\"}}"
+        , "{\"ns\":\"Consensus.LeiosKernel.Voted\",\"data\":{\"kind\":\"LeiosVoted\",\"vote\":{\"rbHash\":\"" <> rb64 <> "\",\"voterId\":2},\"weight\":0.333333333333}}"
+        ]
+        `shouldBe` [CAnnouncementAccepted "eb07" 699, CVoted "eb07" 699]
     it "emits AnnouncementAccepted, which is what makes an EB votable" $
       parse ["{\"ns\":\"Consensus.LeiosKernel.AnnouncementAccepted\",\"data\":{\"kind\":\"LeiosAnnouncementAccepted\",\"ebHash\":\"eb06\",\"electionSlot\":301,\"ebBodySize\":1,\"equivocation\":false}}"]
         `shouldBe` [CAnnouncementAccepted "eb06" 301]

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -43,6 +43,7 @@ stubChainData =
     , cdStakeDistribution = [("node-0", 1000000000), ("node-1", 1000000000), ("node-2", 1000000000)]
     , cdSutIndex = 2
     , cdEpochLength = 10
+    , cdMaxRBBody = 100
     , cdNodeEpoch = 0
     }
 
@@ -139,13 +140,16 @@ praosOnly =
     <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4]
     <> ticks 5 9
 
--- | The same leader slot, but preceded by a Leios acquisition, so the gate is open
---   and forging no EB at slot 4 is a genuine abstention from an available role.
+-- | The same leader slot, but preceded by a Leios acquisition, so the gate is open;
+--   and with a mempool too large for the ranking block, so an EB really was owed and
+--   forging none at slot 4 is a genuine abstention from an available role. Both
+--   conditions are needed: the gate alone no longer makes a bare leader slot a
+--   violation, since an EB is owed only when the mempool would not have fitted.
 leiosActiveThenSilentLeader :: [ChainEvent]
 leiosActiveThenSilentLeader =
   ticks 0 1
     <> [CSlot 2, CAnnouncementAccepted "eb" 2, CEBAcquired "eb" 2, CSlot 3]
-    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4]
+    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4, CMempoolRange 200 200]
     <> ticks 5 9
 
 chainSegments :: Spec

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -133,11 +133,23 @@ voteForUnannouncedEB =
     <> ticks 6 9
 
 -- | A Praos leader slot with no Leios activity anywhere: the node won the lottery
---   and forged a ranking block while the subsystem had not yet done anything.
+--   and forged a ranking block while the subsystem had not yet done anything. The
+--   mempool exceeds the ranking block's capacity, so an EB was owed and the gate is
+--   what excuses the slot — which is the case worth reporting.
 praosOnly :: [ChainEvent]
 praosOnly =
   ticks 0 3
-    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4]
+    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4, CMempoolRange 200 200]
+    <> ticks 5 9
+
+-- | The same, but with a mempool that fits. The gate still suppresses enforcement,
+--   and now costs nothing by doing so: the mempool rule would have excused the slot
+--   on its own terms. Reporting suppression here would claim a loss not incurred,
+--   which on a low-traffic network is every led slot.
+praosOnlyMempoolFits :: [ChainEvent]
+praosOnlyMempoolFits =
+  ticks 0 3
+    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4, CMempoolRange 50 50]
     <> ticks 5 9
 
 -- | The same leader slot, but preceded by a Leios acquisition, so the gate is open;
@@ -238,6 +250,15 @@ chainSegments = do
     it "reports the suppression rather than exempting the slot silently" $ do
       ps <- collectWith 100 praosOnly
       length [n | LeiosInactive n <- ps] `shouldNotBe` 0
+    it "stays quiet when the mempool rule would have excused the slot anyway" $ do
+      -- Same shape, mempool within the ranking block's capacity. The gate suppresses
+      -- nothing the rule would have caught, so claiming a suppression would be noise
+      -- — and on a 1 TX/s network it fires on every led slot.
+      ps <- collectWith 100 praosOnlyMempoolFits
+      length [n | LeiosInactive n <- ps] `shouldBe` 0
+    it "still raises no violation when the gate stays quiet" $ do
+      ps <- collectWith 100 praosOnlyMempoolFits
+      violations ps `shouldBe` []
     it "still enforces the EB role once Leios has shown activity" $ do
       -- Same leader slot, but an EB was acquired earlier, so the gate is open and
       -- forging nothing at slot 4 is a violation.

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests for the segmentation driver in "LinearLeiosChain": how the event stream is
+--   split at epoch boundaries, and what that means for obligations crossing a seam.
+--
+--   These drive the same 'runSegmented' the executable does, with the chain query
+--   stubbed and a collecting reporter in place of the renderer, so the segmentation
+--   decisions are exercised rather than reimplemented.
+module Spec.ChainSegments (
+  chainSegments,
+) where
+
+import ChainEvents (ChainEvent (..))
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Text (Text)
+import LinearLeiosChain (
+  Carry (..),
+  ChainData (..),
+  Progress (..),
+  Segment (..),
+  Timings (..),
+  carryAcross,
+  overlapSlots,
+  runSegmented,
+  segmentAuthoritative,
+ )
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+-- | The timings the chain app uses, under which an announced EB has exactly one legal
+--   vote slot at @ebSlot + 3@ and the carry width is 4.
+timings :: Timings
+timings = Timings{tLhdr = 1, tLvote = 4, tLdiff = 7, tValidityCheckTime = 3}
+
+-- | Ten-slot epochs, so a fixture can cross a boundary in a handful of events. Three
+--   equal-stake pools with the SUT last, and no obtainable schedule, which is the
+--   common case against a devnet.
+stubChainData :: ChainData
+stubChainData =
+  ChainData
+    { cdWinningSlots = Nothing
+    , cdNumParties = 3
+    , cdStakeDistribution = [("node-0", 1000000000), ("node-1", 1000000000), ("node-2", 1000000000)]
+    , cdSutIndex = 2
+    , cdEpochLength = 10
+    , cdNodeEpoch = 0
+    }
+
+-- | Run the driver over an event list, collecting progress instead of rendering it.
+--   Nothing aborts, so a violation does not stop the run and everything is observed.
+collect :: [ChainEvent] -> IO [Progress]
+collect evs = do
+  ref <- newIORef []
+  runSegmented (\p -> modifyIORef' ref (p :)) timings (const (pure stubChainData)) evs
+  reverse <$> readIORef ref
+
+violations :: [Progress] -> [Text]
+violations ps = [status | Violation _ _ status _ <- ps]
+
+segmentStarts :: [Progress] -> [Integer]
+segmentStarts ps = [segStart s | SegmentStarted s _ <- ps]
+
+-- | Slot ticks 0..n, in the order the driver sees them.
+ticks :: Integer -> Integer -> [ChainEvent]
+ticks from to = [CSlot (fromInteger s) | s <- [from .. to]]
+
+-- | An EB announced in slot 8 of a ten-slot epoch, so its vote falls due in slot 11 —
+--   in the next epoch. The vote is present.
+straddlingVoted :: [ChainEvent]
+straddlingVoted =
+  ticks 0 7
+    <> [CSlot 8, CAnnouncementAccepted "eb" 8, CEBAcquired "eb" 8, CSlot 9, CSlot 10, CSlot 11, CVoted "eb" 8, CSlot 12]
+
+-- | The same, with the vote withheld. The obligation is only visible to a segment
+--   that carried the announcement across the boundary, so this is what distinguishes
+--   an overlapping split from a clean cut.
+straddlingUnvoted :: [ChainEvent]
+straddlingUnvoted =
+  ticks 0 7
+    <> [CSlot 8, CAnnouncementAccepted "eb" 8, CEBAcquired "eb" 8, CSlot 9, CSlot 10, CSlot 11, CSlot 12]
+
+chainSegments :: Spec
+chainSegments = do
+  describe "carry width" $
+    it "spans the vote window plus the acquisition lead" $
+      overlapSlots timings `shouldBe` 4
+
+  describe "carrying across a boundary" $ do
+    it "carries nothing for the first segment" $ do
+      let c = carryAcross 4 0 []
+      (carryEvents c, carryStart c, carrySpans c) `shouldBe` ([], 0, False)
+    it "carries the slots within the window and starts there" $ do
+      let c = carryAcross 4 10 (reverse (ticks 0 9))
+      (carryStart c, carrySpans c) `shouldBe` (6, True)
+    it "keeps non-tick events inside the window" $ do
+      let seen = reverse (ticks 6 9 <> [CAnnouncementAccepted "eb" 9])
+          c = carryAcross 4 10 seen
+      length (carryEvents c) `shouldBe` 5
+    it "starts at the earliest tick available when the epoch is shorter than the window" $ do
+      let c = carryAcross 4 3 (reverse (ticks 1 2))
+      carryStart c `shouldBe` 1
+    it "trims events ahead of the first carried tick" $ do
+      -- The oldest event here belongs to a slot before the cutoff; carried whole it
+      -- would be attributed to the segment start rather than to its own slot.
+      let seen = [CSlot 6, CEBAcquired "eb" 5]
+          c = carryAcross 4 10 seen
+      (length (carryEvents c), carryStart c) `shouldBe` (1, 6)
+
+  describe "whether a queried schedule governs a segment" $ do
+    it "does when it is for this epoch and the segment is wholly inside it" $
+      segmentAuthoritative False 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
+        `shouldBe` True
+    it "does even when it is empty, an empty schedule being a real answer" $
+      segmentAuthoritative False 3 stubChainData{cdWinningSlots = Just [], cdNodeEpoch = 3}
+        `shouldBe` True
+    it "does not when the node answered for another epoch" $
+      segmentAuthoritative False 3 stubChainData{cdWinningSlots = Just [21], cdNodeEpoch = 2}
+        `shouldBe` False
+    it "does not when none was obtainable" $
+      segmentAuthoritative False 3 stubChainData{cdWinningSlots = Nothing, cdNodeEpoch = 3}
+        `shouldBe` False
+    it "does not when the segment spans two epochs" $
+      segmentAuthoritative True 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
+        `shouldBe` False
+
+  describe "obligations that straddle an epoch boundary" $ do
+    it "starts the second segment before the boundary" $ do
+      ps <- collect straddlingVoted
+      segmentStarts ps `shouldBe` [0, 6]
+    it "accepts a straddling vote that was cast" $ do
+      ps <- collect straddlingVoted
+      violations ps `shouldBe` []
+    it "rejects a straddling vote that was withheld" $ do
+      -- The discriminating case: with a clean cut the second segment starts on empty
+      -- state, the obligation is invisible, and the abstention passes vacuously.
+      ps <- collect straddlingUnvoted
+      violations ps `shouldNotBe` []

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -170,6 +170,20 @@ leiosActiveThenSilentLeader =
     <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4, CMempoolRange 200 200]
     <> ticks 5 9
 
+-- | An EB announced in slot 4 of a ten-slot epoch: its window opens at 7 and its
+--   deadline is 11, past the boundary. The vote is withheld throughout.
+--
+--   This is what makes the carry width a checked quantity rather than an asserted
+--   one. Only a carry reaching back to slot 4 puts the announcement in the second
+--   segment's prefix at all; with the previous 4-slot width that segment starts at 6,
+--   the announcement is invisible, no head is established, and the missed vote goes
+--   unreported — silently, with every other test still green.
+lateDeadlineStraddling :: [ChainEvent]
+lateDeadlineStraddling =
+  ticks 0 3
+    <> [CSlot 4, CAnnouncementAccepted "eb" 4, CEBAcquired "eb" 4]
+    <> ticks 5 13
+
 -- | The node logs no leadership check for slot 4. The spec advances one slot at a
 --   time, so verification cannot cross the gap; it must restart after it rather than
 --   reject the jump. Observed on a devnet at 30 TX/s as a single missing tick, which
@@ -293,6 +307,9 @@ chainSegments = do
       -- overlap is negligible.
       ps <- collect straddlingVoted
       segmentStarts ps `shouldBe` [0, 2]
+    it "sees an obligation whose deadline falls well past the boundary" $ do
+      ps <- collect lateDeadlineStraddling
+      violations ps `shouldNotBe` []
     it "accepts a straddling vote that was cast" $ do
       ps <- collect straddlingVoted
       violations ps `shouldBe` []

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -109,6 +109,19 @@ twoAnnouncementsInOneSlot =
        ]
     <> ticks 6 9
 
+-- | Announcements in consecutive slots. The EB announced at slot 2 is superseded as
+--   the head at slot 3, before its own vote window opens at 5, so slot 5 abstains
+--   legally and the only vote due is for the later EB at slot 6. Observed against a
+--   devnet as announcements at 698 and 699 with a single vote at 702.
+supersededBeforeVotable :: [ChainEvent]
+supersededBeforeVotable =
+  ticks 0 1
+    <> [CSlot 2, CAnnouncementAccepted "eb2" 2, CEBAcquired "eb2" 2]
+    <> [CSlot 3, CAnnouncementAccepted "eb3" 3, CEBAcquired "eb3" 3]
+    <> [CSlot 4, CSlot 5]
+    <> [CSlot 6, CVoted "eb3" 3]
+    <> ticks 7 9
+
 -- | A vote for an EB the chain never announced must not establish its own
 --   precondition by supplying the head for its slot.
 voteForUnannouncedEB :: [ChainEvent]
@@ -179,7 +192,7 @@ chainSegments = do
       segmentAuthoritative True 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
         `shouldBe` False
 
-  describe "two announcements inside one slot" $ do
+  describe "which announced EB heads a slot" $ do
     it "adjudicates the slot against the EB that was voted for" $ do
       ps <- collectWith 100 twoAnnouncementsInOneSlot
       violations ps `shouldBe` []
@@ -187,6 +200,9 @@ chainSegments = do
       -- eb2 was acquired but never announced, so it was never votable; the vote
       -- must not make itself legal by becoming the slot's head.
       ps <- collectWith 100 voteForUnannouncedEB
+      violations ps `shouldBe` []
+    it "raises no obligation for a head superseded before its vote window opens" $ do
+      ps <- collectWith 100 supersededBeforeVotable
       violations ps `shouldBe` []
 
   describe "Praos leadership without Leios running" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -152,6 +152,13 @@ leiosActiveThenSilentLeader =
     <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4, CMempoolRange 200 200]
     <> ticks 5 9
 
+-- | The node logs no leadership check for slot 4. The spec advances one slot at a
+--   time, so verification cannot cross the gap; it must restart after it rather than
+--   reject the jump. Observed on a devnet at 30 TX/s as a single missing tick, which
+--   killed the session with "8 : Err-Slot / Base₁-Action".
+tickGap :: [ChainEvent]
+tickGap = ticks 0 3 <> ticks 5 9
+
 chainSegments :: Spec
 chainSegments = do
   describe "carry width" $
@@ -208,6 +215,19 @@ chainSegments = do
     it "raises no obligation for a head superseded before its vote window opens" $ do
       ps <- collectWith 100 supersededBeforeVotable
       violations ps `shouldBe` []
+
+  describe "a gap in the slot ticks" $ do
+    it "does not reject the jump" $ do
+      ps <- collectWith 100 tickGap
+      violations ps `shouldBe` []
+    it "reports the gap rather than passing over it silently" $ do
+      ps <- collectWith 100 tickGap
+      [(f, t) | SlotGap f t <- ps] `shouldBe` [(3, 5)]
+    it "restarts verification after the gap, carrying nothing across it" $ do
+      -- Carrying the overlap would bring slots from before the gap into the new
+      -- segment, which would still contain the gap and still be rejected.
+      ps <- collectWith 100 tickGap
+      segmentStarts ps `shouldBe` [0, 5]
 
   describe "Praos leadership without Leios running" $ do
     it "raises no EB obligation when the log shows no Leios activity" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -92,6 +92,32 @@ straddlingUnvoted =
   ticks 0 7
     <> [CSlot 8, CAnnouncementAccepted "eb" 8, CEBAcquired "eb" 8, CSlot 9, CSlot 10, CSlot 11, CSlot 12]
 
+-- | Two announcements inside one slot. An EB announced at slot 2 is votable at 5;
+--   the node votes there and, in the same slot, forges and announces its own EB,
+--   moving the head. The slot must still be adjudicated against the EB voted for.
+twoAnnouncementsInOneSlot :: [ChainEvent]
+twoAnnouncementsInOneSlot =
+  ticks 0 1
+    <> [CSlot 2, CAnnouncementAccepted "eb2" 2, CEBAcquired "eb2" 2]
+    <> [CSlot 3, CSlot 4]
+    <> [ CSlot 5
+       , CNodeIsLeader 5
+       , CVoted "eb2" 2
+       , CEBForged "eb5" 5
+       , CRBForged "rb5" 5
+       , CAnnouncementAccepted "eb5" 5
+       ]
+    <> ticks 6 9
+
+-- | A vote for an EB the chain never announced must not establish its own
+--   precondition by supplying the head for its slot.
+voteForUnannouncedEB :: [ChainEvent]
+voteForUnannouncedEB =
+  ticks 0 1
+    <> [CSlot 2, CEBAcquired "eb2" 2]
+    <> [CSlot 3, CSlot 4, CSlot 5, CVoted "eb2" 2]
+    <> ticks 6 9
+
 -- | A Praos leader slot with no Leios activity anywhere: the node won the lottery
 --   and forged a ranking block while the subsystem had not yet done anything.
 praosOnly :: [ChainEvent]
@@ -152,6 +178,16 @@ chainSegments = do
     it "does not when the segment spans two epochs" $
       segmentAuthoritative True 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
         `shouldBe` False
+
+  describe "two announcements inside one slot" $ do
+    it "adjudicates the slot against the EB that was voted for" $ do
+      ps <- collectWith 100 twoAnnouncementsInOneSlot
+      violations ps `shouldBe` []
+    it "does not let a vote supply the head for an unannounced EB" $ do
+      -- eb2 was acquired but never announced, so it was never votable; the vote
+      -- must not make itself legal by becoming the slot's head.
+      ps <- collectWith 100 voteForUnannouncedEB
+      violations ps `shouldBe` []
 
   describe "Praos leadership without Leios running" $ do
     it "raises no EB obligation when the log shows no Leios activity" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -92,6 +92,23 @@ straddlingUnvoted =
   ticks 0 7
     <> [CSlot 8, CAnnouncementAccepted "eb" 8, CEBAcquired "eb" 8, CSlot 9, CSlot 10, CSlot 11, CSlot 12]
 
+-- | A Praos leader slot with no Leios activity anywhere: the node won the lottery
+--   and forged a ranking block while the subsystem had not yet done anything.
+praosOnly :: [ChainEvent]
+praosOnly =
+  ticks 0 3
+    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4]
+    <> ticks 5 9
+
+-- | The same leader slot, but preceded by a Leios acquisition, so the gate is open
+--   and forging no EB at slot 4 is a genuine abstention from an available role.
+leiosActiveThenSilentLeader :: [ChainEvent]
+leiosActiveThenSilentLeader =
+  ticks 0 1
+    <> [CSlot 2, CAnnouncementAccepted "eb" 2, CEBAcquired "eb" 2, CSlot 3]
+    <> [CSlot 4, CNodeIsLeader 4, CRBForged "rb" 4]
+    <> ticks 5 9
+
 chainSegments :: Spec
 chainSegments = do
   describe "carry width" $
@@ -135,6 +152,21 @@ chainSegments = do
     it "does not when the segment spans two epochs" $
       segmentAuthoritative True 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
         `shouldBe` False
+
+  describe "Praos leadership without Leios running" $ do
+    it "raises no EB obligation when the log shows no Leios activity" $ do
+      -- The devnet shape that failed: leader at slot 4, a ranking block forged, and
+      -- nothing Leios anywhere. NodeIsLeader alone is Praos leadership.
+      ps <- collectWith 100 praosOnly
+      violations ps `shouldBe` []
+    it "reports the suppression rather than exempting the slot silently" $ do
+      ps <- collectWith 100 praosOnly
+      length [n | LeiosInactive n <- ps] `shouldNotBe` 0
+    it "still enforces the EB role once Leios has shown activity" $ do
+      -- Same leader slot, but an EB was acquired earlier, so the gate is open and
+      -- forging nothing at slot 4 is a violation.
+      ps <- collectWith 100 leiosActiveThenSilentLeader
+      violations ps `shouldNotBe` []
 
   describe "checkpoint throttling" $ do
     it "re-verifies periodically rather than at every slot" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -184,6 +184,39 @@ lateDeadlineStraddling =
     <> [CSlot 4, CAnnouncementAccepted "eb" 4, CEBAcquired "eb" 4]
     <> ticks 5 13
 
+-- | A slot tick that repeats, then one that goes backwards — the shape concatenated
+--   or overlapping logs produce. Neither is a continuation nor a gap.
+nonMonotonicTicks :: [ChainEvent]
+nonMonotonicTicks =
+  ticks 0 4 <> [CSlot 4] <> ticks 5 6 <> [CSlot 3] <> ticks 7 9
+
+-- | Two votes in one slot, for two EBs both announced and acquired, both votable at
+--   slot 6 (windows 5..9 and 6..10). Only one can be adjudicated, so the surplus must
+--   be counted rather than vanish — and the one kept has to be the head, ebB. Keeping
+--   ebA instead drops ebB's vote and then demands it again at ebB's deadline, slot 10,
+--   reporting a violation for a vote the node did cast.
+twoVotesOneSlot :: [ChainEvent]
+twoVotesOneSlot =
+  ticks 0 1
+    <> [CSlot 2, CAnnouncementAccepted "ebA" 2, CEBAcquired "ebA" 2]
+    <> [CSlot 3, CAnnouncementAccepted "ebB" 3, CEBAcquired "ebB" 3]
+    <> [CSlot 4, CSlot 5]
+    <> [CSlot 6, CVoted "ebA" 2, CVoted "ebB" 3]
+    <> ticks 7 13
+
+-- | The same, with the votes in the other order. Together the two fixtures rule out
+--   any positional rule: keeping the first loses ebB's vote here's twin, keeping the
+--   last loses it in this one. Only picking the vote that names the head works for
+--   both, because only the head is votable.
+twoVotesOneSlotHeadFirst :: [ChainEvent]
+twoVotesOneSlotHeadFirst =
+  ticks 0 1
+    <> [CSlot 2, CAnnouncementAccepted "ebA" 2, CEBAcquired "ebA" 2]
+    <> [CSlot 3, CAnnouncementAccepted "ebB" 3, CEBAcquired "ebB" 3]
+    <> [CSlot 4, CSlot 5]
+    <> [CSlot 6, CVoted "ebB" 3, CVoted "ebA" 2]
+    <> ticks 7 13
+
 -- | The node logs no leadership check for slot 4. The spec advances one slot at a
 --   time, so verification cannot cross the gap; it must restart after it rather than
 --   reject the jump. Observed on a devnet at 30 TX/s as a single missing tick, which
@@ -249,6 +282,35 @@ chainSegments = do
       violations ps `shouldBe` []
     it "raises no obligation for a head superseded before its vote window opens" $ do
       ps <- collectWith 100 supersededBeforeVotable
+      violations ps `shouldBe` []
+
+  describe "ticks that do not advance" $ do
+    it "drops them rather than restarting a segment mid-epoch" $ do
+      -- Without an explicit case these matched neither the continuation guard
+      -- (s == l + 1) nor the gap condition (s > l + 1) and fell through to the
+      -- boundary path, silently starting a new segment inside the epoch.
+      ps <- collectWith 100 nonMonotonicTicks
+      segmentStarts ps `shouldBe` [0]
+    it "reports each one" $ do
+      ps <- collectWith 100 nonMonotonicTicks
+      [(l, s) | NonMonotonicSlot l s <- ps] `shouldBe` [(4, 4), (6, 3)]
+    it "raises no violation" $ do
+      ps <- collectWith 100 nonMonotonicTicks
+      violations ps `shouldBe` []
+
+  describe "more than one vote in a slot" $ do
+    it "counts the votes it cannot adjudicate" $ do
+      ps <- collectWith 100 twoVotesOneSlot
+      sum [n | SurplusVotesInSlot n <- ps] `shouldNotBe` 0
+    it "keeps the head's vote when it arrives second" $ do
+      ps <- collectWith 100 twoVotesOneSlot
+      violations ps `shouldBe` []
+    it "keeps the head's vote when it arrives first" $ do
+      -- With the previous fixture this excludes both positional rules. Whichever of
+      -- first-wins or last-wins is chosen, one of the two drops the head's vote and
+      -- the verifier then demands it again at that EB's deadline — a violation for a
+      -- vote the node cast.
+      ps <- collectWith 100 twoVotesOneSlotHeadFirst
       violations ps `shouldBe` []
 
   describe "a gap in the slot ticks" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainSegments.hs
@@ -20,6 +20,7 @@ import LinearLeiosChain (
   Segment (..),
   Timings (..),
   carryAcross,
+  checkpointEvery,
   overlapSlots,
   runSegmented,
   segmentAuthoritative,
@@ -47,14 +48,27 @@ stubChainData =
 
 -- | Run the driver over an event list, collecting progress instead of rendering it.
 --   Nothing aborts, so a violation does not stop the run and everything is observed.
-collect :: [ChainEvent] -> IO [Progress]
-collect evs = do
+collectWith :: Integer -> [ChainEvent] -> IO [Progress]
+collectWith epochLen evs = do
   ref <- newIORef []
-  runSegmented (\p -> modifyIORef' ref (p :)) timings (const (pure stubChainData)) evs
+  runSegmented
+    (\p -> modifyIORef' ref (p :))
+    timings
+    (const (pure stubChainData{cdEpochLength = epochLen}))
+    evs
   reverse <$> readIORef ref
+
+collect :: [ChainEvent] -> IO [Progress]
+collect = collectWith 10
 
 violations :: [Progress] -> [Text]
 violations ps = [status | Violation _ _ status _ <- ps]
+
+verifiedCount :: [Progress] -> Int
+verifiedCount ps = length [() | Verified _ _ <- ps]
+
+streamEndedCount :: [Progress] -> Int
+streamEndedCount ps = length [() | StreamEnded _ <- ps]
 
 segmentStarts :: [Progress] -> [Integer]
 segmentStarts ps = [segStart s | SegmentStarted s _ <- ps]
@@ -121,6 +135,17 @@ chainSegments = do
     it "does not when the segment spans two epochs" $
       segmentAuthoritative True 3 stubChainData{cdWinningSlots = Just [31], cdNodeEpoch = 3}
         `shouldBe` False
+
+  describe "checkpoint throttling" $ do
+    it "re-verifies periodically rather than at every slot" $ do
+      -- 46 ticks inside one epoch, so only the periodic checkpoints fire. Slot 0
+      -- takes the boundary path, which starts the segment without checking it.
+      ps <- collectWith 100 (ticks 0 45)
+      verifiedCount ps
+        `shouldBe` length [s | s <- [1 .. 45 :: Integer], s `mod` checkpointEvery == 0]
+    it "still checks the tail at end of input despite throttling" $ do
+      ps <- collectWith 100 (ticks 0 45)
+      streamEndedCount ps `shouldBe` 1
 
   describe "obligations that straddle an epoch boundary" $ do
     it "starts the second segment before the boundary" $ do

--- a/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Behavioural tests for the chain verifier itself, as distinct from the node.log
+--   parser covered by "Spec.ChainEvents". Each case is a hand-written event list run
+--   through the whole pipeline — translation into spec actions, then the Agda
+--   verifier — so what they pin down is the translator decisions that determine
+--   whether an obligation is raised at all, and whether the spec then discharges it.
+--
+--   'verifyChainTraceFinalFromSlot' is used rather than the streaming entry point
+--   because a fixed event list is a complete log: the trailing slot can be
+--   adjudicated, so every slot in a fixture is checked.
+module Spec.ChainVerifier (
+  chainVerifier,
+) where
+
+import ChainEvents (ChainEvent (..))
+import Data.Text (Text)
+import LinearLeiosLib (verifyChainTraceFinalFromSlot)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldNotBe)
+
+-- | Three equal-stake pools with the SUT last, mirroring the devnet the chain
+--   verifier is exercised against. The figures have to be non-zero: vote
+--   eligibility is the CIP-0164 committee, computed from the stake distribution
+--   rather than a per-slot lottery.
+stakeDist :: [(Text, Integer)]
+stakeDist = [("node-0", 1000000000), ("node-1", 1000000000), ("node-2", 1000000000)]
+
+-- | Verify a fixed event list starting at slot 0, returning just the status.
+--
+--   Timings are the ones the chain app hardcodes — Lhdr 1, Lvote 4, Ldiff 7,
+--   validity check 3 — under which an announced EB is votable in exactly one slot,
+--   @ebSlot + (3 * Lhdr `max` validityCheckTime) == ebSlot + 3@.
+verify :: [Integer] -> Bool -> [ChainEvent] -> Text
+verify slots authoritative evs =
+  fst (snd (verifyChainTraceFinalFromSlot 3 2 stakeDist 1 4 7 3 slots authoritative evs 0))
+
+-- | Eligibility taken from the log, as happens for any epoch the queried schedule
+--   cannot cover.
+fromLog :: [ChainEvent] -> Text
+fromLog = verify [] False
+
+-- | An EB announced and acquired in slot 1 and voted in slot 4.
+announcedAndVoted :: [ChainEvent]
+announcedAndVoted =
+  [ CSlot 0
+  , CSlot 1
+  , CAnnouncementAccepted "eb" 1
+  , CEBAcquired "eb" 1
+  , CSlot 2
+  , CSlot 3
+  , CSlot 4
+  , CVoted "eb" 1
+  , CSlot 5
+  ]
+
+-- | The same EB fetched but never announced on the chain, so nothing makes it
+--   votable and abstaining is correct.
+acquiredNotAnnounced :: [ChainEvent]
+acquiredNotAnnounced =
+  [ CSlot 0
+  , CSlot 1
+  , CEBAcquired "eb" 1
+  , CSlot 2
+  , CSlot 3
+  , CSlot 4
+  , CSlot 5
+  ]
+
+-- | Two announced EBs, each voted in its own slot. Requires the EB payload to be
+--   derived from the hash: a constant one collapses both to the same spec-level
+--   hash, and the second vote is then rejected as already cast.
+twoVotes :: [ChainEvent]
+twoVotes =
+  [ CSlot 0
+  , CSlot 1
+  , CAnnouncementAccepted "eb1" 1
+  , CEBAcquired "eb1" 1
+  , CSlot 2
+  , CSlot 3
+  , CSlot 4
+  , CVoted "eb1" 1
+  , CSlot 5
+  , CAnnouncementAccepted "eb2" 5
+  , CEBAcquired "eb2" 5
+  , CSlot 6
+  , CSlot 7
+  , CSlot 8
+  , CVoted "eb2" 5
+  , CSlot 9
+  ]
+
+dropVotes :: [ChainEvent] -> [ChainEvent]
+dropVotes = filter (not . isVote)
+ where
+  isVote (CVoted _ _) = True
+  isVote _ = False
+
+chainVerifier :: Spec
+chainVerifier = do
+  describe "slot ticks alone" $
+    it "accepts a run in which the node does nothing" $
+      fromLog [CSlot 0, CSlot 1, CSlot 2] `shouldBe` "ok"
+
+  describe "EB production" $ do
+    it "accepts an EB forged in a slot the log records as won" $
+      fromLog [CSlot 0, CNodeIsLeader 0, CEBForged "eb" 0, CSlot 1] `shouldBe` "ok"
+    it "rejects an EB forged with no leadership record" $
+      fromLog [CSlot 0, CEBForged "eb" 0, CSlot 1] `shouldNotBe` "ok"
+    it "accepts an EB forged in a slot an authoritative schedule says was won" $
+      verify [0] True [CSlot 0, CEBForged "eb" 0, CSlot 1] `shouldBe` "ok"
+    it "rejects abstention in a slot an authoritative schedule says was won" $
+      verify [0] True [CSlot 0, CSlot 1] `shouldNotBe` "ok"
+
+  describe "voting" $ do
+    it "accepts a vote for an announced EB in its one legal slot" $
+      fromLog announcedAndVoted `shouldBe` "ok"
+    it "rejects abstention when an announced EB was votable" $
+      fromLog (dropVotes announcedAndVoted) `shouldNotBe` "ok"
+    it "raises no obligation for an EB acquired but never announced" $
+      fromLog acquiredNotAnnounced `shouldBe` "ok"
+    it "accepts votes for two distinct EBs in one run" $
+      fromLog twoVotes `shouldBe` "ok"

--- a/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
@@ -226,6 +226,16 @@ chainVerifier = do
     -- down, and a false violation ends the whole session.
     it "excuses abstention when the mempool range straddles the capacity" $
       verify [0] True [CSlot 0, CMempoolRange 50 200, CSlot 1] `shouldBe` "ok"
+    -- A forge drains the mempool, and that drain is after the decision, so the low
+    -- end of the range is the post-decision state. Reading the minimum here would
+    -- excuse the slot precisely because the node's own block emptied the mempool —
+    -- the case the rule exists to catch. Identical ranges, opposite verdicts,
+    -- decided only by whether a ranking block was forged.
+    it "judges a forge by the mempool before its own block drained it" $
+      verify [0] True [CSlot 0, CRBForged "rb" 0, CMempoolRange 50 200, CSlot 1]
+        `shouldNotBe` "ok"
+    it "judges a slot with no forge by the low end of the range" $
+      verify [0] True [CSlot 0, CMempoolRange 50 200, CSlot 1] `shouldBe` "ok"
 
   describe "voting" $ do
     it "accepts a vote for an announced EB in its one legal slot" $

--- a/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
@@ -71,6 +71,39 @@ acquiredNotAnnounced =
   , CSlot 5
   ]
 
+-- | The announcer's own adoption: 'CChainExtended' in the very slot the EB was
+--   announced, which is the ordinary self-forge shape — the node reports adopting its
+--   own ranking block right after announcing, and in Linear Leios that block shares
+--   the EB's election slot. The tip has reached the announcer, not passed it, so the
+--   window must stay open and the vote at slot 4 is still due.
+adoptedAtAnnouncer :: [ChainEvent]
+adoptedAtAnnouncer =
+  [ CSlot 0
+  , CSlot 1
+  , CAnnouncementAccepted "eb" 1
+  , CEBAcquired "eb" 1
+  , CChainExtended 1
+  , CSlot 2
+  , CSlot 3
+  , CSlot 4
+  , CSlot 5
+  ]
+
+-- | The chain moves strictly past the announcer, so the EB can no longer be
+--   certified and the window closes. Abstaining at slot 4 is then correct.
+adoptedPastAnnouncer :: [ChainEvent]
+adoptedPastAnnouncer =
+  [ CSlot 0
+  , CSlot 1
+  , CAnnouncementAccepted "eb" 1
+  , CEBAcquired "eb" 1
+  , CSlot 2
+  , CChainExtended 2
+  , CSlot 3
+  , CSlot 4
+  , CSlot 5
+  ]
+
 -- | A repeat vote far from the original, and the bounded window a windowed verifier
 --   would see when it reaches slot 20: overlap is 4, so the window starts at 16 and
 --   contains neither the announcement nor the first vote.
@@ -159,6 +192,13 @@ chainVerifier = do
       fromLog acquiredNotAnnounced `shouldBe` "ok"
     it "accepts votes for two distinct EBs in one run" $
       fromLog twoVotes `shouldBe` "ok"
+    -- What distinguishes these two is the obligation, not the vote: our head
+    -- selection would let a vote through either way, so the cost of treating the
+    -- announcer's own adoption as superseding is a withheld vote going unreported.
+    it "keeps the window open when the tip only reaches the announcer" $
+      fromLog adoptedAtAnnouncer `shouldNotBe` "ok"
+    it "closes the window when the tip moves past the announcer" $
+      fromLog adoptedPastAnnouncer `shouldBe` "ok"
     it "refuses a repeat vote in the slot after the legal one" $
       fromLog votedTwice `shouldNotBe` "ok"
     it "refuses a repeat vote long after the legal one" $

--- a/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
@@ -39,6 +39,11 @@ verify slots authoritative evs =
 fromLog :: [ChainEvent] -> Text
 fromLog = verify [] False
 
+-- | Verify from a given start slot, as a windowed verifier does for each window.
+verifyFrom :: Integer -> [ChainEvent] -> Text
+verifyFrom from evs =
+  fst (snd (verifyChainTraceFinalFromSlot 3 2 stakeDist 1 4 7 3 [] False evs from))
+
 -- | An EB announced and acquired in slot 1 and voted in slot 4.
 announcedAndVoted :: [ChainEvent]
 announcedAndVoted =
@@ -64,6 +69,40 @@ acquiredNotAnnounced =
   , CSlot 3
   , CSlot 4
   , CSlot 5
+  ]
+
+-- | A repeat vote far from the original, and the bounded window a windowed verifier
+--   would see when it reaches slot 20: overlap is 4, so the window starts at 16 and
+--   contains neither the announcement nor the first vote.
+votedTwiceFar :: [ChainEvent]
+votedTwiceFar =
+  [CSlot 0, CSlot 1, CAnnouncementAccepted "eb" 1, CEBAcquired "eb" 1]
+    <> [CSlot s | s <- [2 .. 3]]
+    <> [CSlot 4, CVoted "eb" 1]
+    <> [CSlot s | s <- [5 .. 19]]
+    <> [CSlot 20, CVoted "eb" 1]
+    <> [CSlot 21]
+
+windowOfVotedTwiceFar :: [ChainEvent]
+windowOfVotedTwiceFar =
+  [CSlot s | s <- [16 .. 19]]
+    <> [CSlot 20, CVoted "eb" 1]
+    <> [CSlot 21]
+
+-- | The same EB voted twice: once in its one legal slot 4, then again in slot 5.
+votedTwice :: [ChainEvent]
+votedTwice =
+  [ CSlot 0
+  , CSlot 1
+  , CAnnouncementAccepted "eb" 1
+  , CEBAcquired "eb" 1
+  , CSlot 2
+  , CSlot 3
+  , CSlot 4
+  , CVoted "eb" 1
+  , CSlot 5
+  , CVoted "eb" 1
+  , CSlot 6
   ]
 
 -- | Two announced EBs, each voted in its own slot. Requires the EB payload to be
@@ -120,3 +159,16 @@ chainVerifier = do
       fromLog acquiredNotAnnounced `shouldBe` "ok"
     it "accepts votes for two distinct EBs in one run" $
       fromLog twoVotes `shouldBe` "ok"
+    it "refuses a repeat vote in the slot after the legal one" $
+      fromLog votedTwice `shouldNotBe` "ok"
+    it "refuses a repeat vote long after the legal one" $
+      fromLog votedTwiceFar `shouldNotBe` "ok"
+    -- Characterises what bounding the verified prefix would cost, rather than
+    -- asserting it is desirable. Verification from slot 16 sees neither the
+    -- announcement nor the first vote, so 'wasAnnounced' is false, CVoted is
+    -- dropped, no VT-Role is raised, and the stale vote passes unnoticed. Any
+    -- windowing scheme has to carry the announcement history forward, or accept
+    -- this blind spot: the overlap width is sized for legitimate obligations and
+    -- says nothing about how far back a spurious event may reach.
+    it "loses a stale vote when the prefix cannot see the announcement" $
+      verifyFrom 16 windowOfVotedTwiceFar `shouldBe` "ok"

--- a/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
+++ b/leios-trace-verifier/hs-src/test/Spec/ChainVerifier.hs
@@ -30,9 +30,38 @@ stakeDist = [("node-0", 1000000000), ("node-1", 1000000000), ("node-2", 10000000
 --   Timings are the ones the chain app hardcodes — Lhdr 1, Lvote 4, Ldiff 7,
 --   validity check 3 — under which an announced EB is votable in exactly one slot,
 --   @ebSlot + (3 * Lhdr `max` validityCheckTime) == ebSlot + 3@.
+--   The ranking block's body capacity is a small round number here, and fixtures give
+--   their mempool ranges relative to it, so "an EB was owed" is legible at a glance.
+capacity :: Integer
+capacity = 100
+
+-- | A mempool that cannot fit in the ranking block, so an EB is owed.
+overflowing :: ChainEvent
+overflowing = CMempoolRange 200 200
+
+-- | A mempool that fits, so no EB is owed and abstaining is legal.
+fitting :: ChainEvent
+fitting = CMempoolRange 50 50
+
 verify :: [Integer] -> Bool -> [ChainEvent] -> Text
 verify slots authoritative evs =
-  fst (snd (verifyChainTraceFinalFromSlot 3 2 stakeDist 1 4 7 3 slots authoritative evs 0))
+  fst
+    ( snd
+        ( verifyChainTraceFinalFromSlot
+            3
+            2
+            stakeDist
+            1
+            4
+            7
+            3
+            slots
+            authoritative
+            capacity
+            evs
+            0
+        )
+    )
 
 -- | Eligibility taken from the log, as happens for any epoch the queried schedule
 --   cannot cover.
@@ -42,7 +71,10 @@ fromLog = verify [] False
 -- | Verify from a given start slot, as a windowed verifier does for each window.
 verifyFrom :: Integer -> [ChainEvent] -> Text
 verifyFrom from evs =
-  fst (snd (verifyChainTraceFinalFromSlot 3 2 stakeDist 1 4 7 3 [] False evs from))
+  fst
+    ( snd
+        (verifyChainTraceFinalFromSlot 3 2 stakeDist 1 4 7 3 [] False capacity evs from)
+    )
 
 -- | An EB announced and acquired in slot 1 and voted in slot 4.
 announcedAndVoted :: [ChainEvent]
@@ -180,8 +212,20 @@ chainVerifier = do
       fromLog [CSlot 0, CEBForged "eb" 0, CSlot 1] `shouldNotBe` "ok"
     it "accepts an EB forged in a slot an authoritative schedule says was won" $
       verify [0] True [CSlot 0, CEBForged "eb" 0, CSlot 1] `shouldBe` "ok"
+    -- An EB is owed only when the mempool could not have fitted in the RB, so these
+    -- two differ purely in the mempool reading. Without one at all, nothing is shown
+    -- to be owed and abstaining is legal — the third case.
     it "rejects abstention in a slot an authoritative schedule says was won" $
-      verify [0] True [CSlot 0, CSlot 1] `shouldNotBe` "ok"
+      verify [0] True [CSlot 0, overflowing, CSlot 1] `shouldNotBe` "ok"
+    it "accepts abstention when the mempool would have fitted in the ranking block" $
+      verify [0] True [CSlot 0, fitting, CSlot 1] `shouldBe` "ok"
+    it "accepts abstention when the log carries no mempool reading" $
+      verify [0] True [CSlot 0, CSlot 1] `shouldBe` "ok"
+    -- A range straddling the capacity cannot settle the question, and is excused
+    -- rather than flagged: the node decides from a snapshot the log does not pin
+    -- down, and a false violation ends the whole session.
+    it "excuses abstention when the mempool range straddles the capacity" $
+      verify [0] True [CSlot 0, CMempoolRange 50 200, CSlot 1] `shouldBe` "ok"
 
   describe "voting" $ do
     it "accepts a vote for an announced EB in its one legal slot" $

--- a/leios-trace-verifier/hs-src/trace-parser.cabal
+++ b/leios-trace-verifier/hs-src/trace-parser.cabal
@@ -80,6 +80,7 @@ test-suite test-trace-verifier
   main-is:          Spec.hs
   other-modules:    Paths_trace_parser
                     Spec.ChainEvents
+                    Spec.ChainVerifier
                     Spec.Generated
                     Spec.Golden
                     Spec.Scenario

--- a/leios-trace-verifier/hs-src/trace-parser.cabal
+++ b/leios-trace-verifier/hs-src/trace-parser.cabal
@@ -80,6 +80,7 @@ test-suite test-trace-verifier
   main-is:          Spec.hs
   other-modules:    Paths_trace_parser
                     Spec.ChainEvents
+                    Spec.ChainSegments
                     Spec.ChainVerifier
                     Spec.Generated
                     Spec.Golden
@@ -109,6 +110,7 @@ library
     hs-source-dirs: src
     exposed-modules:
       LinearLeiosLib
+      LinearLeiosChain
       LeadershipSchedule
     build-depends:
       , base

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -33,6 +33,7 @@ module LinearLeiosVerifierChain where
     CVoteAcquired : String → Word64 → ChainEvent
     CRBForged    : String → Word64 → ChainEvent
     CNodeIsLeader : Word64 → ChainEvent
+    CAnnouncementAccepted : String → Word64 → ChainEvent
 
   {-# FOREIGN GHC import qualified ChainEvents #-}
   {-# COMPILE GHC ChainEvent = data ChainEvents.ChainEvent
@@ -43,6 +44,7 @@ module LinearLeiosVerifierChain where
         | ChainEvents.CVoteAcquired
         | ChainEvents.CRBForged
         | ChainEvents.CNodeIsLeader
+        | ChainEvents.CAnnouncementAccepted
         ) #-}
 
   module _
@@ -271,17 +273,27 @@ module LinearLeiosVerifierChain where
       traceEvent→action a (CEBForged h s) =
         let eb = mkEBrec h s
         in (record a { EB-refs = (h , eb) ∷ EB-refs a ; forgedEB = just eb } , [])
+      -- Acquiring an EB means its body is in hand, which is what Slot₁ ingestion
+      -- models. It says nothing about the EB being announced on the chain, so it must
+      -- not set 'curEB': doing so made VT-Role possible for any EB the node merely
+      -- fetched, and a node is right not to vote for one its chain never announced.
       traceEvent→action a (CEBAcquired h s) =
         let eb = mkEBrec h s
         in (record a
               { EB-refs = (h , eb) ∷ EB-refs a
               ; EB-received = (h , curSlot a) ∷ EB-received a
               ; FFD-blks = EB-Blk eb ∷ FFD-blks a
-              ; curEB = just h
               } , [])
+      -- The chain head announces this EB, which is what 'getCurrentEBHash' denotes.
+      -- This, and not acquisition, is what makes the EB votable.
+      traceEvent→action a (CAnnouncementAccepted h _) =
+        (record a { curEB = just h } , [])
+      -- Deliberately does not touch 'curEB': letting a vote establish its own
+      -- precondition would make VT-Role self-justifying, hiding a node that voted for
+      -- an EB its chain never announced.
       traceEvent→action a (CVoted h s)
         with EB-refs a ⁉ h | EB-received a ⁉ h
-      ... | just eb | just slot' = (record a { votedEB = just (eb , slot') ; curEB = just h } , [])
+      ... | just eb | just slot' = (record a { votedEB = just (eb , slot') } , [])
       ... | _       | _          = (a , [])
       traceEvent→action a (CVoteAcquired _ _) =
         (record a { FFD-blks = VT-Blk (tt ∷ []) ∷ FFD-blks a } , [])

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -7,6 +7,7 @@ open import Leios.SpecStructure using (SpecStructure)
 open import Leios.Prelude hiding (id)
 
 open import Data.Bool using (if_then_else_)
+import Data.Nat as Nat
 import Data.Nat.Show as S
 import Data.String as S
 open import Agda.Builtin.Word using (Word64; primWord64ToNat)
@@ -110,11 +111,54 @@ module LinearLeiosVerifierChain where
           ; Ldiff = Ldiff
           }
 
-      -- Slots in which the log records the node winning the Praos lottery.
+      -- Slots at which the log shows the Leios subsystem itself doing something.
+      -- Praos events — NodeIsLeader, RBForged — deliberately do not count.
+      leiosActivitySlots : EventLog → List ℕ
+      leiosActivitySlots []                               = []
+      leiosActivitySlots (CEBForged _ s ∷ es)             = primWord64ToNat s ∷ leiosActivitySlots es
+      leiosActivitySlots (CEBAcquired _ s ∷ es)           = primWord64ToNat s ∷ leiosActivitySlots es
+      leiosActivitySlots (CAnnouncementAccepted _ s ∷ es) = primWord64ToNat s ∷ leiosActivitySlots es
+      leiosActivitySlots (CVoted _ s ∷ es)                = primWord64ToNat s ∷ leiosActivitySlots es
+      leiosActivitySlots (CVoteAcquired _ s ∷ es)         = primWord64ToNat s ∷ leiosActivitySlots es
+      leiosActivitySlots (_ ∷ es)                         = leiosActivitySlots es
+
+      minSlot : ℕ → List ℕ → ℕ
+      minSlot m []       = m
+      minSlot m (x ∷ xs) = minSlot (if x Nat.<ᵇ m then x else m) xs
+
+      -- Leader slots at or after the first slot where Leios did anything.
+      leaderSlotsFrom : ℕ → EventLog → List ℕ
+      leaderSlotsFrom from []                     = []
+      leaderSlotsFrom from (CNodeIsLeader s ∷ es) =
+        let n = primWord64ToNat s
+        in if n Nat.<ᵇ from
+             then leaderSlotsFrom from es
+             else n ∷ leaderSlotsFrom from es
+      leaderSlotsFrom from (_ ∷ es)               = leaderSlotsFrom from es
+
+      -- Slots in which the node won the Praos lottery, gated on Leios having shown
+      -- signs of life.
+      --
+      -- NodeIsLeader is a Praos event. Treating it as EB-production eligibility rests
+      -- on the spec assuming canProduceEB holds exactly when the node can make a
+      -- ranking block, and that only holds while Leios is actually running. Observed
+      -- against a devnet: 31 slots in, with no EB forged, acquired, announced or voted
+      -- anywhere in the log, the node was Praos leader at slot 9 and forged a plain
+      -- ranking block — and No-EB-Role was rejected, because eligibility had been
+      -- inferred from a Praos event alone while the subsystem was still warming up.
+      --
+      -- Only the negative inference is gated. A forged EB is still verified wherever
+      -- it appears, since accepting one needs no assumption about the subsystem being
+      -- up; and because the gate compares slot numbers rather than log positions, a
+      -- leader slot whose own EB forge is the first Leios activity still qualifies.
+      --
+      -- The node emits no positive readiness event, and its "wait for leios ready"
+      -- message recurs a dozen times in runs that do forge EBs, so that cannot serve
+      -- as the gate.
       leaderSlots : EventLog → List ℕ
-      leaderSlots []                     = []
-      leaderSlots (CNodeIsLeader s ∷ es) = primWord64ToNat s ∷ leaderSlots es
-      leaderSlots (_ ∷ es)               = leaderSlots es
+      leaderSlots es = case leiosActivitySlots es of λ where
+        []       → []
+        (a ∷ as) → leaderSlotsFrom (minSlot a as) es
 
       -- EB-production eligibility. The queried leadership schedule is authoritative
       -- and is used whenever it applies to the epoch under test. It does not always:

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -131,6 +131,8 @@ module LinearLeiosVerifierChain where
         RB-Blk : RankingBlock → Blk
 
       -- Synthesized non-empty transaction list (the node records only counts).
+      -- Must agree with the 'ToPropose' established by 'closeSlot', otherwise the
+      -- EB the spec derives from the mempool will not match 'mkEBrec' below.
       synthTxs : List Tx
       synthTxs = 0 ∷ []
 
@@ -189,6 +191,16 @@ module LinearLeiosVerifierChain where
       closeSlot : Accumulator → List Step
       closeSlot a =
         let s = curSlot a
+            -- node.log carries no mempool contents, so re-establish the
+            -- synthesized proposal set at the head of every slot. Without it
+            -- 'ToPropose' stays empty, 'toProposeEB' is always 'nothing', and
+            -- EB-Role's first premise is unsatisfiable — leaving every forged EB
+            -- unverifiable. 'synthTxs' is chosen so the EB the spec derives from
+            -- 'ToPropose' coincides with the one 'mkEBrec' builds. 'Base₁' has no
+            -- premises, records no upkeep and only overwrites 'ToPropose', so
+            -- re-emitting it each slot is idempotent.
+            mempool : List Step
+            mempool = (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
             annRB : List Step
             annRB = case curEB a of λ where
               nothing  → []
@@ -203,7 +215,8 @@ module LinearLeiosVerifierChain where
             vtRole = case votedEB a of λ where
               (just (eb , slot')) → (VT-Role-Action s eb slot' , inj₁ FFDT.SLOT) ∷ []
               nothing             → (No-VT-Role-Action s , inj₁ FFDT.SLOT) ∷ []
-        in annRB
+        in mempool
+           ++ annRB
            ++ ((Base₂-Action s , inj₁ FFDT.SLOT) ∷ ebRole)
            ++ vtRole
            ++ ((Slot₁-Action s , inj₁ (FFDT.FFD-OUT (blksToHeaderAndBodyList (FFD-blks a)))) ∷ [])

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -262,10 +262,20 @@ module LinearLeiosVerifierChain where
       --                     drops to 'none'. Merely forgetting the hash would stop
       --                     re-announcing but never reset the spec's 'currentRB',
       --                     leaving the window (wrongly) open.
+      --   retiring        : a vote landed in the very slot the chain superseded the
+      --                     EB, so 'annRB' presented the voted EB there instead of
+      --                     de-announcing, and the de-announcement owes one slot.
+      --                     It is emitted unconditionally on the next slot — a vote
+      --                     arriving then is for an EB the chain has already moved
+      --                     past and should fail. Without this state the deferral
+      --                     renewed itself for as long as votes kept arriving, so a
+      --                     superseded EB could stay head indefinitely, which is not
+      --                     what the one-slot deferral was meant to allow.
       data EBStatus : Type where
         none       : EBStatus
         announcing : String → ℕ → EBStatus
         superseded : EBStatus
+        retiring   : EBStatus
 
       -- Accumulator threaded through the chain events. Slot obligations are
       -- flushed when the next CSlot arrives (or at end of stream).
@@ -317,6 +327,15 @@ module LinearLeiosVerifierChain where
       hashOf a h = case EB-refs a ⁉ h of λ where
         (just eb) → hash eb
         nothing   → []
+
+      -- Whether this hash is the EB the chain head currently announces. Only that EB
+      -- is votable, so where a slot holds several votes this picks the one the spec
+      -- can actually discharge.
+      isCurrentHead : String → EBStatus → Bool
+      isCurrentHead h (announcing h' _) = case h ≟ h' of λ where
+        (yes _) → true
+        (no  _) → false
+      isCurrentHead _ _ = false
 
       wasAnnounced : String → List String → Bool
       wasAnnounced h []       = false
@@ -407,18 +426,24 @@ module LinearLeiosVerifierChain where
             -- been repeatedly corrected for. Votes genuinely outside the window are
             -- still caught, by VT-Role's timing premise.
             annRB : List Step
-            annRB = case votedEB a of λ where
-              (just (eb , _)) → announceStep (just (hash eb))
-              nothing         → case curEB a of λ where
-                -- No announcement to make: leave 'currentRB' as it stands.
-                none             → []
-                -- Re-assert the announcement so the window stays open this slot.
-                (announcing h _) → announceStep (just (hashOf a h))
-                -- The chain has extended past the announcer: overwrite 'currentRB'
-                -- with a non-announcing RB so 'getCurrentEBHash ≡ nothing',
-                -- 'voteDeadline ≡ 0', and the spec's own rules close the window
-                -- (abstention becomes licensed by Roles₂, no vote is forced).
-                superseded     → announceStep nothing
+            annRB = case curEB a of λ where
+              -- The deferred de-announcement falls due, and is emitted whatever else
+              -- happened this slot: a vote arriving now is for an EB the chain has
+              -- already moved past, and should fail rather than renew the deferral.
+              retiring → announceStep nothing
+              st       → case votedEB a of λ where
+                (just (eb , _)) → announceStep (just (hash eb))
+                nothing         → case st of λ where
+                  -- No announcement to make: leave 'currentRB' as it stands.
+                  none             → []
+                  -- Re-assert the announcement so the window stays open this slot.
+                  (announcing h _) → announceStep (just (hashOf a h))
+                  -- The chain has extended past the announcer: overwrite 'currentRB'
+                  -- with a non-announcing RB so 'getCurrentEBHash ≡ nothing',
+                  -- 'voteDeadline ≡ 0', and the spec's own rules close the window
+                  -- (abstention becomes licensed by Roles₂, no vote is forced).
+                  superseded       → announceStep nothing
+                  retiring         → announceStep nothing
             ebRole : List Step
             ebRole = case forgedEB a of λ where
               (just eb) → (EB-Role-Action s eb , inj₁ FFDT.SLOT) ∷ []
@@ -458,14 +483,19 @@ module LinearLeiosVerifierChain where
                 --
                 -- Unless a vote was cast in this slot: 'annRB' presented the voted EB
                 -- instead of de-announcing, so the de-announcement has not happened
-                -- yet and 'superseded' must survive into the next slot to fire there.
-                -- Dropping to 'none' here would retire the status without ever
-                -- resetting 'currentRB', leaving the window open — the very failure
-                -- the three-state status was introduced to avoid.
+                -- yet and must fire on the next slot. Dropping to 'none' here would
+                -- retire the status without ever resetting 'currentRB', leaving the
+                -- window open — the failure the status was introduced to avoid.
+                --
+                -- It becomes 'retiring' rather than staying 'superseded', so the
+                -- deferral is spent: 'retiring' de-announces unconditionally. Staying
+                -- 'superseded' let a vote in each following slot renew the deferral,
+                -- and a superseded EB could then remain head indefinitely.
                 nextEB = case curEB a of λ where
                   superseded → case votedEB a of λ where
-                    (just _) → superseded
+                    (just _) → retiring
                     nothing  → none
+                  retiring   → none
                   st         → st
             in (record a
                   { curSlot = primWord64ToNat s
@@ -497,9 +527,24 @@ module LinearLeiosVerifierChain where
       -- Deliberately does not touch 'curEB': letting a vote establish its own
       -- precondition would make VT-Role self-justifying, hiding a node that voted for
       -- an EB its chain never announced.
+      -- 'closeSlot' emits at most one VT-Role per slot, the spec recording VT-Role
+      -- upkeep once per slot, so where a slot holds several votes only one can be
+      -- adjudicated. Which one is not arbitrary: only the chain's current head is
+      -- votable, so the vote naming the head is the one the spec can discharge, and
+      -- the others are unrepresentable whatever we do. The driver counts them.
+      --
+      -- Keeping simply the first is actively wrong. With EB A announced at 2 and B at
+      -- 3, both votable at 6, holding A leaves B's vote dropped — and at B's deadline
+      -- the verifier then demands a vote the node had in fact cast, turning a silent
+      -- loss into a false violation.
       traceEvent→action a (CVoted h s)
         with wasAnnounced h (announced a) | EB-refs a ⁉ h | EB-received a ⁉ h
-      ... | true | just eb | just slot' = (record a { votedEB = just (eb , slot') } , [])
+      ... | true | just eb | just slot' =
+              case votedEB a of λ where
+                nothing  → (record a { votedEB = just (eb , slot') } , [])
+                (just _) → if isCurrentHead h (curEB a)
+                             then (record a { votedEB = just (eb , slot') } , [])
+                             else (a , [])
       ... | _    | _       | _          = (a , [])
       traceEvent→action a (CVoteAcquired _ _) =
         (record a { FFD-blks = VT-Blk (tt ∷ []) ∷ FFD-blks a } , [])

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -273,6 +273,9 @@ module LinearLeiosVerifierChain where
               announced   : List String
               -- (min , max) mempool bytes observed during the slot being accumulated.
               memRange    : Maybe (ℕ × ℕ)
+              -- Whether the node forged a ranking block in this slot, which locates
+              -- the mempool drain relative to its EB decision. See 'ebOwed'.
+              forgedRB    : Bool
               forgedEB    : Maybe EndorserBlock
               votedEB     : Maybe (EndorserBlock × ℕ)
 
@@ -331,20 +334,30 @@ module LinearLeiosVerifierChain where
             -- 'Roles₂' licenses the abstention — the spec's own account of a node
             -- with nothing to put in an EB.
             --
-            -- Owed iff the mempool could not have fitted in the ranking block:
-            -- 'min > maxRBBody'. The reading is a range because the node decides from
-            -- a snapshot taken at an unobservable instant, and taking the minimum is
-            -- what makes the test one-sided — a range straddling the capacity is
+            -- Owed iff the mempool could not have fitted in the ranking block. The
+            -- reading is a range, and which end of it corresponds to the node's
+            -- decision depends on whether the node forged here.
+            --
+            -- No forge: the snapshot instant is unobservable, so take the MINIMUM.
+            -- That makes the test one-sided — a range straddling the capacity is
             -- treated as not owed, so an indeterminate slot is excused rather than
             -- flagged. A false violation ends the whole verification session, while a
             -- missed one costs only that slot's coverage.
+            --
+            -- Forge: the node's own block drained the mempool, and that drain is
+            -- causally after the decision, so the minimum is the post-decision state
+            -- and the MAXIMUM is what the node actually saw. Taking the minimum here
+            -- would excuse a leader slot precisely because its own block emptied the
+            -- mempool — the very case this rule exists to catch. The maximum is the
+            -- slot's opening value, which the parser seeds the range with.
             --
             -- No reading at all (a log without the Mempool traces) is likewise not
             -- owed: EB-role enforcement then lapses rather than firing on a guess.
             ebOwed : Bool
             ebOwed = case memRange a of λ where
-              nothing          → false
-              (just (mn , _))  → maxRBBody Nat.<ᵇ mn
+              nothing           → false
+              (just (mn , mx))  →
+                maxRBBody Nat.<ᵇ (if forgedRB a then mx else mn)
             mempool : List Step
             mempool = case forgedEB a of λ where
               (just eb) → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs (EndorserBlockOSig.txs eb)))) ∷ []
@@ -437,6 +450,7 @@ module LinearLeiosVerifierChain where
                   ; FFD-blks = []
                   ; curEB = nextEB
                   ; memRange = nothing
+                  ; forgedRB = false
                   ; forgedEB = nothing
                   ; votedEB = nothing
                   } , steps)
@@ -467,7 +481,9 @@ module LinearLeiosVerifierChain where
       ... | _    | _       | _          = (a , [])
       traceEvent→action a (CVoteAcquired _ _) =
         (record a { FFD-blks = VT-Blk (tt ∷ []) ∷ FFD-blks a } , [])
-      traceEvent→action a (CRBForged h s) = (a , [])
+      -- Not a step of its own: what it contributes is locating the mempool drain
+      -- relative to the node's EB decision, which 'ebOwed' reads.
+      traceEvent→action a (CRBForged h s) = (record a { forgedRB = true } , [])
       -- Consumed by 'leaderSlots' as the eligibility fallback, not as a step.
       traceEvent→action a (CNodeIsLeader _) = (a , [])
       -- The selected chain adopted a new tip. Mark the announcement 'superseded' so
@@ -519,7 +535,7 @@ module LinearLeiosVerifierChain where
       n₀ st = record
         { EB-refs = [] ; EB-received = [] ; FFD-blks = [] ; curSlot = st
         ; started = false ; curEB = none ; announced = [] ; memRange = nothing
-        ; forgedEB = nothing ; votedEB = nothing }
+        ; forgedRB = false ; forgedEB = nothing ; votedEB = nothing }
 
       opaque
         unfolding List-Model

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -10,6 +10,7 @@ open import Data.Bool using (if_then_else_)
 import Data.Nat.Show as S
 import Data.String as S
 open import Agda.Builtin.Word using (Word64; primWord64ToNat)
+open import Agda.Builtin.Char using (primCharToNat)
 open import Foreign.Haskell.Pair
 
 open import Tactic.Defaults
@@ -130,18 +131,27 @@ module LinearLeiosVerifierChain where
         VT-Blk : List Vote → Blk
         RB-Blk : RankingBlock → Blk
 
-      -- Synthesized non-empty transaction list (the node records only counts).
-      -- Must agree with the 'ToPropose' established by 'closeSlot', otherwise the
-      -- EB the spec derives from the mempool will not match 'mkEBrec' below.
+      -- Fallback payload for a slot in which the node forged nothing (it records
+      -- only counts, never contents). Needs only to be non-empty, so that
+      -- 'toProposeEB' returns 'just' and a failing EB-Role is attributable to
+      -- 'canProduceEB' alone.
       synthTxs : List Tx
       synthTxs = 0 ∷ []
 
+      -- EB payload, derived injectively from the EB hash string. 'Defaults' hashes
+      -- an EB to its transaction list, so a constant payload collapses every EB to
+      -- a single spec-level hash: 'getCurrentEBHash' then matches whichever EB
+      -- happens to come first in 'EBs'', and the second vote of a run is rejected
+      -- as 'Already voted' because 'VotedEBs' already holds that hash.
+      txsOfHash : String → List Tx
+      txsOfHash h = L.map primCharToNat (S.toList h)
+
       mkEBrec : String → Word64 → EndorserBlock
-      mkEBrec _ s = record
+      mkEBrec h s = record
         { slotNumber = primWord64ToNat s
         ; producerID = SUT-id
         ; lotteryPf  = tt
-        ; txs        = synthTxs
+        ; txs        = txsOfHash h
         ; signature  = tt
         }
 
@@ -191,16 +201,18 @@ module LinearLeiosVerifierChain where
       closeSlot : Accumulator → List Step
       closeSlot a =
         let s = curSlot a
-            -- node.log carries no mempool contents, so re-establish the
-            -- synthesized proposal set at the head of every slot. Without it
-            -- 'ToPropose' stays empty, 'toProposeEB' is always 'nothing', and
-            -- EB-Role's first premise is unsatisfiable — leaving every forged EB
-            -- unverifiable. 'synthTxs' is chosen so the EB the spec derives from
-            -- 'ToPropose' coincides with the one 'mkEBrec' builds. 'Base₁' has no
-            -- premises, records no upkeep and only overwrites 'ToPropose', so
-            -- re-emitting it each slot is idempotent.
+            -- node.log carries no mempool contents, so re-establish a proposal set
+            -- at the head of every slot. Without it 'ToPropose' stays empty,
+            -- 'toProposeEB' is always 'nothing', and EB-Role's first premise is
+            -- unsatisfiable — leaving every forged EB unverifiable. In a slot with
+            -- a forge the payload has to be that of the forged EB itself, since
+            -- EB-Role checks 'toProposeEB s π ≡ just eb'. 'Base₁' has no premises,
+            -- records no upkeep and only overwrites 'ToPropose', so re-emitting it
+            -- each slot is idempotent.
             mempool : List Step
-            mempool = (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
+            mempool = case forgedEB a of λ where
+              (just eb) → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs (EndorserBlockOSig.txs eb)))) ∷ []
+              nothing   → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
             annRB : List Step
             annRB = case curEB a of λ where
               nothing  → []

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -234,19 +234,22 @@ module LinearLeiosVerifierChain where
       -- 'currentRB' — and hence 'getCurrentEBHash', 'voteDeadline', and every
       -- role rule that reads them.
       --
-      --   none          : no EB currently announced (default RB announces nothing)
-      --   announcing h  : the head RB announces EB 'h'; re-asserted each slot to
-      --                   keep the voting window open until 'voteDeadline'
-      --   superseded    : the chain has extended past the announcer (a later RB
-      --                   is now the tip). The EB can no longer be certified, so
-      --                   the window must close: 'closeSlot' emits ONE
-      --                   non-announcing 'Slot₂' to overwrite 'currentRB', then
-      --                   drops to 'none'. Merely forgetting the hash would stop
-      --                   re-announcing but never reset the spec's 'currentRB',
-      --                   leaving the window (wrongly) open.
+      --   none            : no EB currently announced (default RB announces nothing)
+      --   announcing h e  : the head RB announces EB 'h', whose election slot is 'e';
+      --                     re-asserted each slot to keep the voting window open
+      --                     until 'voteDeadline'. The election slot is carried
+      --                     because it is what tells a tip advance *to* the
+      --                     announcer from one *past* it — see 'CChainExtended'.
+      --   superseded      : the chain has extended past the announcer (a later RB
+      --                     is now the tip). The EB can no longer be certified, so
+      --                     the window must close: 'closeSlot' emits ONE
+      --                     non-announcing 'Slot₂' to overwrite 'currentRB', then
+      --                     drops to 'none'. Merely forgetting the hash would stop
+      --                     re-announcing but never reset the spec's 'currentRB',
+      --                     leaving the window (wrongly) open.
       data EBStatus : Type where
         none       : EBStatus
-        announcing : String → EBStatus
+        announcing : String → ℕ → EBStatus
         superseded : EBStatus
 
       -- Accumulator threaded through the chain events. Slot obligations are
@@ -355,9 +358,9 @@ module LinearLeiosVerifierChain where
               (just (eb , _)) → announceStep (just (hash eb))
               nothing         → case curEB a of λ where
                 -- No announcement to make: leave 'currentRB' as it stands.
-                none           → []
+                none             → []
                 -- Re-assert the announcement so the window stays open this slot.
-                (announcing h) → announceStep (just (hashOf a h))
+                (announcing h _) → announceStep (just (hashOf a h))
                 -- The chain has extended past the announcer: overwrite 'currentRB'
                 -- with a non-announcing RB so 'getCurrentEBHash ≡ nothing',
                 -- 'voteDeadline ≡ 0', and the spec's own rules close the window
@@ -421,8 +424,8 @@ module LinearLeiosVerifierChain where
               } , [])
       -- The chain head announces this EB, which is what 'getCurrentEBHash' denotes.
       -- This, and not acquisition, is what makes the EB votable.
-      traceEvent→action a (CAnnouncementAccepted h _) =
-        (record a { curEB = announcing h ; announced = h ∷ announced a } , [])
+      traceEvent→action a (CAnnouncementAccepted h s) =
+        (record a { curEB = announcing h (primWord64ToNat s) ; announced = h ∷ announced a } , [])
       -- Deliberately does not touch 'curEB': letting a vote establish its own
       -- precondition would make VT-Role self-justifying, hiding a node that voted for
       -- an EB its chain never announced.
@@ -435,14 +438,25 @@ module LinearLeiosVerifierChain where
       traceEvent→action a (CRBForged h s) = (a , [])
       -- Consumed by 'leaderSlots' as the eligibility fallback, not as a step.
       traceEvent→action a (CNodeIsLeader _) = (a , [])
-      -- The selected chain extended past the announcer. Mark the announcement
-      -- 'superseded' so the next 'closeSlot' de-announces it via a non-announcing
-      -- 'Slot₂', collapsing the spec's voteDeadline to 0. If nothing is currently
-      -- announced, there is nothing to supersede.
-      traceEvent→action a (CChainExtended _) =
+      -- The selected chain adopted a new tip. Mark the announcement 'superseded' so
+      -- the next 'closeSlot' de-announces it via a non-announcing 'Slot₂', collapsing
+      -- the spec's voteDeadline to 0. If nothing is currently announced, there is
+      -- nothing to supersede.
+      --
+      -- Only a tip strictly beyond the announcer retires the EB. Adopting the
+      -- announcer itself is the ordinary case — in Linear Leios the announcing RB and
+      -- its EB share an election slot, and the node reports adopting its own block
+      -- immediately after announcing it, so treating any tip advance as superseding
+      -- closes every window in the slot it opened. Observed on a devnet as
+      -- CAnnouncementAccepted at slot 20 followed by CChainExtended 20, which then
+      -- retired an EB not votable until slot 23.
+      traceEvent→action a (CChainExtended tip) =
         case curEB a of λ where
-          (announcing _) → (record a { curEB = superseded } , [])
-          _              → (a , [])
+          (announcing h e) →
+            if e Nat.<ᵇ primWord64ToNat tip
+              then (record a { curEB = superseded } , [])
+              else (record a { curEB = announcing h e } , [])
+          _ → (a , [])
       -- A deliberate, protocol-legal abstention the node logged. It corroborates
       -- the retirement but drives no state itself: the window is closed by the
       -- chain extension (CChainExtended) or by the deadline, both via 'currentRB'.

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -23,10 +23,6 @@ module LinearLeiosVerifierChain where
   {-# FOREIGN GHC import Data.Text #-}
   {-# COMPILE GHC error = \ _ s -> error (unpack s) #-}
 
-  postulate leadershipSchedule : List ℕ
-  {-# FOREIGN GHC import qualified LeadershipSchedule #-}
-  {-# COMPILE GHC leadershipSchedule = LeadershipSchedule.leadershipScheduleSlots #-}
-
   -- | A Leios event extracted from a cardano-node tracing log (node.log), keyed
   --   by the EB hash. Mirrors 'ChainEvents.ChainEvent' on the Haskell side.
   data ChainEvent : Type where
@@ -36,6 +32,7 @@ module LinearLeiosVerifierChain where
     CVoted       : String → Word64 → ChainEvent
     CVoteAcquired : String → Word64 → ChainEvent
     CRBForged    : String → Word64 → ChainEvent
+    CNodeIsLeader : Word64 → ChainEvent
 
   {-# FOREIGN GHC import qualified ChainEvents #-}
   {-# COMPILE GHC ChainEvent = data ChainEvents.ChainEvent
@@ -45,6 +42,7 @@ module LinearLeiosVerifierChain where
         | ChainEvents.CVoted
         | ChainEvents.CVoteAcquired
         | ChainEvents.CRBForged
+        | ChainEvents.CNodeIsLeader
         ) #-}
 
   module _
@@ -52,6 +50,13 @@ module LinearLeiosVerifierChain where
     (sutId : ℕ)
     (stakeDistr : List (Pair String ℕ))
     (Lhdr Lvote Ldiff validityCheckTimeValue : ℕ)
+    -- The SUT's EB-production eligibility, as queried from the node, together with
+    -- whether that answer is authoritative for the epoch about to be verified.
+    -- Passed in per call rather than read from a mutable global: the caller chooses
+    -- a different source per segment, and a top-level binding would be a CAF, fixed
+    -- after its first evaluation.
+    (winningSlots : List ℕ)
+    (scheduleAuthoritative : Bool)
     where
 
     from-id : ℕ → Fin numberOfParties
@@ -103,10 +108,28 @@ module LinearLeiosVerifierChain where
           ; Ldiff = Ldiff
           }
 
-      -- EB-production eligibility comes from the leadership schedule (queried from
-      -- the node); voting eligibility is the CIP-0164 committee in Defaults.
+      -- Slots in which the log records the node winning the Praos lottery.
+      leaderSlots : EventLog → List ℕ
+      leaderSlots []                     = []
+      leaderSlots (CNodeIsLeader s ∷ es) = primWord64ToNat s ∷ leaderSlots es
+      leaderSlots (_ ∷ es)               = leaderSlots es
+
+      -- EB-production eligibility. The queried leadership schedule is authoritative
+      -- and is used whenever it applies to the epoch under test. It does not always:
+      -- pool stake takes two epochs to activate, and a node answers only for its own
+      -- current epoch, which in practice trails the epoch being verified. In those
+      -- gaps fall back to the node's own leadership record from the log, which covers
+      -- every epoch the log spans and is not circular with the EB events being
+      -- checked. Note an authoritative schedule may legitimately be empty, so that
+      -- case must not be mistaken for an absent one — hence the explicit flag.
+      --
+      -- Voting eligibility is unaffected: it follows the CIP-0164 committee in
+      -- Defaults, computed from the stake distribution rather than a per-slot lottery.
       winning-slots-of : ℙ (BlockType × ℕ)
-      winning-slots-of = fromList (L.map (λ s → EB , s) leadershipSchedule)
+      winning-slots-of =
+        if scheduleAuthoritative
+          then fromList (L.map (λ s → EB , s) winningSlots)
+          else fromList (L.map (λ s → EB , s) (leaderSlots l))
 
       testParams : TestParams params
       testParams =
@@ -263,6 +286,8 @@ module LinearLeiosVerifierChain where
       traceEvent→action a (CVoteAcquired _ _) =
         (record a { FFD-blks = VT-Blk (tt ∷ []) ∷ FFD-blks a } , [])
       traceEvent→action a (CRBForged h s) = (a , [])
+      -- Consumed by 'leaderSlots' as the eligibility fallback, not as a step.
+      traceEvent→action a (CNodeIsLeader _) = (a , [])
 
       s₀ : LeiosState
       s₀ = initLeiosState tt exampleDistr ((SUT-id , tt) ∷ [])

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -35,6 +35,8 @@ module LinearLeiosVerifierChain where
     CRBForged    : String → Word64 → ChainEvent
     CNodeIsLeader : Word64 → ChainEvent
     CAnnouncementAccepted : String → Word64 → ChainEvent
+    CNotVoted    : String → Word64 → String → ChainEvent
+    CChainExtended : Word64 → ChainEvent
 
   {-# FOREIGN GHC import qualified ChainEvents #-}
   {-# COMPILE GHC ChainEvent = data ChainEvents.ChainEvent
@@ -46,6 +48,8 @@ module LinearLeiosVerifierChain where
         | ChainEvents.CRBForged
         | ChainEvents.CNodeIsLeader
         | ChainEvents.CAnnouncementAccepted
+        | ChainEvents.CNotVoted
+        | ChainEvents.CChainExtended
         ) #-}
 
   module _
@@ -224,6 +228,27 @@ module LinearLeiosVerifierChain where
         ; signature  = tt
         }
 
+      -- Status of the EB the chain currently announces, as the model tracks it
+      -- across a voting window. This drives the 'Slot₂'/'BASE-LDG' ledger step
+      -- ('annRB' below), which is the ONLY thing that sets the spec's
+      -- 'currentRB' — and hence 'getCurrentEBHash', 'voteDeadline', and every
+      -- role rule that reads them.
+      --
+      --   none          : no EB currently announced (default RB announces nothing)
+      --   announcing h  : the head RB announces EB 'h'; re-asserted each slot to
+      --                   keep the voting window open until 'voteDeadline'
+      --   superseded    : the chain has extended past the announcer (a later RB
+      --                   is now the tip). The EB can no longer be certified, so
+      --                   the window must close: 'closeSlot' emits ONE
+      --                   non-announcing 'Slot₂' to overwrite 'currentRB', then
+      --                   drops to 'none'. Merely forgetting the hash would stop
+      --                   re-announcing but never reset the spec's 'currentRB',
+      --                   leaving the window (wrongly) open.
+      data EBStatus : Type where
+        none       : EBStatus
+        announcing : String → EBStatus
+        superseded : EBStatus
+
       -- Accumulator threaded through the chain events. Slot obligations are
       -- flushed when the next CSlot arrives (or at end of stream).
       record Accumulator : Type where
@@ -232,7 +257,7 @@ module LinearLeiosVerifierChain where
               FFD-blks    : List Blk
               curSlot     : ℕ
               started     : Bool
-              curEB       : Maybe String
+              curEB       : EBStatus
               -- Every EB the chain has announced, not only the latest. Two
               -- announcements can land inside a single slot, and closeSlot collapses
               -- a slot into one snapshot.
@@ -292,33 +317,52 @@ module LinearLeiosVerifierChain where
             mempool = case forgedEB a of λ where
               (just eb) → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs (EndorserBlockOSig.txs eb)))) ∷ []
               nothing   → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
-            -- Which announced EB to present as the chain head for this slot.
+            -- One 'Slot₂'/'BASE-LDG' step per slot, setting the spec's 'currentRB'
+            -- (the head of 'RBs') — which is what 'getCurrentEBHash', and hence the
+            -- voting window and every role rule reading it, is derived from.
+            announceStep : Maybe Hash → List Step
+            announceStep mh =
+              (Slot₂-Action s , inj₂ (inj₁ (BaseAbstract.BASE-LDG
+                (record { txs = [] ; announcedEB = mh ; ebCert = nothing ; slot = s } ∷ [])))) ∷ []
+            -- Which EB to present as the chain head for this slot.
             --
-            -- Two announcements can land inside one slot: the node votes for an EB
-            -- announced earlier, then forges its own and that gets announced too,
-            -- moving the head. closeSlot collapses the slot into a single snapshot,
-            -- so taking the latest announcement would contradict the vote emitted
-            -- for the same slot — observed as
-            -- "442 : Err-VT-Role-premises: Current EB hash does not match".
+            -- A vote cast in this slot wins over the announcement status, because
+            -- closeSlot collapses a slot into one snapshot and the log timestamps
+            -- only to slot granularity, so intra-slot order is unknowable. Two ways
+            -- that bites:
             --
-            -- So present the EB the vote was cast for. That is not self-justifying:
-            -- CVoted only records a vote for an EB the chain actually announced, so
-            -- a vote for an unannounced EB still leaves votedEB unset. What it gives
-            -- up is intra-slot ordering — "the EB the head announced at that instant"
-            -- weakens to "an EB the head announced" — which the log cannot support
-            -- anyway.
-            headHash : Maybe Hash
-            headHash = case votedEB a of λ where
-              (just (eb , _)) → just (hash eb)
-              nothing         → case curEB a of λ where
-                (just h) → just (hashOf a h)
-                nothing  → nothing
+            --   * Two announcements in one slot — the node votes for an EB announced
+            --     earlier, then forges its own and that is announced too, moving the
+            --     head. Presenting the later one contradicts the vote emitted for the
+            --     same slot: "442 : Err-VT-Role-premises: Current EB hash does not
+            --     match".
+            --   * The chain supersedes the announcer in the very slot the vote was
+            --     cast. De-announcing here would refuse a vote we cannot show was
+            --     illegal, so the de-announcement is deferred one slot ('nextEB').
+            --
+            -- Presenting the voted EB is not self-justifying: 'CVoted' records a vote
+            -- only for an EB the chain actually announced, so a vote for an
+            -- unannounced EB leaves 'votedEB' unset and no head is invented for it.
+            --
+            -- The residual weakening is deliberate: a vote cast in its legal slot for
+            -- an EB whose announcer the chain had already superseded is accepted
+            -- rather than refused. Refusing it would mean rejecting votes the log
+            -- cannot prove were late, which is the false-positive class this file has
+            -- been repeatedly corrected for. Votes genuinely outside the window are
+            -- still caught, by VT-Role's timing premise.
             annRB : List Step
-            annRB = case headHash of λ where
-              nothing  → []
-              (just h) →
-                (Slot₂-Action s , inj₂ (inj₁ (BaseAbstract.BASE-LDG
-                  (record { txs = [] ; announcedEB = just h ; ebCert = nothing ; slot = s } ∷ [])))) ∷ []
+            annRB = case votedEB a of λ where
+              (just (eb , _)) → announceStep (just (hash eb))
+              nothing         → case curEB a of λ where
+                -- No announcement to make: leave 'currentRB' as it stands.
+                none           → []
+                -- Re-assert the announcement so the window stays open this slot.
+                (announcing h) → announceStep (just (hashOf a h))
+                -- The chain has extended past the announcer: overwrite 'currentRB'
+                -- with a non-announcing RB so 'getCurrentEBHash ≡ nothing',
+                -- 'voteDeadline ≡ 0', and the spec's own rules close the window
+                -- (abstention becomes licensed by Roles₂, no vote is forced).
+                superseded     → announceStep nothing
             ebRole : List Step
             ebRole = case forgedEB a of λ where
               (just eb) → (EB-Role-Action s eb , inj₁ FFDT.SLOT) ∷ []
@@ -339,9 +383,25 @@ module LinearLeiosVerifierChain where
           then (record a { curSlot = primWord64ToNat s ; started = true } , [])
           else
             let steps = closeSlot a
+                -- A 'superseded' de-announcement is emitted once, by the closeSlot
+                -- above; the spec's 'currentRB' is then non-announcing, so drop to
+                -- 'none'. 'announcing'/'none' persist across the slot.
+                --
+                -- Unless a vote was cast in this slot: 'annRB' presented the voted EB
+                -- instead of de-announcing, so the de-announcement has not happened
+                -- yet and 'superseded' must survive into the next slot to fire there.
+                -- Dropping to 'none' here would retire the status without ever
+                -- resetting 'currentRB', leaving the window open — the very failure
+                -- the three-state status was introduced to avoid.
+                nextEB = case curEB a of λ where
+                  superseded → case votedEB a of λ where
+                    (just _) → superseded
+                    nothing  → none
+                  st         → st
             in (record a
                   { curSlot = primWord64ToNat s
                   ; FFD-blks = []
+                  ; curEB = nextEB
                   ; forgedEB = nothing
                   ; votedEB = nothing
                   } , steps)
@@ -362,7 +422,7 @@ module LinearLeiosVerifierChain where
       -- The chain head announces this EB, which is what 'getCurrentEBHash' denotes.
       -- This, and not acquisition, is what makes the EB votable.
       traceEvent→action a (CAnnouncementAccepted h _) =
-        (record a { curEB = just h ; announced = h ∷ announced a } , [])
+        (record a { curEB = announcing h ; announced = h ∷ announced a } , [])
       -- Deliberately does not touch 'curEB': letting a vote establish its own
       -- precondition would make VT-Role self-justifying, hiding a node that voted for
       -- an EB its chain never announced.
@@ -375,6 +435,18 @@ module LinearLeiosVerifierChain where
       traceEvent→action a (CRBForged h s) = (a , [])
       -- Consumed by 'leaderSlots' as the eligibility fallback, not as a step.
       traceEvent→action a (CNodeIsLeader _) = (a , [])
+      -- The selected chain extended past the announcer. Mark the announcement
+      -- 'superseded' so the next 'closeSlot' de-announces it via a non-announcing
+      -- 'Slot₂', collapsing the spec's voteDeadline to 0. If nothing is currently
+      -- announced, there is nothing to supersede.
+      traceEvent→action a (CChainExtended _) =
+        case curEB a of λ where
+          (announcing _) → (record a { curEB = superseded } , [])
+          _              → (a , [])
+      -- A deliberate, protocol-legal abstention the node logged. It corroborates
+      -- the retirement but drives no state itself: the window is closed by the
+      -- chain extension (CChainExtended) or by the deadline, both via 'currentRB'.
+      traceEvent→action a (CNotVoted _ _ _) = (a , [])
 
       s₀ : LeiosState
       s₀ = initLeiosState tt exampleDistr ((SUT-id , tt) ∷ [])
@@ -396,7 +468,7 @@ module LinearLeiosVerifierChain where
       n₀ : ℕ → Accumulator
       n₀ st = record
         { EB-refs = [] ; EB-received = [] ; FFD-blks = [] ; curSlot = st
-        ; started = false ; curEB = nothing ; announced = []
+        ; started = false ; curEB = none ; announced = []
         ; forgedEB = nothing ; votedEB = nothing }
 
       opaque

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -233,6 +233,10 @@ module LinearLeiosVerifierChain where
               curSlot     : ℕ
               started     : Bool
               curEB       : Maybe String
+              -- Every EB the chain has announced, not only the latest. Two
+              -- announcements can land inside a single slot, and closeSlot collapses
+              -- a slot into one snapshot.
+              announced   : List String
               forgedEB    : Maybe EndorserBlock
               votedEB     : Maybe (EndorserBlock × ℕ)
 
@@ -266,6 +270,12 @@ module LinearLeiosVerifierChain where
         (just eb) → hash eb
         nothing   → []
 
+      wasAnnounced : String → List String → Bool
+      wasAnnounced h []       = false
+      wasAnnounced h (x ∷ xs) = case h ≟ x of λ where
+        (yes _) → true
+        (no  _) → wasAnnounced h xs
+
       -- Emit the obligations for the slot being closed, chronologically.
       closeSlot : Accumulator → List Step
       closeSlot a =
@@ -282,12 +292,33 @@ module LinearLeiosVerifierChain where
             mempool = case forgedEB a of λ where
               (just eb) → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs (EndorserBlockOSig.txs eb)))) ∷ []
               nothing   → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
+            -- Which announced EB to present as the chain head for this slot.
+            --
+            -- Two announcements can land inside one slot: the node votes for an EB
+            -- announced earlier, then forges its own and that gets announced too,
+            -- moving the head. closeSlot collapses the slot into a single snapshot,
+            -- so taking the latest announcement would contradict the vote emitted
+            -- for the same slot — observed as
+            -- "442 : Err-VT-Role-premises: Current EB hash does not match".
+            --
+            -- So present the EB the vote was cast for. That is not self-justifying:
+            -- CVoted only records a vote for an EB the chain actually announced, so
+            -- a vote for an unannounced EB still leaves votedEB unset. What it gives
+            -- up is intra-slot ordering — "the EB the head announced at that instant"
+            -- weakens to "an EB the head announced" — which the log cannot support
+            -- anyway.
+            headHash : Maybe Hash
+            headHash = case votedEB a of λ where
+              (just (eb , _)) → just (hash eb)
+              nothing         → case curEB a of λ where
+                (just h) → just (hashOf a h)
+                nothing  → nothing
             annRB : List Step
-            annRB = case curEB a of λ where
+            annRB = case headHash of λ where
               nothing  → []
               (just h) →
                 (Slot₂-Action s , inj₂ (inj₁ (BaseAbstract.BASE-LDG
-                  (record { txs = [] ; announcedEB = just (hashOf a h) ; ebCert = nothing ; slot = s } ∷ [])))) ∷ []
+                  (record { txs = [] ; announcedEB = just h ; ebCert = nothing ; slot = s } ∷ [])))) ∷ []
             ebRole : List Step
             ebRole = case forgedEB a of λ where
               (just eb) → (EB-Role-Action s eb , inj₁ FFDT.SLOT) ∷ []
@@ -331,14 +362,14 @@ module LinearLeiosVerifierChain where
       -- The chain head announces this EB, which is what 'getCurrentEBHash' denotes.
       -- This, and not acquisition, is what makes the EB votable.
       traceEvent→action a (CAnnouncementAccepted h _) =
-        (record a { curEB = just h } , [])
+        (record a { curEB = just h ; announced = h ∷ announced a } , [])
       -- Deliberately does not touch 'curEB': letting a vote establish its own
       -- precondition would make VT-Role self-justifying, hiding a node that voted for
       -- an EB its chain never announced.
       traceEvent→action a (CVoted h s)
-        with EB-refs a ⁉ h | EB-received a ⁉ h
-      ... | just eb | just slot' = (record a { votedEB = just (eb , slot') } , [])
-      ... | _       | _          = (a , [])
+        with wasAnnounced h (announced a) | EB-refs a ⁉ h | EB-received a ⁉ h
+      ... | true | just eb | just slot' = (record a { votedEB = just (eb , slot') } , [])
+      ... | _    | _       | _          = (a , [])
       traceEvent→action a (CVoteAcquired _ _) =
         (record a { FFD-blks = VT-Blk (tt ∷ []) ∷ FFD-blks a } , [])
       traceEvent→action a (CRBForged h s) = (a , [])
@@ -365,7 +396,8 @@ module LinearLeiosVerifierChain where
       n₀ : ℕ → Accumulator
       n₀ st = record
         { EB-refs = [] ; EB-received = [] ; FFD-blks = [] ; curSlot = st
-        ; started = false ; curEB = nothing ; forgedEB = nothing ; votedEB = nothing }
+        ; started = false ; curEB = nothing ; announced = []
+        ; forgedEB = nothing ; votedEB = nothing }
 
       opaque
         unfolding List-Model

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -277,10 +277,16 @@ module LinearLeiosVerifierChain where
       opaque
         unfolding List-Model
 
-        verifyChainTrace' : LeiosState → Pair (List String) (Pair String String)
-        verifyChainTrace' s =
+        -- 'closeLast' decides whether the trailing slot is adjudicated. A slot is
+        -- complete only once a later CSlot has closed it in 'traceEvent→action';
+        -- the slot still in progress has not had its CEBForged/CVoted events read
+        -- yet, so emitting its obligations asserts an abstention that the rest of
+        -- the input may contradict. Streaming checkpoints must pass 'false'; only
+        -- a caller that knows the log ends on a slot boundary may pass 'true'.
+        verifyChainTrace' : Bool → LeiosState → Pair (List String) (Pair String String)
+        verifyChainTrace' closeLast s =
           let (aFinal , l') = mapAccuml traceEvent→action (n₀ (LeiosState.slot s)) l
-              final = if started aFinal then closeSlot aFinal else []
+              final = if closeLast then (if started aFinal then closeSlot aFinal else []) else []
               chron = L.concat l' ++ final
               αs = L.reverse chron
               tr = checkTrace αs s
@@ -298,6 +304,15 @@ module LinearLeiosVerifierChain where
             result f g (Ok x) = f x
             result f g (Err x) = g x
 
+        -- Streaming checkpoint: adjudicate only the slots already closed by a
+        -- later CSlot, leaving the in-progress one to the next checkpoint.
         verifyChainTraceFromSlot : ℕ → Pair (List String) (Pair String String)
-        verifyChainTraceFromSlot n = verifyChainTrace' (record s₀ { slot = n })
+        verifyChainTraceFromSlot n = verifyChainTrace' false (record s₀ { slot = n })
         {-# COMPILE GHC verifyChainTraceFromSlot as verifyChainTraceFromSlot #-}
+
+        -- Whole-log variant: additionally adjudicate the trailing slot. Sound only
+        -- for a complete capture (e.g. a fixed event list in a test); on a stream
+        -- truncated mid-slot it reports a spurious abstention violation.
+        verifyChainTraceFinalFromSlot : ℕ → Pair (List String) (Pair String String)
+        verifyChainTraceFinalFromSlot n = verifyChainTrace' true (record s₀ { slot = n })
+        {-# COMPILE GHC verifyChainTraceFinalFromSlot as verifyChainTraceFinalFromSlot #-}

--- a/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
+++ b/leios-trace-verifier/src/LinearLeiosVerifierChain.agda
@@ -37,6 +37,7 @@ module LinearLeiosVerifierChain where
     CAnnouncementAccepted : String → Word64 → ChainEvent
     CNotVoted    : String → Word64 → String → ChainEvent
     CChainExtended : Word64 → ChainEvent
+    CMempoolRange : Word64 → Word64 → ChainEvent
 
   {-# FOREIGN GHC import qualified ChainEvents #-}
   {-# COMPILE GHC ChainEvent = data ChainEvents.ChainEvent
@@ -50,6 +51,7 @@ module LinearLeiosVerifierChain where
         | ChainEvents.CAnnouncementAccepted
         | ChainEvents.CNotVoted
         | ChainEvents.CChainExtended
+        | ChainEvents.CMempoolRange
         ) #-}
 
   module _
@@ -64,6 +66,10 @@ module LinearLeiosVerifierChain where
     -- after its first evaluation.
     (winningSlots : List ℕ)
     (scheduleAuthoritative : Bool)
+    -- The ranking block's body capacity in bytes ('maxBlockBodySize'). An EB is owed
+    -- only when the mempool does not fit in the RB, so this is what separates a forge
+    -- without an EB that is a violation from one that is ordinary behaviour.
+    (maxRBBody : ℕ)
     where
 
     from-id : ℕ → Fin numberOfParties
@@ -265,6 +271,8 @@ module LinearLeiosVerifierChain where
               -- announcements can land inside a single slot, and closeSlot collapses
               -- a slot into one snapshot.
               announced   : List String
+              -- (min , max) mempool bytes observed during the slot being accumulated.
+              memRange    : Maybe (ℕ × ℕ)
               forgedEB    : Maybe EndorserBlock
               votedEB     : Maybe (EndorserBlock × ℕ)
 
@@ -316,10 +324,33 @@ module LinearLeiosVerifierChain where
             -- EB-Role checks 'toProposeEB s π ≡ just eb'. 'Base₁' has no premises,
             -- records no upkeep and only overwrites 'ToPropose', so re-emitting it
             -- each slot is idempotent.
+            --
+            -- In a slot with no forge the proposal set says whether an EB was OWED.
+            -- 'EB-Role' needs 'toProposeEB ≡ just eb', which holds exactly when the
+            -- set is non-empty, so an empty one makes the rule inapplicable and
+            -- 'Roles₂' licenses the abstention — the spec's own account of a node
+            -- with nothing to put in an EB.
+            --
+            -- Owed iff the mempool could not have fitted in the ranking block:
+            -- 'min > maxRBBody'. The reading is a range because the node decides from
+            -- a snapshot taken at an unobservable instant, and taking the minimum is
+            -- what makes the test one-sided — a range straddling the capacity is
+            -- treated as not owed, so an indeterminate slot is excused rather than
+            -- flagged. A false violation ends the whole verification session, while a
+            -- missed one costs only that slot's coverage.
+            --
+            -- No reading at all (a log without the Mempool traces) is likewise not
+            -- owed: EB-role enforcement then lapses rather than firing on a guess.
+            ebOwed : Bool
+            ebOwed = case memRange a of λ where
+              nothing          → false
+              (just (mn , _))  → maxRBBody Nat.<ᵇ mn
             mempool : List Step
             mempool = case forgedEB a of λ where
               (just eb) → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs (EndorserBlockOSig.txs eb)))) ∷ []
-              nothing   → (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
+              nothing   → if ebOwed
+                            then (Base₁-Action s , inj₂ (inj₂ (SubmitTxs synthTxs))) ∷ []
+                            else (Base₁-Action s , inj₂ (inj₂ (SubmitTxs []))) ∷ []
             -- One 'Slot₂'/'BASE-LDG' step per slot, setting the spec's 'currentRB'
             -- (the head of 'RBs') — which is what 'getCurrentEBHash', and hence the
             -- voting window and every role rule reading it, is derived from.
@@ -405,6 +436,7 @@ module LinearLeiosVerifierChain where
                   { curSlot = primWord64ToNat s
                   ; FFD-blks = []
                   ; curEB = nextEB
+                  ; memRange = nothing
                   ; forgedEB = nothing
                   ; votedEB = nothing
                   } , steps)
@@ -461,6 +493,10 @@ module LinearLeiosVerifierChain where
       -- the retirement but drives no state itself: the window is closed by the
       -- chain extension (CChainExtended) or by the deadline, both via 'currentRB'.
       traceEvent→action a (CNotVoted _ _ _) = (a , [])
+      -- The mempool range for the slot now ending; the parser emits it just ahead of
+      -- the tick that closes that slot, so 'closeSlot' sees the right one.
+      traceEvent→action a (CMempoolRange mn mx) =
+        (record a { memRange = just (primWord64ToNat mn , primWord64ToNat mx) } , [])
 
       s₀ : LeiosState
       s₀ = initLeiosState tt exampleDistr ((SUT-id , tt) ∷ [])
@@ -482,7 +518,7 @@ module LinearLeiosVerifierChain where
       n₀ : ℕ → Accumulator
       n₀ st = record
         { EB-refs = [] ; EB-received = [] ; FFD-blks = [] ; curSlot = st
-        ; started = false ; curEB = none ; announced = []
+        ; started = false ; curEB = none ; announced = [] ; memRange = nothing
         ; forgedEB = nothing ; votedEB = nothing }
 
       opaque

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -20,7 +20,7 @@ in
   }
   # Trace verifier: separate haskell.nix project (see ./trace-verifier.nix).
   {
-    packages = repoRoot.nix.trace-verifier.packages;
+    inherit (repoRoot.nix.trace-verifier) packages;
     devShells.trace-verifier = repoRoot.nix.trace-verifier.devShell;
   }
 ]

--- a/nix/trace-verifier.nix
+++ b/nix/trace-verifier.nix
@@ -121,7 +121,8 @@ in
   # cabal-component names (trace-parser:exe:...) from the project flake.
   packages = tvFlake.packages // {
     linear-leios-trace-verifier = tvFlake.packages."trace-parser:exe:linear-leios-trace-verifier";
-    linear-leios-trace-verifier-chain = tvFlake.packages."trace-parser:exe:linear-leios-trace-verifier-chain";
+    linear-leios-trace-verifier-chain =
+      tvFlake.packages."trace-parser:exe:linear-leios-trace-verifier-chain";
     test-trace-verifier = tvFlake.packages."trace-parser:test:test-trace-verifier";
   };
 


### PR DESCRIPTION
Brings the Linear Leios chain trace-verifier work onto current `main`, which had
meanwhile merged #963 and repinned `leios-spec` to the CIP-aligned spec. That pin bump is an API change, so the merge commit is a port rather than a textual merge.

Two commits are @ramsay-t's, replayed with authorship preserved.

## What changed, by theme

**Made the verifier able to check anything at all.** `ToPropose` is re-established each slot, so `EB-Role`'s first premise is satisfiable; the EB payload is derived injectively from its hash, so distinct EBs don't collapse to one spec-level hash; the in-progress slot is no longer adjudicated at a checkpoint.

**Corrected what raises an obligation.** Voting keys on *announcement* rather than acquisition; a slot is adjudicated against the EB actually voted for; a vote cannot establish its own precondition; only a tip strictly *beyond* an announcer retires its EB; votes for ranking blocks adopted on a fork are resolved rather than dropped.

**Stopped false positives from killing sessions.** An EB is demanded only when the mempool could not have fitted in the ranking block, judged by the pre-drain reading in a slot that forged. An empty leadership schedule is trusted only past the two-epoch stake activation delay. A gap in the slot ticks restarts verification instead of being rejected. EB-role enforcement is gated on Leios being active, and that gate is reported only where it costs something.

**Made it usable on long runs.** The segmentation driver moved into the library so it is testable with a stubbed query and a collecting reporter; segments are re-verified periodically rather than at every tick (the quadratic cost had the verifier starving the node it observes); segments overlap so straddling obligations are still checked.

## The port

`validityCheckTime` is gone from `SpecStructure`, replaced by the `isValidityChecked` predicate. `σc-num`/`σc-den` moved into `Params`, with committee selection now `inVotingCommittee` in `Leios.Config`. A key is registered for every party, without which acquired EB headers fail `isValid` and never reach `EBs'`.

The new spec also changes voting materially: `VT-Role` is no longer satisfiable in exactly one slot. The window opens at `ebSlot + 3·Lhdr` and runs to a deadline at `ebSlot + 3·Lhdr + Lvote`, and a new rule `Roles₃` licenses abstention anywhere inside it. A vote is forced only at the deadline. Consequently `overlapSlots` is now `3·Lhdr + Lvote + Lhdr` = 8, not 4 — carrying only 4 across a boundary would silently drop votes falling due late in the window.

Two of `main`'s changes are deliberately not taken, being superseded here: treating *any* leadership error as an authoritative empty schedule (which reported an epoch-0 devnet forge as violating `EB-Role`), and `CEBAcquired`/`CVoted` setting `curEB`.

## Verification

- 67 examples pass; the executable builds.
- The carry width has a discriminating test: it fails with the old width
  (`not expected: []`) rather than merely asserting a number.
- Byte-identical output to the pre-merge binary over 830 slots of devnet traffic at 100 TX/s — no regression.
- With 50-slot epochs, the diff against the pre-merge binary shows the expected
  difference at five boundaries (segments starting at `boundary − 8` versus
  `boundary − 4`) with no violations from either, so the wider carry adds coverage without false positives.
- Several fixes are corroborated independently by the node's own
  `CNotVoted … chainTipDoesNotAnnounce` reason field.

## Known limitations, and one open question

**The queried leadership schedule can never govern a segment.** `segmentAuthoritative` requires `not spans`, and the boundary carry always carries something, so only the very first segment can ever be authoritative — and only if the node answers for that same epoch. Eligibility therefore always falls back to the log's self-report, which is the weaker check. The `not spans` reasoning is sound in itself (an EB in the carried tail belongs to the previous epoch), but the fix is per-slot epoch attribution rather than relaxing it. Filed as follow-up; it means the cardano-api schedule query is currently inert.

**Votes for the node's own EBs go unverified.** `VT-Role` requires the EB in `EBs'`, which `Slot₁` fills only from received messages, so the spec models no vote for an EB you produced. Measured at 1–3 of every 8 votes, scaling with the node's share of production. Needs a spec decision, not a translator patch.

**Obligations straddling a tick gap are not checked.** A gap restarts verification carrying nothing, since a carried tail would still contain the gap. One devnet case had a node-admitted missed vote (`NotVoted … tooLate`) fall through this and the self-forged gap simultaneously.

**Open question for the node team:** the node reported `tooLate` at slot 425 for an EB announced at 423 — two slots *before* the voting window opens under the `Lhdr = 1` that `Main.hs` hardcodes. Either the prototype's Leios timings differ from `(1, 4, 7)`, or `tooLate` tests something other than the voting deadline. If the timings differ, every window calculation here needs revisiting. The node's config carries only tracer settings and nothing in the log echoes the values.

## Note for reviewers

`main`'s devnet devshell does not currently build — `ouroboros-consensus` fails
`-Werror=deprecations` on `encodeVerKeyDSIGN`, and the derivation is in `origin/main`'s own closure, unrelated to this branch. Running the devnet needs a checkout from before the pin realignment.