### PR TITLE
Address TPA review findings on MEV docs

### DIFF
--- a/docs/mev/README.md
+++ b/docs/mev/README.md
@@ -60,13 +60,13 @@ Other patterns: liquidation races (Liqwid), oracle front-running, auction displa
 
 ### On-Chain Activity
 
-| Category | Redeemers | % of Top 100 | MEV Risk |
+| Category | Redeemers | % of Categorized | MEV Risk |
 |----------|-----------|--------------|----------|
 | DEX | 21.0M | 61% | HIGH |
 | NFT | 8.0M | 23% | MEDIUM |
 | Unknown | 5.4M | 16% | Variable |
 
-Top DEX by volume: Minswap (62%), WingRiders (13%), SundaeSwap (9%).
+Top DEX by volume: Minswap (66%), WingRiders (13%), SundaeSwap (11%).
 
 → [Script mapping](./script-mapping.md)
 

--- a/docs/mev/front-running-cost-model.md
+++ b/docs/mev/front-running-cost-model.md
@@ -2,12 +2,17 @@
 
 | Adversary % | FR Rate (2 ms delay) | Throughput | Fee Revenue/mo | Exploitable Yield/mo | Est. Infra Cost/mo | Profitable? |
 |------------:|---------------------:|------------|---------------:|---------------------:|-------------------:|-------------|
-| 5% | ~1.0% | Praos (~4.5 TxkB/s) | $492K | ~$130 | $25K-$75K | No |
-| 25% | ~5.0% | Praos (~4.5 TxkB/s) | $492K | ~$650 | $125K-$375K | No |
-| 5% | ~1.0% | Leios (~140 TxkB/s) | $9.8M | ~$2.6K | $40K-$140K | No |
-| 25% | ~5.0% | Leios (~140 TxkB/s) | $9.8M | ~$13K | $200K-$700K | No |
-| 5% | ~1.0% | Leios (~300 TxkB/s) | $49.2M | ~$13K | $40K-$140K | No |
-| 25% | ~5.0% | Leios (~300 TxkB/s) | $49.2M | ~$65K | $200K-$700K | No |
+| 5% | ~1.0% | Praos (~4.5 TxkB/s) | $436K | ~$110 | $25K-$75K | No |
+| 25% | ~5.0% | Praos (~4.5 TxkB/s) | $436K | ~$570 | $125K-$375K | No |
+| 5% | ~1.0% | Leios (~140 TxkB/s) | $13.6M | ~$3.5K | $40K-$140K | No |
+| 25% | ~5.0% | Leios (~140 TxkB/s) | $13.6M | ~$17.7K | $200K-$700K | No |
+| 5% | ~1.0% | Leios (~300 TxkB/s) | $29.1M | ~$7.6K | $40K-$140K | No |
+| 25% | ~5.0% | Leios (~300 TxkB/s) | $29.1M | ~$37.8K | $200K-$700K | No |
+
+**Fee Revenue** is total network fee revenue per the [cost estimate](../cost-estimate/README.md)
+fee model: fee = 0.155381 + 0.0000440576 × size, i.e. 0.221467 ADA at the assumed
+1,500-byte average transaction, over a 30.42-day month at $0.25/ADA. For example,
+300 TxkB/s = 200 tx/s → 525.6M tx/mo → 116.4M ADA ≈ $29.1M.
 
 **Exploitable Yield** = Fee Revenue × FR Rate × ~2.6% exploitable fraction.
 
@@ -15,7 +20,7 @@ The ~2.6% exploitable fraction reflects compounding attrition:
 
 1. Only ~32% of [top-100 script redeemers](./script-mapping.md) are DEX order validators (order submission scripts, not pool or batching validators).
 2. ~84% of DEX volume runs through FIFO batchers (Minswap, SundaeSwap, WingRiders), where mempool ordering manipulation has limited impact on final execution order.
-3. Of the remaining ~16% on non-FIFO DEXes, only ~50% of orders carry sufficient value and slippage tolerance to be profitably exploited.
+3. Of the remaining ~16% on non-FIFO DEXes, we assume ~50% of orders carry sufficient value and slippage tolerance to be profitably exploited. This factor is a modeling assumption, not a measured quantity. Yield is linear in it, so the sensitivity is bounded: at the assumed 50%, yields fall short of infrastructure cost by 5x (300 TxkB/s against the cheapest hosting) to 220x (Praos). Doubling the factor to 100% halves those margins, leaving the tightest case ~2.7x short, so no scenario becomes profitable.
 4. Combined: 32% × 16% × 50% ≈ 2.6%.
 5. The front-running success rate depends on crafting speed: the adversary must observe, construct, and propagate a competing transaction faster than normal gossip. The 2 ms delay in the simulation already captures this race.
 

