### PR TITLE
Documentation and nix flake fixes

### DIFF
--- a/post-cip/README.md
+++ b/post-cip/README.md
@@ -46,7 +46,7 @@ The figure below shows example results for the probability distribution of the n
 
 ## Analysis of UTxO set size and UTxO lifetime
 
-[Analysis of Cardano mainnet](../post-cip/tx-lifetime/tx-lifetime.ipynb) indicates that the number of active UTxOs has leveled off at approximately 11 million unspent transaction outputs. The data likely is not sufficient to build a statistical model to forecast the size of the UTxO set as a function of demand: a more speculative model would be needed.
+[Analysis of Cardano mainnet](./tx-lifetime/Exploratory%20analysis.ipynb) indicates that the number of active UTxOs has leveled off at approximately 11 million unspent transaction outputs. The data likely is not sufficient to build a statistical model to forecast the size of the UTxO set as a function of demand: a more speculative model would be needed.
 
 ![Size of mainnet UTxO set as a function of slot number](./tx-measurements/utxo-set.png)
 In terms of lifetime, UTxOs have a trimodal distribution:

--- a/post-cip/constraint-model/ReadMe.md
+++ b/post-cip/constraint-model/ReadMe.md
@@ -1,5 +1,13 @@
 # Constraint model for Leios resource usage
 
+## Setup
+
+```bash
+nix develop
+pip install matplotlib networkx numpy ortools pulp pyyaml
+python3 main.py --help
+```
+
 ## Scenario
 
 1. The model starts at time $T_0 = 0$.

--- a/post-cip/constraint-model/ReadMe.md
+++ b/post-cip/constraint-model/ReadMe.md
@@ -253,7 +253,7 @@ options:
   --abs-gap ABS_GAP     Absolute gap tolerance in microseconds
 ```
 
-The output YAML file contains the schedule of all operations, and the Chrome Trace JSON formats that for use in the [Perfetto Viewer](https://ui.perfetto.dev "null"). Beware that producing a Gantt chart for a large block takes a long time. The CSV output file can be imported into [Grafana](https://grafana.com/ "null").
+The output YAML file contains the schedule of all operations, and the Chrome Trace JSON formats that for use in the [Perfetto Viewer](https://ui.perfetto.dev "null"). Beware that producing a Gantt chart for a large block takes a long time. The CSV output file can be imported into [Grafana](https://grafana.com/ "null"). Also note that Perfetto reports `slice_spill_overlapping_complete_event` messages when importing the file because it is not a true Chrome trace but was instead generated outside of Chrome in a manner that doesn't precisely adhere to a Chrome trace's conventions.
 
 Two scenarios are provided, but `python main.py --generate-dummy` will create a small example.
 

--- a/post-cip/constraint-model/flake.nix
+++ b/post-cip/constraint-model/flake.nix
@@ -8,6 +8,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       flake-utils,
     }:

--- a/post-cip/mempool-sim-web/flake.nix
+++ b/post-cip/mempool-sim-web/flake.nix
@@ -9,6 +9,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       flake-utils,
     }:


### PR DESCRIPTION
In response to reviewer report:

> - Both post-cip/mempool-sim-web/ and post-cip/constraint-model/ fail on nix develop:
> error: flake 'git+file://…?dir=post-cip/mempool-sim-web' does not provide attribute
'devShells.x86_64-linux.default', 'devShell.x86_64-linux', 'packages.x86_64-linux.default'
or 'defaultPackage.x86_64-linux'
> Only the simulator's README documents nix develop (ReadMe.md#L188); the constraint-model flake is undocumented but breaks the same way.
> - The 2 MB trace JSON opens in Perfetto with 278 slice_spill_overlapping_complete_event errors. Is that expected, am I using it wrong?
> - post-cip/README.md: the "Analysis of Cardano mainnet" link points to post-cip/tx-lifetime/tx-lifetime.ipynb.