--- a/docs/mev/script-mapping.md
+++ b/docs/mev/script-mapping.md
@@ -4,15 +4,34 @@ Identification of high-activity Plutus scripts by MEV relevance. Data sourced fr
 
 | Version | Date       | Scripts Mapped |
 |---------|------------|----------------|
+| 0.2     | 2026-09-02 | 59 scripts     |
 | 0.1     | 2026-02-05 | 59 scripts     |
+
+Dates refer to the document version. The underlying chain data is a mainnet
+snapshot taken around 2026-01-29 (all history up to that date, ~55.6M redeemers).
+
+## Data Provenance
+
+Redeemer counts come from a `cardano-db-sync` query against Cardano mainnet:
+[redeemer-stats.sql](../../post-cip/mainnet-scripts/redeemer-stats.sql) aggregates
+the `redeemer` table by script hash and purpose. The raw output is committed
+alongside it: the [full dataset](../../post-cip/mainnet-scripts/redeemer-stats.csv.gz)
+(142,977 scripts) and the [top 100](../../post-cip/mainnet-scripts/redeemer-stats-top100.csv)
+by all-time redeemer count. "Top 100" throughout this document means those 100
+busiest scripts. Of them, 59 were identified and mapped to protocols; the summary
+below covers the 28 mapped scripts in the three MEV-relevant categories (the
+remaining mapped scripts are staking, minting, or governance validators).
 
 ## Summary
 
-| Category | Scripts | Redeemers | % of Top 100 |
-|----------|---------|-----------|--------------|
-| DEX      | 18      | 21.0M     | 61%          |
-| NFT      | 4       | 8.0M      | 23%          |
-| Unknown  | 6       | 5.4M      | 16%          |
+| Category | Scripts | Redeemers | % of Categorized |
+|----------|---------|-----------|------------------|
+| DEX      | 18      | 21.0M     | 61%              |
+| NFT      | 4       | 8.0M      | 23%              |
+| Unknown  | 6       | 5.4M      | 16%              |
+
+Percentages are shares of the 34.4M redeemers in these three categories. The full
+top 100 totals 46.6M redeemers; against that base, DEX activity is ~45%.
 
 ## Top Scripts by Activity
 
@@ -44,9 +63,9 @@ Identification of high-activity Plutus scripts by MEV relevance. Data sourced fr
 
 | Protocol | Scripts | Redeemers | % of DEX |
 |----------|---------|-----------|----------|
-| Minswap | 5 | 13.8M | 62% |
+| Minswap | 5 | 13.8M | 66% |
 | WingRiders | 3 | 2.8M | 13% |
-| SundaeSwap | 4 | 1.9M | 9% |
+| SundaeSwap | 3 | 2.4M | 11% |
 | Splash | 1 | 1.7M | 8% |
 | MuesliSwap | 1 | 0.4M | 2% |
 
@@ -58,13 +77,20 @@ Identification of high-activity Plutus scripts by MEV relevance. Data sourced fr
 | **MEDIUM** | NFT marketplaces, oracle-dependent | JPG Store listings |
 | **LOW** | Staking, governance, minting | Reward validators |
 
+## Methodology
+
+1. Queried the top 100 scripts by redeemer count from `cardano-db-sync` (see [Data Provenance](#data-provenance))
+2. Matched script hashes against the StricaHQ registry, Cardanoscan, and protocol GitHub repositories
+3. CBOR-decoded unknown scripts to extract error strings for identification
+4. Classified by MEV relevance based on contract function
+
 ## Tools
 
 - [UPLC Analyzer](https://uplc.pages.dev) — Decode and inspect script bytecode
-- Script data query via Koios API
+- Koios API — script metadata lookups during identification
 
 ## Sources
 
-- [StricaHQ Script Registry](https://github.com/ADAOcommunity/cardano-plutus-script-registry)
-- [SundaeSwap GraphQL API](https://api.sundae.fi/graphql)
+- [redeemer-stats.sql](../../post-cip/mainnet-scripts/redeemer-stats.sql) on mainnet `cardano-db-sync` (redeemer counts)
+- StricaHQ script registry and [SundaeSwap GraphQL API](https://api.sundae.fi/graphql) (identification)
 - Protocol documentation and GitHub repositories


### PR DESCRIPTION
Answers the TPA review of D1.1.1: fee revenue recomputed at the actual TxkB/s rates (the old figures were scaled off a TPS baseline and survived a unit relabel unchanged), the unsourced 50% factor now labeled an assumption with the margins it implies, and `script-mapping.md` linked to the db-sync SQL and raw CSVs it was always based on. Plus a corrected SundaeSwap row and a relabeled percent column.

Scoped to `docs/mev`; the review's tooling and link items under `post-cip` are not included.
